### PR TITLE
Add a Reactor rollback test, wrap select_block_at_height queries to hide retry logic

### DIFF
--- a/kontor/src/bitcoin_follower/mod.rs
+++ b/kontor/src/bitcoin_follower/mod.rs
@@ -11,6 +11,7 @@ pub mod events;
 pub mod messages;
 pub mod reconciler;
 pub mod rpc;
+pub mod queries;
 pub mod zmq;
 
 pub async fn run<T: Tx + 'static>(

--- a/kontor/src/bitcoin_follower/queries.rs
+++ b/kontor/src/bitcoin_follower/queries.rs
@@ -1,0 +1,38 @@
+use anyhow::{Result, anyhow};
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    database::{
+        self,
+        queries,
+        types::BlockRow,
+    },
+    retry::{new_backoff_unlimited, retry},
+};
+
+pub async fn select_block_at_height(
+    reader: &database::Reader,
+    height: u64,
+    cancel_token: CancellationToken,
+) -> Result<BlockRow> {
+
+    retry(
+        async || match queries::select_block_at_height(
+            &*reader.connection().await?,
+            height,
+        )
+        .await
+        {
+            Ok(Some(row)) => Ok(row),
+            Ok(None) => Err(anyhow!(
+                "Block at height not found: {}", height
+            )),
+            Err(e) => Err(e),
+        },
+        "read block at height",
+        new_backoff_unlimited(),
+        cancel_token.clone(),
+    )
+    .await
+}
+

--- a/kontor/tests/reactor.rs
+++ b/kontor/tests/reactor.rs
@@ -1,0 +1,95 @@
+use anyhow::Result;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use bitcoin::{
+    BlockHash,
+    hashes::Hash,
+};
+
+use kontor::{
+    reactor,
+    bitcoin_follower::{
+        events::Event,
+        queries::select_block_at_height,
+    },
+    block::{ Block },
+    utils::{ MockTransaction, new_test_db },
+};
+
+
+#[tokio::test]
+async fn test_reactor_rollback() -> Result<()> {
+    let cancel_token = CancellationToken::new();
+    let (tx, rx) = mpsc::channel(1);
+    let (reader, writer, _temp_dir) = new_test_db().await?;
+
+    let handle = reactor::run::<MockTransaction>(cancel_token.clone(), reader.clone(), writer.clone(), rx);
+
+    assert!(tx.send(Event::Block((
+        100, Block{
+            height: 91,
+            hash: BlockHash::from_byte_array([0x10; 32]),
+            prev_hash: BlockHash::from_byte_array([0x00; 32]),
+            transactions: vec![],
+        },
+    ))).await.is_ok());
+
+    assert!(tx.send(Event::Block((
+        100, Block{
+            height: 92,
+            hash: BlockHash::from_byte_array([0x20; 32]),
+            prev_hash: BlockHash::from_byte_array([0x10; 32]),
+            transactions: vec![],
+        },
+    ))).await.is_ok());
+
+    assert!(tx.send(Event::Block((
+        100, Block{
+            height: 93,
+            hash: BlockHash::from_byte_array([0x30; 32]),
+            prev_hash: BlockHash::from_byte_array([0x20; 32]),
+            transactions: vec![],
+        },
+    ))).await.is_ok());
+
+    let block = select_block_at_height(&reader, 92, cancel_token.clone()).await?;
+    assert_eq!(block.height, 92);
+    assert_eq!(block.hash, BlockHash::from_byte_array([0x20; 32]));
+
+    assert!(tx.send(Event::Rollback(91)).await.is_ok());
+
+    assert!(tx.send(Event::Block((
+        100, Block{
+            height: 92,
+            hash: BlockHash::from_byte_array([0x21; 32]),
+            prev_hash: BlockHash::from_byte_array([0x10; 32]),
+            transactions: vec![],
+        },
+    ))).await.is_ok());
+
+    assert!(tx.send(Event::Block((
+        100, Block{
+            height: 93,
+            hash: BlockHash::from_byte_array([0x31; 32]),
+            prev_hash: BlockHash::from_byte_array([0x21; 32]),
+            transactions: vec![],
+        },
+    ))).await.is_ok());
+
+    let block = select_block_at_height(&reader, 92, cancel_token.clone()).await?;
+    assert_eq!(block.height, 92);
+    assert_eq!(block.hash, BlockHash::from_byte_array([0x21; 32]));
+
+    let block = select_block_at_height(&reader, 93, cancel_token.clone()).await?;
+    assert_eq!(block.height, 93);
+    assert_eq!(block.hash, BlockHash::from_byte_array([0x31; 32]));
+
+    assert!(!handle.is_finished());
+
+    cancel_token.cancel();
+    let _ = handle.await;
+
+    Ok(())
+}
+


### PR DESCRIPTION
Before I start making changes for https://github.com/UnspendableLabs/Kontor/issues/24 I decided to set up a test case for the existing logic to have something to extend. I ran into a race condition when using the raw `select_block_at_height` query in the test, so took the opportunity to factor out the retry and error-collapsing logic while at it.

Side note: libsql supports an in-memory variant (https://docs.rs/libsql/latest/libsql/#getting-started), but since every build generates a separate instance, it means we need to be able to create `Writer` and `Reader` implementations wrapping around a connection to the same instance. This isn't straight-forward given our current structure, but seems like a similar kind of design that we'd want if we wanted to support external databases, so perhaps something to consider down the road.