### PR TITLE
Fix contract address in API

### DIFF
--- a/core/indexer/src/api/handlers.rs
+++ b/core/indexer/src/api/handlers.rs
@@ -272,7 +272,7 @@ impl From<ContractResultPublicRow> for ResultRow {
             contract: ContractAddress {
                 name: row.contract_name,
                 height: row.contract_height as u64,
-                tx_index: row.tx_index as u64,
+                tx_index: row.contract_tx_index as u64,
             }
             .to_string(),
         }


### PR DESCRIPTION
The ContractAddress in ResultRow was using the operation's tx_index (row.tx_index) instead of the contract's publication tx_index (row.contract_tx_index). This caused API responses to return incorrect contract address.