### PR TITLE
Factored the rest of rpc::Fetcher pipeline into separate stages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -163,7 +163,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -420,7 +420,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn",
+ "syn 2.0.101",
  "which",
 ]
 
@@ -548,7 +548,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -708,7 +708,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -861,7 +861,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -872,7 +872,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -942,7 +942,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1096,7 +1096,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1735,6 +1735,7 @@ dependencies = [
  "indexmap 2.9.0",
  "kontor_macro",
  "libsql",
+ "ntest",
  "rayon",
  "reqwest",
  "rustls 0.23.27",
@@ -1761,7 +1762,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2048,6 +2049,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntest"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb183f0a1da7a937f672e5ee7b7edb727bf52b8a52d531374ba8ebb9345c0330"
+dependencies = [
+ "ntest_test_cases",
+ "ntest_timeout",
+]
+
+[[package]]
+name = "ntest_test_cases"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d0d3f2a488592e5368ebbe996e7f1d44aa13156efad201f5b4d84e150eaa93"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ntest_timeout"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc7c92f190c97f79b4a332f5e81dcf68c8420af2045c936c9be0bc9de6f63b5"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2111,7 +2145,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2229,7 +2263,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2291,7 +2325,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -2323,7 +2366,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2855,7 +2898,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2996,6 +3039,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
@@ -3028,7 +3082,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3110,7 +3164,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3121,7 +3175,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3226,7 +3280,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3489,7 +3543,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3713,7 +3767,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -3748,7 +3802,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4074,7 +4128,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -4105,7 +4159,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4116,7 +4170,7 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4136,7 +4190,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -4186,7 +4240,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/kontor/Cargo.toml
+++ b/kontor/Cargo.toml
@@ -50,6 +50,7 @@ ciborium = "0.2"
 bon = "3.6"
 axum-test = "17.3"
 urlencoding = "2.1"
+ntest = "0.9.3"
 
 [dev-dependencies]
 tokio-tungstenite = { version = "0.26", features = ["rustls-tls-native-roots"] }

--- a/kontor/src/bitcoin_client/client.rs
+++ b/kontor/src/bitcoin_client/client.rs
@@ -177,10 +177,20 @@ impl Client {
 
 pub trait BitcoinRpc: Send + Sync + Clone + 'static {
     fn get_blockchain_info(&self) -> impl std::future::Future<Output = Result<GetBlockchainInfoResult, Error>> + std::marker::Send;
+
+    fn get_block_hash(&self, height: u64) -> impl std::future::Future<Output = Result<BlockHash, Error>> + std::marker::Send;
+
+    fn get_block(&self, hash: &BlockHash) -> impl std::future::Future<Output = Result<Block, Error>> + std::marker::Send;
 }
 
 impl BitcoinRpc for Client {
     async fn get_blockchain_info(&self) -> Result<GetBlockchainInfoResult, Error> {
         self.get_blockchain_info().await
+    }
+    async fn get_block_hash(&self, height: u64) -> Result<BlockHash, Error> {
+        self.get_block_hash(height).await
+    }
+    async fn get_block(&self, hash: &BlockHash) -> Result<Block, Error> {
+        self.get_block(hash).await
     }
 }

--- a/kontor/tests/bitcoin_follower.rs
+++ b/kontor/tests/bitcoin_follower.rs
@@ -1,12 +1,27 @@
 use anyhow::Result;
+use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
-use bitcoin::{Network};
+use bitcoin::{
+    self,
+    Network,
+    BlockHash,
+    hashes::Hash,
+};
 
 use kontor::{
-    bitcoin_follower::rpc::run_producer,
+    bitcoin_follower::rpc::{
+        run_producer,
+        run_fetcher,
+        run_processor,
+        run_orderer,
+    },
     bitcoin_client::{ client, types, error },
+    block::{ Block },
+    utils::{ MockTransaction },
 };
+
+use ntest::timeout;
 
 #[derive(Clone)]
 struct MockClient {
@@ -30,9 +45,28 @@ impl client::BitcoinRpc for MockClient {
             prune_target_size: None,
         })
     }
+
+    async fn get_block_hash(&self, _height: u64) -> Result<BlockHash, error::Error> {
+        Ok(BlockHash::from_byte_array([0x11; 32]))
+    }
+
+    async fn get_block(&self, _hash: &BlockHash) -> Result<bitcoin::Block, error::Error> {
+        Ok(bitcoin::Block{
+            header: bitcoin::block::Header{
+                version: bitcoin::block::Version::ONE,
+                prev_blockhash: BlockHash::from_byte_array([0x99; 32]),
+                merkle_root: bitcoin::TxMerkleNode::from_byte_array([0x77; 32]),
+                time: 123,
+                bits: bitcoin::CompactTarget::from_consensus(3),
+                nonce: 4,
+            },
+            txdata: vec![],
+        })
+    }
 }
 
 #[tokio::test]
