### PR TITLE
Collapse the two Rollback events into one taking either a height or a hash

### DIFF
--- a/core/kontor/src/bitcoin_follower/events.rs
+++ b/core/kontor/src/bitcoin_follower/events.rs
@@ -14,10 +14,15 @@ pub enum ZmqEvent<T: Tx> {
 }
 
 #[derive(Debug, PartialEq)]
+pub enum BlockId {
+    Height(u64),
+    Hash(BlockHash),
+}
+
+#[derive(Debug, PartialEq)]
 pub enum Event<T: Tx> {
     MempoolUpdate { removed: Vec<Txid>, added: Vec<T> },
     MempoolSet(Vec<T>),
     Block((u64, Block<T>)),
-    Rollback(u64),
-    RollbackHash(BlockHash),
+    Rollback(BlockId),
 }

--- a/core/kontor/src/bitcoin_follower/reconciler.rs
+++ b/core/kontor/src/bitcoin_follower/reconciler.rs
@@ -14,7 +14,7 @@ use crate::{
     block::{Block, Tx},
 };
 
-use super::events::{Event, ZmqEvent};
+use super::events::{BlockId, Event, ZmqEvent};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Mode {
@@ -146,7 +146,7 @@ impl<T: Tx + 'static, I: BlockchainInfo, F: BlockFetcher> Reconciler<T, I, F> {
             }
             ZmqEvent::BlockDisconnected(block_hash) => {
                 if self.state.mode == Mode::Zmq {
-                    vec![Event::RollbackHash(block_hash)]
+                    vec![Event::Rollback(BlockId::Hash(block_hash))]
                 } else {
                     vec![]
                 }
@@ -248,7 +248,7 @@ impl<T: Tx + 'static, I: BlockchainInfo, F: BlockFetcher> Reconciler<T, I, F> {
                     start_height, last_hash, block_hash
                 );
 
-                return Ok(vec![Event::Rollback(start_height - 2)]);
+                return Ok(vec![Event::Rollback(BlockId::Height(start_height - 2))]);
             }
         }
 

--- a/core/kontor/tests/reactor.rs
+++ b/core/kontor/tests/reactor.rs
@@ -7,7 +7,10 @@ use tokio_util::sync::CancellationToken;
 use bitcoin::{BlockHash, hashes::Hash};
 
 use kontor::{
-    bitcoin_follower::{events::Event, seek::SeekChannel},
+    bitcoin_follower::{
+        events::{BlockId, Event},
+        seek::SeekChannel,
+    },
     block::{Block, Tx},
     config::Config,
     database::{queries, types::BlockRow},
@@ -135,7 +138,7 @@ async fn test_reactor_rollback_event() -> Result<()> {
     assert_eq!(block.height, 92);
     assert_eq!(block.hash, BlockHash::from_byte_array([0x20; 32]));
 
-    assert!(tx.send(Event::Rollback(91)).await.is_ok());
+    assert!(tx.send(Event::Rollback(BlockId::Height(91))).await.is_ok());
 
     let seek = ctrl_rx.recv().await.unwrap();
     assert_eq!(seek.start_height, 92);
@@ -477,7 +480,7 @@ async fn test_reactor_rollback_hash_event() -> Result<()> {
     let tx = seek.event_tx;
 
     assert!(
-        tx.send(Event::RollbackHash(blocks[2 - 1].hash))
+        tx.send(Event::Rollback(BlockId::Hash(blocks[2 - 1].hash)))
             .await
             .is_ok()
     );

--- a/core/kontor/tests/reconciler.rs
+++ b/core/kontor/tests/reconciler.rs
@@ -8,7 +8,7 @@ use bitcoin::{self, BlockHash, hashes::Hash};
 
 use kontor::{
     bitcoin_follower::{
-        events::{Event, ZmqEvent},
+        events::{BlockId, Event, ZmqEvent},
         info,
         reconciler::{self},
         rpc,
@@ -301,7 +301,7 @@ async fn test_reconciler_zmq_rollback_message() -> Result<()> {
     );
 
     let e = event_rx.recv().await.unwrap();
-    assert_eq!(e, Event::RollbackHash(blocks[2 - 1].hash));
+    assert_eq!(e, Event::Rollback(BlockId::Hash(blocks[2 - 1].hash)));
 
     cancel_token.cancel();
     let _ = handle.await;

--- a/core/kontor/tests/rollback.rs
+++ b/core/kontor/tests/rollback.rs
@@ -12,7 +12,7 @@ use kontor::{
     bitcoin_client::{client::BitcoinRpc, error, types},
     bitcoin_follower::{
         self,
-        events::Event,
+        events::{BlockId, Event},
         info,
         reconciler::{self, Reconciler},
         rpc::Fetcher,
@@ -495,7 +495,7 @@ async fn test_follower_handle_control_signal() -> Result<()> {
         })
         .await
         .unwrap();
-    assert_eq!(res, vec![Event::Rollback(1)]);
+    assert_eq!(res, vec![Event::Rollback(BlockId::Height(1))]);
     assert_eq!(rec.fetcher.running(), false);
 
     // start-up at block height 3 with matching hash for last block at 2


### PR DESCRIPTION
I believe this simplifies the event interface while keeping strict type-checking. We could also consider two optional parameters to avoid the enum, but that raises issues when neither or both are set.