### PR TITLE
Close event channel on reactor errors

### DIFF
--- a/core/kontor/src/reactor/mod.rs
+++ b/core/kontor/src/reactor/mod.rs
@@ -183,7 +183,7 @@ impl<T: Tx + 'static> Reactor<T> {
         Ok(())
     }
 
-    pub async fn run(&mut self) -> Result<()> {
+    async fn run_event_loop(&mut self) -> Result<()> {
         let rx = match self
             .ctrl
             .clone()
@@ -243,12 +243,18 @@ impl<T: Tx + 'static> Reactor<T> {
                 }
             }
         }
+        Ok(())
+    }
+
+    pub async fn run(&mut self) -> Result<()> {
+        let res = self.run_event_loop().await;
 
         if let Some(rx) = self.event_rx.as_mut() {
             rx.close();
             while rx.recv().await.is_some() {}
         }
-        Ok(())
+
+        res
     }
 }
 


### PR DESCRIPTION
Make sure we always close and drain the event channel when exiting the Reactor (even on errors). I attempted to use `scopeguard::defer` for this but since both the channel shutdown and the event loop requires mutable access to the channel the compiler doesn't like it (also, defer doesn't support async https://github.com/bluss/scopeguard/issues/29)