+#[timeout(100)]
 async fn test_producer() -> Result<()> {
     let cancel_token = CancellationToken::new();
 
@@ -51,6 +85,139 @@ async fn test_producer() -> Result<()> {
 
     cancel_token.cancel();
     let _ = producer.await;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[timeout(100)]
+async fn test_fetcher() -> Result<()> {
+    let cancel_token = CancellationToken::new();
+
+    let client = MockClient{ height: 1000 };
+    let (tx_in, rx_in) = mpsc::channel(10);
+
+    let (fetcher, mut rx_out) = run_fetcher(rx_in, client, cancel_token.clone());
+
+    assert!(tx_in.send((1000, 700)).await.is_ok());
+
+    let (target_height, height, block) = rx_out.recv().await.unwrap();
+    assert_eq!(target_height, 1000);
+    assert_eq!(height, 700);
+    assert_eq!(block.header.prev_blockhash, BlockHash::from_byte_array([0x99; 32]));
+
+    assert!(!fetcher.is_finished());
+    cancel_token.cancel();
+    let _ = fetcher.await;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[timeout(100)]
+async fn test_processor() -> Result<()> {
+    let cancel_token = CancellationToken::new();
+
+    let (tx_in, rx_in) = mpsc::channel(10);
+
+    // dummy transaction grabbed from bitcoin-rs test-code
+    const SOME_TX: &str = "0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000";
+    let raw_tx = hex::decode(SOME_TX).unwrap();
+    let tx: bitcoin::Transaction = bitcoin::consensus::Decodable::consensus_decode(&mut raw_tx.as_slice()).unwrap();
+
+    fn f(t: bitcoin::Transaction) -> Option<MockTransaction> {
+        let raw_tx = hex::decode(SOME_TX).unwrap();
+        let tx: bitcoin::Transaction = bitcoin::consensus::Decodable::consensus_decode(&mut raw_tx.as_slice()).unwrap();
+
+        assert_eq!(t, tx);
+
+        Some(MockTransaction::new(123))
+    }
+
+    let (processor, mut rx_out) = run_processor(rx_in, f, cancel_token.clone());
+
+    assert!(tx_in.send((1000, 700, bitcoin::Block{
+        header: bitcoin::block::Header{
+            version: bitcoin::block::Version::ONE,
+            prev_blockhash: BlockHash::from_byte_array([0x99; 32]),
+            merkle_root: bitcoin::TxMerkleNode::from_byte_array([0x77; 32]),
+            time: 123,
+            bits: bitcoin::CompactTarget::from_consensus(3),
+            nonce: 4,
+        },
+        txdata: vec![tx],
+    })).await.is_ok());
+
+    let (target_height, block) = rx_out.recv().await.unwrap();
+    assert_eq!(target_height, 1000);
+    assert_eq!(block.height, 700);
+    assert_eq!(block.transactions, vec![MockTransaction::new(123)]);
+
+    assert!(!processor.is_finished());
+    cancel_token.cancel();
+    let _ = processor.await;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[timeout(100)]
+async fn test_orderer() -> Result<()> {
+    let cancel_token = CancellationToken::new();
+    let (tx_in, rx_in) = mpsc::channel(10);
+    let (tx_out, mut rx_out) = mpsc::channel(10);
+
+    let orderer = run_orderer::<MockTransaction>(700, rx_in, tx_out, cancel_token.clone());
+
+    // send 3 blocks in mixed order
+    assert!(tx_in.send((1000, Block{
+        height: 702,
+        hash: BlockHash::from_byte_array([0x44; 32]),
+        prev_hash: BlockHash::from_byte_array([0x33; 32]),
+        transactions: vec![],
+    })).await.is_ok());
+    assert!(tx_in.send((1000, Block{
+        height: 700,
+        hash: BlockHash::from_byte_array([0x22; 32]),
+        prev_hash: BlockHash::from_byte_array([0x11; 32]),
+        transactions: vec![],
+    })).await.is_ok());
+    assert!(tx_in.send((1000, Block{
+        height: 701,
+        hash: BlockHash::from_byte_array([0x33; 32]),
+        prev_hash: BlockHash::from_byte_array([0x22; 32]),
+        transactions: vec![],
+    })).await.is_ok());
+
+    // verify that they come out ordered
+    let (target_height, block) = rx_out.recv().await.unwrap();
+    assert_eq!(target_height, 1000);
+    assert_eq!(block, Block{
+        height: 700,
+        hash: BlockHash::from_byte_array([0x22; 32]),
+        prev_hash: BlockHash::from_byte_array([0x11; 32]),
+        transactions: vec![],
+    });
+    let (target_height, block) = rx_out.recv().await.unwrap();
+    assert_eq!(target_height, 1000);
+    assert_eq!(block, Block{
+        height: 701,
+        hash: BlockHash::from_byte_array([0x33; 32]),
+        prev_hash: BlockHash::from_byte_array([0x22; 32]),
+        transactions: vec![],
+    });
+    let (target_height, block) = rx_out.recv().await.unwrap();
+    assert_eq!(target_height, 1000);
+    assert_eq!(block, Block{
+        height: 702,
+        hash: BlockHash::from_byte_array([0x44; 32]),
+        prev_hash: BlockHash::from_byte_array([0x33; 32]),
+        transactions: vec![],
+    });
+
+    assert!(!orderer.is_finished());
+    cancel_token.cancel();
+    let _ = orderer.await;
 
     Ok(())
 }


### PR DESCRIPTION
Following the pattern from https://github.com/UnspendableLabs/Kontor/pull/11

Code is unchanged, simply factored out into separate stages. Added a rudimentary test for each stage.