### PR TITLE
Enforce determnistic execution of contracts in the host runtime.

### DIFF
--- a/contracts/.cargo/config.toml
+++ b/contracts/.cargo/config.toml
@@ -1,2 +1,5 @@
 [build]
 target = "wasm32-unknown-unknown"
+
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "target-feature=-simd128"]

--- a/core/indexer/src/runtime/mod.rs
+++ b/core/indexer/src/runtime/mod.rs
@@ -59,6 +59,10 @@ impl Runtime {
         let mut config = wasmtime::Config::new();
         config.async_support(true);
         config.wasm_component_model(true);
+        // Ensure deterministic execution
+        config.wasm_threads(false);
+        config.wasm_relaxed_simd(false);
+        config.cranelift_nan_canonicalization(true);
         let engine = Engine::new(&config)?;
         let runtime = Self {
             engine,


### PR DESCRIPTION
Also compile contracts without simd support.

See the [notion page for a more detailed explanation around these determinism changes](https://www.notion.so/unspendablelabs/Smart-Contracts-1c055fc17201803ea6bfdfac9a58fe37?source=copy_link#24e55fc172018087a676dca7a489ab5b).

Note that Gas and Memory limits have not been implemented here to furthur enforce determinism, and are expected to be implemented together in a future patch.