### PR TITLE
split out producer to run_producer function

### DIFF
--- a/src/bitcoin_client/client.rs
+++ b/src/bitcoin_client/client.rs
@@ -174,3 +174,13 @@ impl Client {
         self.call("testmempoolaccept", vec![raw_txs.into()]).await
     }
 }
+
+pub trait BitcoinRpc: Send + Sync + Clone + 'static {
+    fn get_blockchain_info(&self) -> impl std::future::Future<Output = Result<GetBlockchainInfoResult, Error>> + std::marker::Send;
+}
+
+impl BitcoinRpc for Client {
+    async fn get_blockchain_info(&self) -> Result<GetBlockchainInfoResult, Error> {
+        self.get_blockchain_info().await
+    }
+}

--- a/src/bitcoin_follower/rpc.rs
+++ b/src/bitcoin_follower/rpc.rs
@@ -27,9 +27,9 @@ use crate::{
 };
 
 
-fn run_producer(
+pub fn run_producer<C: bitcoin_client::client::BitcoinRpc>(
     start_height: u64,
-    bitcoin: bitcoin_client::Client,
+    bitcoin: C,
     cancel_token: CancellationToken,
 ) -> (
     JoinHandle<()>,

--- a/tests/bitcoin_follower.rs
+++ b/tests/bitcoin_follower.rs
@@ -1,0 +1,56 @@
+use anyhow::Result;
+use tokio_util::sync::CancellationToken;
+
+use bitcoin::{Network};
+
+use kontor::{
+    bitcoin_follower::rpc::run_producer,
+    bitcoin_client::{ client, types, error },
+};
+
+#[derive(Clone)]
+struct MockClient {
+    height: u64,
+}
+
+impl client::BitcoinRpc for MockClient {
+    async fn get_blockchain_info(&self) -> Result<types::GetBlockchainInfoResult, error::Error> {
+        Ok(types::GetBlockchainInfoResult{
+            chain: Network::Bitcoin,
+            blocks: self.height,
+            headers: self.height,
+            difficulty: 1.0,
+            median_time: 1,
+            verification_progress: 1.0,
+            initial_block_download: false,
+            size_on_disk: 0,
+            pruned: false,
+            prune_height: None,
+            automatic_pruning: None,
+            prune_target_size: None,
+        })
+    }
+}
+
+#[tokio::test]
+async fn test_producer() -> Result<()> {
+    let cancel_token = CancellationToken::new();
+
+    let client = MockClient{ height: 1000 };
+    let (producer, mut rx) = run_producer(700, client, cancel_token.clone());
+
+    let (target_height, height) = rx.recv().await.unwrap();
+    assert_eq!(target_height, 1000);
+    assert_eq!(height, 700);
+
+    let (target_height, height) = rx.recv().await.unwrap();
+    assert_eq!(target_height, 1000);
+    assert_eq!(height, 701);
+
+    assert!(!producer.is_finished());
+
+    cancel_token.cancel();
+    let _ = producer.await;
+
+    Ok(())
+}


### PR DESCRIPTION
Starting small, this simply moves the `producer` code, including thread spawning into a new function. Does this seem like a reasonable pattern for the pipeline stages?