### PR TITLE
make api more RESTful

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2162,6 +2162,7 @@ dependencies = [
  "proptest",
  "rand 0.9.2",
  "rayon",
+ "regex",
  "reqwest",
  "rustls 0.23.35",
  "rustls-native-certs 0.8.2",
@@ -3362,9 +3363,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3374,9 +3375,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/core/indexer/Cargo.toml
+++ b/core/indexer/Cargo.toml
@@ -68,6 +68,7 @@ rustls-pemfile = "=2.2.0"
 tokio-tungstenite = { version = "=0.28.0", features = ["rustls-tls-webpki-roots"] }
 uuid = { version = "=1.18.1", features = ["v4"] }
 tracing-stackdriver = "=0.10.0"
+regex = "=1.12.2"
 
 [dev-dependencies]
 testlib = { path = "../testlib" }

--- a/core/indexer/src/database/queries.rs
+++ b/core/indexer/src/database/queries.rs
@@ -5,7 +5,7 @@ use thiserror::Error as ThisError;
 
 use crate::{
     database::types::{
-        CheckpointRow, ContractResultRow, ContractRow, OpResultId, PaginationMeta,
+        CheckpointRow, ContractListRow, ContractResultRow, ContractRow, OpResultId, PaginationMeta,
         TransactionCursor, TransactionRow,
     },
     runtime::ContractAddress,
@@ -403,6 +403,20 @@ pub async fn insert_contract(conn: &Connection, row: ContractRow) -> Result<i64,
     .await?;
 
     Ok(conn.last_insert_rowid())
+}
+
+pub async fn get_contracts(conn: &Connection) -> Result<Vec<ContractListRow>, Error> {
+    let mut rows = conn
+        .query(
+            "SELECT id, name, height, tx_index, size FROM contracts ORDER BY id DESC",
+            params![],
+        )
+        .await?;
+    let mut results = Vec::new();
+    while let Some(row) = rows.next().await? {
+        results.push(from_row(&row)?);
+    }
+    Ok(results)
 }
 
 pub async fn get_contract_bytes_by_address(

--- a/core/indexer/src/database/types.rs
+++ b/core/indexer/src/database/types.rs
@@ -54,6 +54,27 @@ pub struct TransactionRow {
     pub tx_index: i64,
 }
 
+#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
+pub struct ContractListRow {
+    pub id: i64,
+    pub name: String,
+    pub height: i64,
+    pub tx_index: i64,
+    pub size: i64,
+}
+
+impl From<ContractRow> for ContractListRow {
+    fn from(row: ContractRow) -> Self {
+        ContractListRow {
+            id: row.id,
+            name: row.name,
+            height: row.height,
+            tx_index: row.tx_index,
+            size: row.bytes.len() as i64,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Builder)]
 pub struct ContractRow {
     #[builder(default = 0)]

--- a/core/indexer/src/reactor/results.rs
+++ b/core/indexer/src/reactor/results.rs
@@ -19,7 +19,7 @@ use crate::{
     runtime::ContractAddress,
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Builder)]
+#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize, Builder)]
 pub struct ResultEventMetadata {
     #[builder(default = ContractAddress { name: String::new(), height: 0, tx_index: 0 })]
     pub contract_address: ContractAddress,
@@ -30,7 +30,7 @@ pub struct ResultEventMetadata {
     pub op_result_id: Option<OpResultId>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub enum ResultEvent {
     Ok {
         metadata: ResultEventMetadata,

--- a/core/indexer/src/reg_tester.rs
+++ b/core/indexer/src/reg_tester.rs
@@ -577,14 +577,23 @@ impl RegTester {
         self.inner.lock().await.mempool_accept_result(raw_txs).await
     }
 
-    pub async fn transaction_ops(&self, tx_hex: &str) -> Result<Vec<OpWithResult>> {
+    pub async fn transaction_hex_inspect(&self, tx_hex: &str) -> Result<Vec<OpWithResult>> {
         self.inner
             .lock()
             .await
             .kontor_client
-            .transaction_ops(TransactionHex {
+            .transaction_hex_inspect(TransactionHex {
                 hex: tx_hex.to_string(),
             })
+            .await
+    }
+
+    pub async fn transaction_inspect(&self, txid: &Txid) -> Result<Vec<OpWithResult>> {
+        self.inner
+            .lock()
+            .await
+            .kontor_client
+            .transaction_inspect(txid)
             .await
     }
 

--- a/core/indexer/tests/database.rs
+++ b/core/indexer/tests/database.rs
@@ -10,15 +10,16 @@ use indexer::{
         queries::{
             contract_has_state, delete_contract_state, delete_matching_paths,
             exists_contract_state, get_contract_bytes_by_address, get_contract_bytes_by_id,
-            get_contract_id_from_address, get_contract_result, get_latest_contract_state,
-            get_latest_contract_state_value, get_op_result, get_transaction_by_txid,
-            get_transactions_at_height, insert_block, insert_contract, insert_contract_result,
-            insert_contract_state, insert_processed_block, insert_transaction, matching_path,
-            path_prefix_filter_contract_state, select_block_at_height,
-            select_block_by_height_or_hash, select_block_latest,
+            get_contract_id_from_address, get_contract_result, get_contracts,
+            get_latest_contract_state, get_latest_contract_state_value, get_op_result,
+            get_transaction_by_txid, get_transactions_at_height, insert_block, insert_contract,
+            insert_contract_result, insert_contract_state, insert_processed_block,
+            insert_transaction, matching_path, path_prefix_filter_contract_state,
+            select_block_at_height, select_block_by_height_or_hash, select_block_latest,
         },
         types::{
-            BlockRow, ContractResultRow, ContractRow, ContractStateRow, OpResultId, TransactionRow,
+            BlockRow, ContractListRow, ContractResultRow, ContractRow, ContractStateRow,
+            OpResultId, TransactionRow,
         },
     },
     logging,
@@ -454,6 +455,9 @@ async fn test_contracts() -> Result<()> {
         .unwrap();
     let bytes = get_contract_bytes_by_id(&conn, id).await?.unwrap();
     assert_eq!(bytes, row.bytes);
+    let rows = get_contracts(&conn).await?;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0], ContractListRow { id, ..row.into() });
     Ok(())
 }
 

--- a/core/indexer/tests/ops_contract.rs
+++ b/core/indexer/tests/ops_contract.rs
@@ -28,7 +28,7 @@ async fn test_get_ops_from_api_regtest() -> Result<()> {
 
     let tx = deserialize_hex::<bitcoin::Transaction>(&reveal_tx_hex)?;
 
-    let ops = reg_tester.transaction_ops(&reveal_tx_hex).await?;
+    let ops = reg_tester.transaction_hex_inspect(&reveal_tx_hex).await?;
     assert_eq!(ops.len(), 1);
     assert_eq!(
         ops[0].op,
@@ -61,6 +61,11 @@ async fn test_get_ops_from_api_regtest() -> Result<()> {
     } else {
         bail!("Unexpected result event: {:?}", result);
     }
+
+    assert_eq!(
+        ops,
+        reg_tester.transaction_inspect(&tx.compute_txid()).await?
+    );
 
     Ok(())
 }

--- a/core/indexer/tests/wit_contract.rs
+++ b/core/indexer/tests/wit_contract.rs
@@ -1,3 +1,4 @@
+use indexer::runtime::token;
 use testlib::*;
 
 const WIT: &str = r#"package root:component;
@@ -6,23 +7,26 @@ world root {
   import kontor:built-in/context;
   import kontor:built-in/error;
   import kontor:built-in/numbers;
-  use kontor:built-in/context.{view-context, proc-context, signer};
+  use kontor:built-in/context.{core-context, view-context, proc-context, signer};
   use kontor:built-in/error.{error};
-  use kontor:built-in/numbers.{integer, decimal};
+  use kontor:built-in/numbers.{decimal};
+
+  record balance {
+    key: string,
+    value: decimal,
+  }
 
   export init: func(ctx: borrow<proc-context>);
-  export mint: func(ctx: borrow<proc-context>, n: integer);
-  export mint-checked: func(ctx: borrow<proc-context>, n: integer) -> result<_, error>;
-  export transfer: func(ctx: borrow<proc-context>, to: string, n: integer) -> result<_, error>;
-  export balance: func(ctx: borrow<view-context>, acc: string) -> option<integer>;
-  export balance-log10: func(ctx: borrow<view-context>, acc: string) -> result<option<decimal>, error>;
+  export mint: func(ctx: borrow<proc-context>, n: decimal);
+  export transfer: func(ctx: borrow<proc-context>, to: string, n: decimal) -> result<_, error>;
+  export balance: func(ctx: borrow<view-context>, acc: string) -> option<decimal>;
+  export balances: func(ctx: borrow<view-context>) -> list<balance>;
+  export total-supply: func(ctx: borrow<view-context>) -> decimal;
 }
 "#;
 
 async fn run_test(runtime: &mut Runtime) -> Result<()> {
-    let alice = runtime.identity().await?;
-    let token = runtime.publish(&alice, "token").await?;
-    let wit = runtime.wit(&token).await?;
+    let wit = runtime.wit(&token::address()).await?;
     assert_eq!(WIT, wit);
     Ok(())
 }

--- a/native-contracts/token/wit/contract.wit
+++ b/native-contracts/token/wit/contract.wit
@@ -1,23 +1,23 @@
 package kontor:contract;
 
 world contract {
-    include kontor:built-in/built-in;
-    use kontor:built-in/context.{core-context, view-context, proc-context, signer};
-    use kontor:built-in/error.{error};
-    use kontor:built-in/numbers.{decimal};
+	include kontor:built-in/built-in;
+	use kontor:built-in/context.{core-context, view-context, proc-context, signer};
+	use kontor:built-in/error.{error};
+	use kontor:built-in/numbers.{decimal};
 
-    record balance {
-  		key: string,
-  		value: decimal,
-  	}
+  record balance {
+		key: string,
+		value: decimal,
+	}
 
-    export init: func(ctx: borrow<proc-context>);
+	export issuance: func(ctx: borrow<core-context>, to: string);
 
-    export issuance: func(ctx: borrow<core-context>, to: string);
+	export init: func(ctx: borrow<proc-context>);
 
-    export mint: func(ctx: borrow<proc-context>, n: decimal);
-    export transfer: func(ctx: borrow<proc-context>, to: string, n: decimal) -> result<_, error>;
-    export balance: func(ctx: borrow<view-context>, acc: string) -> option<decimal>;
-    export balances: func(ctx: borrow<view-context>) -> list<balance>;
-    export total-supply: func(ctx: borrow<view-context>) -> decimal;
+	export mint: func(ctx: borrow<proc-context>, n: decimal);
+	export transfer: func(ctx: borrow<proc-context>, to: string, n: decimal) -> result<_, error>;
+	export balance: func(ctx: borrow<view-context>, acc: string) -> option<decimal>;
+	export balances: func(ctx: borrow<view-context>) -> list<balance>;
+	export total-supply: func(ctx: borrow<view-context>) -> decimal;
 }

--- a/test-contracts/amm/wit/contract.wit
+++ b/test-contracts/amm/wit/contract.wit
@@ -1,42 +1,42 @@
 package kontor:contract;
 
 world contract {
-    include kontor:built-in/built-in;
-    use kontor:built-in/context.{view-context, proc-context, signer};
-    use kontor:built-in/error.{error};
-    use kontor:built-in/foreign.{contract-address};
-    use kontor:built-in/numbers.{integer, decimal};
+  include kontor:built-in/built-in;
+  use kontor:built-in/context.{view-context, proc-context, signer};
+  use kontor:built-in/error.{error};
+  use kontor:built-in/foreign.{contract-address};
+  use kontor:built-in/numbers.{integer, decimal};
 
-  	record token-pair {
-  		a: contract-address,
-  		b: contract-address,
-  	}
+  record token-pair {
+    a: contract-address,
+    b: contract-address,
+  }
 
-  	record deposit-result {
-  		lp-shares: integer,
-  		deposit-a: integer,
-  		deposit-b: integer,
-  	}
+  record deposit-result {
+    lp-shares: integer,
+    deposit-a: integer,
+    deposit-b: integer,
+  }
 
-  	record withdraw-result {
-  		amount-a: integer,
-  		amount-b: integer,
-  	}
+  record withdraw-result {
+    amount-a: integer,
+    amount-b: integer,
+  }
 
-    export init: func(ctx: borrow<proc-context>);
+  export init: func(ctx: borrow<proc-context>);
 
-    export create: func(ctx: borrow<proc-context>, pair: token-pair, amount-a: integer, amount-b: integer, fee-bps: integer) -> result<integer, error>;
+  export create: func(ctx: borrow<proc-context>, pair: token-pair, amount-a: integer, amount-b: integer, fee-bps: integer) -> result<integer, error>;
 
-  	export fee: func(ctx: borrow<view-context>, pair: token-pair) -> result<integer, error>;
+  export fee: func(ctx: borrow<view-context>, pair: token-pair) -> result<integer, error>;
 
-    export balance: func(ctx: borrow<view-context>, pair: token-pair, acc: string) -> option<integer>;
-    export token-balance: func(ctx: borrow<view-context>, pair: token-pair, token: contract-address) -> result<integer, error>;
-    export quote-deposit: func(ctx: borrow<view-context>, pair: token-pair, amount-a: integer, amount-b: integer) -> result<deposit-result, error>;
-    export deposit: func(ctx: borrow<proc-context>, pair: token-pair, amount-a: integer, amount-b: integer) -> result<deposit-result, error>;
-    export quote-withdraw: func(ctx: borrow<view-context>, pair: token-pair, shares: integer) -> result<withdraw-result, error>;
-    export withdraw: func(ctx: borrow<proc-context>, pair: token-pair, shares: integer) -> result<withdraw-result, error>;
+  export balance: func(ctx: borrow<view-context>, pair: token-pair, acc: string) -> option<integer>;
+  export token-balance: func(ctx: borrow<view-context>, pair: token-pair, token: contract-address) -> result<integer, error>;
+  export quote-deposit: func(ctx: borrow<view-context>, pair: token-pair, amount-a: integer, amount-b: integer) -> result<deposit-result, error>;
+  export deposit: func(ctx: borrow<proc-context>, pair: token-pair, amount-a: integer, amount-b: integer) -> result<deposit-result, error>;
+  export quote-withdraw: func(ctx: borrow<view-context>, pair: token-pair, shares: integer) -> result<withdraw-result, error>;
+  export withdraw: func(ctx: borrow<proc-context>, pair: token-pair, shares: integer) -> result<withdraw-result, error>;
 
 
-    export swap: func(ctx: borrow<proc-context>, pair: token-pair, token-in: contract-address, amount-in: integer, min-out: integer) -> result<integer, error>;
-    export quote-swap: func(ctx: borrow<view-context>, pair: token-pair, token-in: contract-address, amount-in: integer) -> result<integer, error>;
+  export swap: func(ctx: borrow<proc-context>, pair: token-pair, token-in: contract-address, amount-in: integer, min-out: integer) -> result<integer, error>;
+  export quote-swap: func(ctx: borrow<view-context>, pair: token-pair, token-in: contract-address, amount-in: integer) -> result<integer, error>;
 }

--- a/test-contracts/arith/wit/contract.wit
+++ b/test-contracts/arith/wit/contract.wit
@@ -1,33 +1,33 @@
 package kontor:contract;
 
 world contract {
-    include kontor:built-in/built-in;
-    use kontor:built-in/foreign.{contract-address};
-    use kontor:built-in/context.{view-context, proc-context};
-    use kontor:built-in/error.{error};
+  include kontor:built-in/built-in;
+  use kontor:built-in/foreign.{contract-address};
+  use kontor:built-in/context.{view-context, proc-context};
+  use kontor:built-in/error.{error};
 
-    record operand {
-        y: u64,
-    }
+  record operand {
+    y: u64,
+  }
 
-    variant op {
-        id,
-        sum(operand),
-        mul(operand),
-        div(operand),
-    }
+  variant op {
+    id,
+    sum(operand),
+    mul(operand),
+    div(operand),
+  }
 
-    record arith-return {
-        value: u64
-    }
+  record arith-return {
+    value: u64
+  }
 
-    export init: func(ctx: borrow<proc-context>);
+  export init: func(ctx: borrow<proc-context>);
 
-    export eval: func(ctx: borrow<proc-context>, x: u64, op: op) -> arith-return;
+  export eval: func(ctx: borrow<proc-context>, x: u64, op: op) -> arith-return;
 
-    export last-op: func(ctx: borrow<view-context>) -> option<op>;
+  export last-op: func(ctx: borrow<view-context>) -> option<op>;
 
-    export checked-sub: func(ctx: borrow<view-context>, x: string, y: string) -> result<u64, error>;
+  export checked-sub: func(ctx: borrow<view-context>, x: string, y: string) -> result<u64, error>;
 
-    export fib: func(ctx: borrow<proc-context>, contract-address: contract-address, n: u64) -> u64;
+  export fib: func(ctx: borrow<proc-context>, contract-address: contract-address, n: u64) -> u64;
 }

--- a/test-contracts/crypto/wit/contract.wit
+++ b/test-contracts/crypto/wit/contract.wit
@@ -1,14 +1,14 @@
 package kontor:contract;
 
 world contract {
-    include kontor:built-in/built-in;
-    use kontor:built-in/context.{view-context, proc-context};
+  include kontor:built-in/built-in;
+  use kontor:built-in/context.{view-context, proc-context};
 
-    export init: func(ctx: borrow<proc-context>);
+  export init: func(ctx: borrow<proc-context>);
 
-    export hash: func(ctx: borrow<view-context>, input: string) -> string;
+  export hash: func(ctx: borrow<view-context>, input: string) -> string;
 
-    export hash-with-salt: func(ctx: borrow<view-context>, input: string, salt: string) -> string;
+  export hash-with-salt: func(ctx: borrow<view-context>, input: string, salt: string) -> string;
 
-    export generate-id: func(ctx: borrow<proc-context>) -> string;
+  export generate-id: func(ctx: borrow<proc-context>) -> string;
 }

--- a/test-contracts/fib/wit/contract.wit
+++ b/test-contracts/fib/wit/contract.wit
@@ -1,16 +1,16 @@
 package kontor:contract;
 
 world contract {
-    include kontor:built-in/built-in;
-    use kontor:built-in/foreign.{contract-address};
-    use kontor:built-in/context.{fall-context, view-context, proc-context, signer};
-    use kontor:built-in/error.{error};
+  include kontor:built-in/built-in;
+  use kontor:built-in/foreign.{contract-address};
+  use kontor:built-in/context.{fall-context, view-context, proc-context, signer};
+  use kontor:built-in/error.{error};
 
-    export init: func(ctx: borrow<proc-context>);
+  export init: func(ctx: borrow<proc-context>);
 
-    export fib: func(ctx: borrow<proc-context>, arith-address: contract-address, n: u64) -> u64;
+  export fib: func(ctx: borrow<proc-context>, arith-address: contract-address, n: u64) -> u64;
 
-    export fib-of-sub: func(ctx: borrow<proc-context>, arith-address: contract-address, x: string, y: string) -> result<u64, error>;
+  export fib-of-sub: func(ctx: borrow<proc-context>, arith-address: contract-address, x: string, y: string) -> result<u64, error>;
 
-    export cached-values: func(ctx: borrow<view-context>) -> list<u64>;
+  export cached-values: func(ctx: borrow<view-context>) -> list<u64>;
 }

--- a/test-contracts/pool/wit/contract.wit
+++ b/test-contracts/pool/wit/contract.wit
@@ -1,39 +1,39 @@
 package kontor:contract;
 
 world contract {
-    include kontor:built-in/built-in;
-    use kontor:built-in/context.{view-context, proc-context, signer};
-    use kontor:built-in/error.{error};
-    use kontor:built-in/foreign.{contract-address};
-    use kontor:built-in/numbers.{integer, decimal};
+  include kontor:built-in/built-in;
+  use kontor:built-in/context.{view-context, proc-context, signer};
+  use kontor:built-in/error.{error};
+  use kontor:built-in/foreign.{contract-address};
+  use kontor:built-in/numbers.{integer, decimal};
 
-  	record deposit-result {
-  		lp-shares: integer,
-  		deposit-a: integer,
-  		deposit-b: integer,
-  	}
+  record deposit-result {
+    lp-shares: integer,
+    deposit-a: integer,
+    deposit-b: integer,
+  }
 
-  	record withdraw-result {
-  		amount-a: integer,
-  		amount-b: integer,
-  	}
+  record withdraw-result {
+    amount-a: integer,
+    amount-b: integer,
+  }
 
-    export init: func(ctx: borrow<proc-context>);
+  export init: func(ctx: borrow<proc-context>);
 
-    export re-init: func(ctx: borrow<proc-context>, token-a: contract-address, amount-a: integer, token-b: contract-address, amount-b: integer, fee: integer) -> result<integer, error>;
+  export re-init: func(ctx: borrow<proc-context>, token-a: contract-address, amount-a: integer, token-b: contract-address, amount-b: integer, fee: integer) -> result<integer, error>;
 
-  	export fee: func(ctx: borrow<view-context>) -> integer;
+  export fee: func(ctx: borrow<view-context>) -> integer;
 
-    export balance: func(ctx: borrow<view-context>, acc: string) -> option<integer>;
-    export transfer: func(ctx: borrow<proc-context>, to: string, n: integer) -> result<_, error>;
+  export balance: func(ctx: borrow<view-context>, acc: string) -> option<integer>;
+  export transfer: func(ctx: borrow<proc-context>, to: string, n: integer) -> result<_, error>;
 
-    export token-balance: func(ctx: borrow<view-context>, token: contract-address) -> result<integer, error>;
-    export quote-deposit: func(ctx: borrow<view-context>, amount-a: integer, amount-b: integer) -> result<deposit-result, error>;
-    export deposit: func(ctx: borrow<proc-context>, amount-a: integer, amount-b: integer) -> result<deposit-result, error>;
-    export quote-withdraw: func(ctx: borrow<view-context>, shares: integer) -> result<withdraw-result, error>;
-    export withdraw: func(ctx: borrow<proc-context>, shares: integer) -> result<withdraw-result, error>;
+  export token-balance: func(ctx: borrow<view-context>, token: contract-address) -> result<integer, error>;
+  export quote-deposit: func(ctx: borrow<view-context>, amount-a: integer, amount-b: integer) -> result<deposit-result, error>;
+  export deposit: func(ctx: borrow<proc-context>, amount-a: integer, amount-b: integer) -> result<deposit-result, error>;
+  export quote-withdraw: func(ctx: borrow<view-context>, shares: integer) -> result<withdraw-result, error>;
+  export withdraw: func(ctx: borrow<proc-context>, shares: integer) -> result<withdraw-result, error>;
 
 
-    export swap: func(ctx: borrow<proc-context>, token-in: contract-address, amount-in: integer, min-out: integer) -> result<integer, error>;
-    export quote-swap: func(ctx: borrow<view-context>, token-in: contract-address, amount-in: integer) -> result<integer, error>;
+  export swap: func(ctx: borrow<proc-context>, token-in: contract-address, amount-in: integer, min-out: integer) -> result<integer, error>;
+  export quote-swap: func(ctx: borrow<view-context>, token-in: contract-address, amount-in: integer) -> result<integer, error>;
 }

--- a/test-contracts/proxy/wit/contract.wit
+++ b/test-contracts/proxy/wit/contract.wit
@@ -1,15 +1,15 @@
 package kontor:contract;
 
 world contract {
-    include kontor:built-in/built-in;
-    use kontor:built-in/context.{fall-context, proc-context, view-context, signer};
-    use kontor:built-in/foreign.{contract-address};
+  include kontor:built-in/built-in;
+  use kontor:built-in/context.{fall-context, proc-context, view-context, signer};
+  use kontor:built-in/foreign.{contract-address};
 
-    export fallback: func(ctx: borrow<fall-context>, expr: string) -> string;
+  export fallback: func(ctx: borrow<fall-context>, expr: string) -> string;
 
-    export init: func(ctx: borrow<proc-context>);
+  export init: func(ctx: borrow<proc-context>);
 
-    export get-contract-address: func(ctx: borrow<view-context>) -> option<contract-address>;
+  export get-contract-address: func(ctx: borrow<view-context>) -> option<contract-address>;
 
-    export set-contract-address: func(ctx: borrow<proc-context>, contract-address: contract-address);
+  export set-contract-address: func(ctx: borrow<proc-context>, contract-address: contract-address);
 }

--- a/test-contracts/shared-account/wit/contract.wit
+++ b/test-contracts/shared-account/wit/contract.wit
@@ -1,23 +1,23 @@
 package kontor:contract;
 
 world contract {
-    include kontor:built-in/built-in;
-    use kontor:built-in/context.{view-context, proc-context, signer};
-    use kontor:built-in/error.{error};
-    use kontor:built-in/foreign.{contract-address};
-    use kontor:built-in/numbers.{integer, decimal};
+  include kontor:built-in/built-in;
+  use kontor:built-in/context.{view-context, proc-context, signer};
+  use kontor:built-in/error.{error};
+  use kontor:built-in/foreign.{contract-address};
+  use kontor:built-in/numbers.{integer, decimal};
 
-    export init: func(ctx: borrow<proc-context>);
+  export init: func(ctx: borrow<proc-context>);
 
-    export open: func(ctx: borrow<proc-context>, token: contract-address, n: integer, other-tenants: list<string>) -> result<string, error>;
+  export open: func(ctx: borrow<proc-context>, token: contract-address, n: integer, other-tenants: list<string>) -> result<string, error>;
 
-    export deposit: func(ctx: borrow<proc-context>, token: contract-address, account-id: string, n: integer) -> result<_, error>;
+  export deposit: func(ctx: borrow<proc-context>, token: contract-address, account-id: string, n: integer) -> result<_, error>;
 
-    export withdraw: func(ctx: borrow<proc-context>, token: contract-address, account-id: string, n: integer) -> result<_, error>;
+  export withdraw: func(ctx: borrow<proc-context>, token: contract-address, account-id: string, n: integer) -> result<_, error>;
 
-    export balance: func(ctx: borrow<view-context>, account-id: string) -> option<integer>;
+  export balance: func(ctx: borrow<view-context>, account-id: string) -> option<integer>;
 
-    export token-balance: func(ctx: borrow<view-context>, token: contract-address, holder: string) -> option<integer>;
+  export token-balance: func(ctx: borrow<view-context>, token: contract-address, holder: string) -> option<integer>;
 
-    export tenants: func(ctx: borrow<view-context>, account-id: string) -> option<list<string>>;
+  export tenants: func(ctx: borrow<view-context>, account-id: string) -> option<list<string>>;
 }

--- a/test-contracts/token/wit/contract.wit
+++ b/test-contracts/token/wit/contract.wit
@@ -1,16 +1,16 @@
 package kontor:contract;
 
 world contract {
-    include kontor:built-in/built-in;
-    use kontor:built-in/context.{view-context, proc-context, signer};
-    use kontor:built-in/error.{error};
-    use kontor:built-in/numbers.{integer, decimal};
+  include kontor:built-in/built-in;
+  use kontor:built-in/context.{view-context, proc-context, signer};
+  use kontor:built-in/error.{error};
+  use kontor:built-in/numbers.{integer, decimal};
 
-    export init: func(ctx: borrow<proc-context>);
+  export init: func(ctx: borrow<proc-context>);
 
-    export mint: func(ctx: borrow<proc-context>, n: integer);
-    export mint-checked: func(ctx: borrow<proc-context>, n: integer) -> result<_, error>;
-    export transfer: func(ctx: borrow<proc-context>, to: string, n: integer) -> result<_, error>;
-    export balance: func(ctx: borrow<view-context>, acc: string) -> option<integer>;
-    export balance-log10: func(ctx: borrow<view-context>, acc: string) -> result<option<decimal>, error>;
+  export mint: func(ctx: borrow<proc-context>, n: integer);
+  export mint-checked: func(ctx: borrow<proc-context>, n: integer) -> result<_, error>;
+  export transfer: func(ctx: borrow<proc-context>, to: string, n: integer) -> result<_, error>;
+  export balance: func(ctx: borrow<view-context>, acc: string) -> option<integer>;
+  export balance-log10: func(ctx: borrow<view-context>, acc: string) -> result<option<decimal>, error>;
 }


### PR DESCRIPTION
Changes to API:

`POST /transactions/op` -> `POST /transactions/inspect`
This same functionality is also exposed at
`GET /transactions/{txid}/inspect`
Which can be used more conveniently when you know the transaction has at least been seen by bitcoin.

`POST /compose` -> `POST /transactions/compose`

`POST /view/{address}` -> `POST /contracts/{address}`

`GET /wit/{address}` -> `GET /contracts/{address}`

A new get contracts endpoint now exists:
`GET /contracts`