### PR TITLE
Handle closed / stale event channel more gracefully

### DIFF
--- a/core/indexer/src/bitcoin_follower/reconciler.rs
+++ b/core/indexer/src/bitcoin_follower/reconciler.rs
@@ -299,8 +299,7 @@ impl<T: Tx + 'static, I: BlockchainInfo, F: BlockFetcher, M: MempoolFetcher<T>>
                     if let Some(tx) = &self.event_tx {
                         for event in events {
                             if tx.send(event).await.is_err() {
-                                info!("Send channel closed, exiting");
-                                return;
+                                warn!("Dropping events due to stale event channel");
                             }
                         }
                     } else {


### PR DESCRIPTION
As suggested in https://github.com/UnspendableLabs/Kontor/issues/75 we shouldn't shut down the Reconciler if it's attempting to send on a closed event channel.