### PR TITLE
Test cleanup and speedup

### DIFF
--- a/core/indexer/src/reg_tester.rs
+++ b/core/indexer/src/reg_tester.rs
@@ -50,19 +50,26 @@ use tokio::{
     sync::Mutex,
 };
 
-const REGTEST_CONF: &str = r#"
-regtest=1
-rpcuser=rpc
-rpcpassword=rpc
+fn regtest_conf(rpc_port: u16, zmq_port: u16, p2p_port: u16) -> String {
+    format!(
+        r#"regtest=1
 server=1
 txindex=1
 prune=0
 dbcache=4000
-zmqpubsequence=tcp://127.0.0.1:28332
+
+[regtest]
+rpcuser=rpc
+rpcpassword=rpc
+rpcport={rpc_port}
+port={p2p_port}
+zmqpubsequence=tcp://127.0.0.1:{zmq_port}
 zmqpubsequencehwm=0
-zmqpubrawtx=tcp://127.0.0.1:28332
+zmqpubrawtx=tcp://127.0.0.1:{zmq_port}
 zmqpubrawtxhwm=0
-"#;
+"#
+    )
+}
 
 /// Derive a BLS12-381 secret key from a BIP-39 seed using EIP-2333.
 ///
@@ -70,14 +77,24 @@ zmqpubrawtxhwm=0
 /// on BLS12-381 scalars (unlike BIP-32, which is secp256k1-specific). All EIP-2333 child
 /// derivation is hardened by design, so paths are written without the `'` marker.
 ///
-async fn create_bitcoin_conf(data_dir: &Path) -> Result<()> {
+async fn create_bitcoin_conf(
+    data_dir: &Path,
+    rpc_port: u16,
+    zmq_port: u16,
+    p2p_port: u16,
+) -> Result<()> {
     let mut f = fs::File::create(data_dir.join("bitcoin.conf")).await?;
-    f.write_all(REGTEST_CONF.as_bytes()).await?;
+    f.write_all(regtest_conf(rpc_port, zmq_port, p2p_port).as_bytes())
+        .await?;
     Ok(())
 }
 
-async fn run_bitcoin(data_dir: &Path) -> Result<(Child, bitcoin_client::Client)> {
-    create_bitcoin_conf(data_dir).await?;
+/// Returns (child, client, rpc_url, zmq_port)
+async fn run_bitcoin(data_dir: &Path) -> Result<(Child, bitcoin_client::Client, String, u16)> {
+    let rpc_port = allocate_ports(1)?[0];
+    let zmq_port = allocate_ports(1)?[0];
+    let p2p_port = allocate_ports(1)?[0];
+    create_bitcoin_conf(data_dir, rpc_port, zmq_port, p2p_port).await?;
 
     // Check if bitcoind is in PATH
     let bitcoind_check = Command::new("which").arg("bitcoind").output().await;
@@ -92,7 +109,11 @@ async fn run_bitcoin(data_dir: &Path) -> Result<(Child, bitcoin_client::Client)>
     let process = Command::new("bitcoind")
         .arg(format!("-datadir={}", data_dir.to_string_lossy()))
         .spawn()?;
-    let client = bitcoin_client::Client::new_from_config(&RegtestConfig::default())?;
+    let config = RegtestConfig {
+        bitcoin_rpc_url: format!("http://127.0.0.1:{rpc_port}"),
+        ..RegtestConfig::default()
+    };
+    let client = bitcoin_client::Client::new_from_config(&config)?;
     retry_simple(async || {
         let i = client.get_blockchain_info().await?;
         if i.chain != Network::Regtest {
@@ -101,7 +122,8 @@ async fn run_bitcoin(data_dir: &Path) -> Result<(Child, bitcoin_client::Client)>
         Ok(())
     })
     .await?;
-    Ok((process, client))
+    let rpc_url = config.bitcoin_rpc_url;
+    Ok((process, client, rpc_url, zmq_port))
 }
 
 struct ConsensusNodeConfig {
@@ -114,6 +136,8 @@ struct ConsensusNodeConfig {
 async fn run_kontor(
     data_dir: &Path,
     api_port: u16,
+    bitcoin_rpc_url: &str,
+    zmq_port: u16,
     consensus: Option<&ConsensusNodeConfig>,
 ) -> Result<(Child, KontorClient)> {
     let config = RegtestConfig::default();
@@ -128,11 +152,13 @@ async fn run_kontor(
         .arg("--starting-block-height")
         .arg("102")
         .arg("--bitcoin-rpc-url")
-        .arg(config.bitcoin_rpc_url)
+        .arg(bitcoin_rpc_url)
         .arg("--bitcoin-rpc-user")
         .arg(config.bitcoin_rpc_user)
         .arg("--bitcoin-rpc-password")
-        .arg(config.bitcoin_rpc_password);
+        .arg(config.bitcoin_rpc_password)
+        .arg("--zmq-address")
+        .arg(format!("tcp://127.0.0.1:{zmq_port}"));
 
     if let Some(c) = consensus {
         cmd.arg("--consensus-private-key")
@@ -792,6 +818,8 @@ pub struct RegTesterCluster {
     pub identity: Identity,
     pub reg_tester: RegTester,
     pub pool: IdentityPool,
+    bitcoin_rpc_url: String,
+    zmq_port: u16,
     node_counter: AtomicUsize,
     genesis_path: std::path::PathBuf,
     miner_cmd_tx: tokio::sync::mpsc::Sender<MinerCmd>,
@@ -820,7 +848,8 @@ impl RegTesterCluster {
         assert!(active <= total, "active must be <= total");
 
         let bitcoin_data_dir = TempDir::new()?;
-        let (bitcoin_child, bitcoin_client) = run_bitcoin(bitcoin_data_dir.path()).await?;
+        let (bitcoin_child, bitcoin_client, bitcoin_rpc_url, zmq_port) =
+            run_bitcoin(bitcoin_data_dir.path()).await?;
 
         // Create a funded identity for transaction building
         let mut seed = [0u8; 64];
@@ -902,7 +931,16 @@ impl RegTesterCluster {
             .iter()
             .enumerate()
             .take(active)
-            .map(|(i, nc)| Self::launch_node(nc, i, &all_consensus_ports, &genesis_path))
+            .map(|(i, nc)| {
+                Self::launch_node(
+                    nc,
+                    i,
+                    &all_consensus_ports,
+                    &genesis_path,
+                    &bitcoin_rpc_url,
+                    zmq_port,
+                )
+            })
             .collect();
         let results = futures_util::future::join_all(launch_futures).await;
         for (i, result) in results.into_iter().enumerate() {
@@ -973,6 +1011,8 @@ impl RegTesterCluster {
             identity,
             reg_tester,
             pool,
+            bitcoin_rpc_url,
+            zmq_port,
             node_counter: AtomicUsize::new(0),
             genesis_path,
             miner_cmd_tx,
@@ -998,6 +1038,8 @@ impl RegTesterCluster {
         index: usize,
         all_consensus_ports: &[u16],
         genesis_path: &std::path::Path,
+        bitcoin_rpc_url: &str,
+        zmq_port: u16,
     ) -> Result<(Child, KontorClient)> {
         let consensus_config = ConsensusNodeConfig {
             private_key_hex: hex::encode(nc.ed25519_key.inner().to_bytes()),
@@ -1010,7 +1052,14 @@ impl RegTesterCluster {
                 .collect(),
             genesis_file: genesis_path.to_string_lossy().into_owned(),
         };
-        run_kontor(nc.data_dir.path(), nc.api_port, Some(&consensus_config)).await
+        run_kontor(
+            nc.data_dir.path(),
+            nc.api_port,
+            bitcoin_rpc_url,
+            zmq_port,
+            Some(&consensus_config),
+        )
+        .await
     }
 
     /// Get the client for a running node.
@@ -1043,8 +1092,15 @@ impl RegTesterCluster {
             .map(|nc| nc.consensus_port)
             .collect();
         let nc = &self.node_configs[index];
-        let (child, client) =
-            Self::launch_node(nc, index, &all_consensus_ports, &self.genesis_path).await?;
+        let (child, client) = Self::launch_node(
+            nc,
+            index,
+            &all_consensus_ports,
+            &self.genesis_path,
+            &self.bitcoin_rpc_url,
+            self.zmq_port,
+        )
+        .await?;
         self.node_configs[index].running = Some(ClusterNode { client, child });
 
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);

--- a/core/indexer/src/reg_tester.rs
+++ b/core/indexer/src/reg_tester.rs
@@ -13,9 +13,7 @@ use backon::BackoffBuilder;
 use crate::{
     api::{client::Client as KontorClient, ws_client::WebSocketClient},
     bitcoin_client::{
-        self, Client as BitcoinClient,
-        client::RegtestRpc,
-        types::{GetMempoolInfoResult, TestMempoolAcceptResult},
+        self, Client as BitcoinClient, client::RegtestRpc, types::TestMempoolAcceptResult,
     },
     bls::{
         RegistrationProof, bls_derivation_path, derive_bls_secret_key_eip2333,
@@ -259,8 +257,6 @@ pub struct RegTesterInner {
     ws_client: WebSocketClient,
     /// Address to mine blocks to (cluster admin identity's address).
     mine_address: String,
-    /// When true, batchable ops skip mining and rely on consensus batching.
-    pub cluster_mode: bool,
     /// Cache of published contracts by name — enables idempotent publish.
     pub published_contracts: HashMap<String, ContractAddress>,
     /// Shared identity pool for popping pre-created identities.
@@ -293,7 +289,6 @@ impl RegTesterInner {
             bitcoin_client,
             kontor_client,
             mine_address,
-            cluster_mode: false,
             published_contracts: HashMap::new(),
             pool,
         })
@@ -335,11 +330,6 @@ impl RegTesterInner {
             .generate_to_address(count, &self.mine_address)
             .await?;
         Ok(())
-    }
-
-    pub async fn mempool_info(&self) -> Result<GetMempoolInfoResult> {
-        let result = self.bitcoin_client.get_mempool_info().await?;
-        Ok(result)
     }
 
     pub async fn compose_instruction(
@@ -457,11 +447,10 @@ impl RegTesterInner {
         ident: &mut Identity,
         insts: Insts,
     ) -> Result<InstructionResult> {
-        let needs_mine = !self.cluster_mode
-            || insts
-                .ops
-                .iter()
-                .any(|inst| matches!(inst, Inst::Publish { .. }));
+        let needs_mine = insts
+            .ops
+            .iter()
+            .any(|inst| matches!(inst, Inst::Publish { .. }));
         let sent = self.send_insts(ident, insts).await?;
         let id = OpResultId::builder()
             .txid(sent.reveal_txid.to_string())
@@ -564,16 +553,6 @@ impl RegTester {
         self.inner.lock().await.kontor_client.clone()
     }
 
-    pub async fn wait_next_block(&self) -> Result<()> {
-        let mut inner = self.inner.lock().await;
-        inner
-            .ws_client
-            .next()
-            .await
-            .context("Failed to receive response from websocket")?;
-        Ok(())
-    }
-
     pub async fn mempool_accept_result(
         &self,
         raw_txs: &[String],
@@ -620,10 +599,6 @@ impl RegTester {
             .kontor_client
             .compose_reveal(query)
             .await
-    }
-
-    pub async fn mempool_info(&self) -> Result<GetMempoolInfoResult> {
-        self.inner.lock().await.mempool_info().await
     }
 
     pub async fn compose_instruction(
@@ -694,10 +669,6 @@ impl RegTester {
         self.inner.lock().await.identity().await
     }
 
-    pub async fn cluster_mode(&self) -> bool {
-        self.inner.lock().await.cluster_mode
-    }
-
     pub async fn view(&self, contract_address: &ContractAddress, expr: &str) -> Result<String> {
         self.inner.lock().await.view(contract_address, expr).await
     }
@@ -740,7 +711,7 @@ impl RegTester {
         self.inner.lock().await.checkpoint().await
     }
 
-    pub async fn info(&mut self) -> Result<Info> {
+    pub async fn info(&self) -> Result<Info> {
         self.inner.lock().await.kontor_client.index().await
     }
 }
@@ -983,7 +954,7 @@ impl RegTesterCluster {
             .expect("Node 0 not running")
             .client;
         let mine_address = identity.address.to_string();
-        let mut inner = RegTesterInner::with_port(
+        let inner = RegTesterInner::with_port(
             bitcoin_client.clone(),
             client.clone(),
             node_configs[0].api_port,
@@ -991,7 +962,7 @@ impl RegTesterCluster {
             pool.clone(),
         )
         .await?;
-        inner.cluster_mode = true;
+
         let reg_tester = RegTester {
             inner: Arc::new(Mutex::new(inner)),
         };
@@ -1119,7 +1090,7 @@ impl RegTesterCluster {
 
         let nc = &self.node_configs[node_idx];
         let client = &nc.running.as_ref().unwrap().client;
-        let mut inner = RegTesterInner::with_port(
+        let inner = RegTesterInner::with_port(
             self.bitcoin_client.clone(),
             client.clone(),
             nc.api_port,
@@ -1127,7 +1098,7 @@ impl RegTesterCluster {
             self.pool.clone(),
         )
         .await?;
-        inner.cluster_mode = true;
+
         Ok(RegTester {
             inner: Arc::new(Mutex::new(inner)),
         })

--- a/core/indexer/src/retry.rs
+++ b/core/indexer/src/retry.rs
@@ -16,7 +16,7 @@ pub fn new_backoff_unlimited() -> ExponentialBuilder {
 }
 
 pub fn new_backoff_limited() -> ExponentialBuilder {
-    new_backoff().with_max_times(5)
+    new_backoff().with_max_times(6)
 }
 
 pub fn notify<E: std::fmt::Debug>(action: &str) -> impl FnMut(&E, Duration) {

--- a/core/indexer/src/test_utils.rs
+++ b/core/indexer/src/test_utils.rs
@@ -734,3 +734,32 @@ pub mod reactor_harness {
         }
     }
 }
+
+/// BLS test helpers shared between unit and regtest attack vector tests.
+pub mod bls_test {
+    use blst::min_sig::{AggregatePublicKey, PublicKey as BlsPublicKey};
+
+    pub fn derive_test_key(seed_byte: u8) -> blst::min_sig::SecretKey {
+        let seed = [seed_byte; 64];
+        crate::bls::derive_bls_secret_key_eip2333(
+            &seed,
+            &crate::bls::bls_derivation_path(bitcoin::Network::Regtest),
+        )
+        .expect("failed to derive EIP-2333 secret key")
+    }
+
+    pub fn construct_rogue_g2_pubkey(
+        beta_pk_compressed: &[u8; 96],
+        victim_pk_compressed: &[u8; 96],
+    ) -> [u8; 96] {
+        let beta_pk =
+            BlsPublicKey::key_validate(beta_pk_compressed).expect("beta pk must be valid G2");
+        let mut neg_victim_bytes = *victim_pk_compressed;
+        neg_victim_bytes[0] ^= 0x20;
+        let neg_victim_pk = BlsPublicKey::key_validate(&neg_victim_bytes)
+            .expect("negated victim pk must be valid G2");
+        let agg = AggregatePublicKey::aggregate(&[&beta_pk, &neg_victim_pk], false)
+            .expect("aggregation must succeed");
+        agg.to_public_key().to_bytes()
+    }
+}

--- a/core/indexer/tests/bls_attack_unit.rs
+++ b/core/indexer/tests/bls_attack_unit.rs
@@ -1,0 +1,111 @@
+use bitcoin::hashes::{Hash, sha256};
+use bitcoin::key::{Keypair, Secp256k1, rand};
+use bitcoin::secp256k1::Message;
+use blst::BLST_ERROR;
+use blst::min_sig::AggregateSignature;
+use indexer::bls::{
+    BLS_BINDING_PREFIX, KONTOR_BLS_DST, SCHNORR_BINDING_PREFIX, validate_aggregate_shape,
+};
+use indexer::test_utils::bls_test::{construct_rogue_g2_pubkey, derive_test_key};
+use indexer_types::{AggregateInfo, Inst, Insts};
+
+#[test]
+fn rogue_key_forgery_succeeds_with_same_message() {
+    let victim_sk = derive_test_key(10);
+    let victim_pk = victim_sk.sk_to_pk();
+    let beta_sk = derive_test_key(11);
+    let beta_pk = beta_sk.sk_to_pk();
+    let rogue_pk_bytes = construct_rogue_g2_pubkey(&beta_pk.to_bytes(), &victim_pk.to_bytes());
+    let rogue_pk =
+        blst::min_sig::PublicKey::key_validate(&rogue_pk_bytes).expect("rogue key must be valid");
+    let msg = b"identical-message";
+    let forged_sig = beta_sk.sign(msg, KONTOR_BLS_DST, &[]);
+    let result = forged_sig.aggregate_verify(
+        true,
+        &[msg.as_slice(), msg.as_slice()],
+        KONTOR_BLS_DST,
+        &[&rogue_pk, &victim_pk],
+        true,
+    );
+    assert_eq!(
+        result,
+        BLST_ERROR::BLST_SUCCESS,
+        "same-message rogue-key forgery must succeed (this is the attack)"
+    );
+}
+
+#[test]
+fn rogue_key_forgery_fails_with_distinct_messages() {
+    let victim_sk = derive_test_key(10);
+    let victim_pk = victim_sk.sk_to_pk();
+    let beta_sk = derive_test_key(11);
+    let beta_pk = beta_sk.sk_to_pk();
+    let rogue_pk_bytes = construct_rogue_g2_pubkey(&beta_pk.to_bytes(), &victim_pk.to_bytes());
+    let rogue_pk =
+        blst::min_sig::PublicKey::key_validate(&rogue_pk_bytes).expect("rogue key must be valid");
+    let msg_attacker = b"attacker-op-data";
+    let msg_victim = b"victim-op-data";
+    let victim_sig = victim_sk.sign(msg_victim, KONTOR_BLS_DST, &[]);
+    let attacker_sig = beta_sk.sign(msg_attacker, KONTOR_BLS_DST, &[]);
+    let agg =
+        AggregateSignature::aggregate(&[&attacker_sig, &victim_sig], true).expect("aggregate");
+    let agg_sig = agg.to_signature();
+    let result = agg_sig.aggregate_verify(
+        true,
+        &[msg_attacker.as_slice(), msg_victim.as_slice()],
+        KONTOR_BLS_DST,
+        &[&rogue_pk, &victim_pk],
+        true,
+    );
+    assert_ne!(
+        result,
+        BLST_ERROR::BLST_SUCCESS,
+        "distinct-message rogue-key forgery must fail"
+    );
+}
+
+#[test]
+fn bls_attack_eve_registers_own_key_under_alice_identity_aggregate_rejected() {
+    let secp = Secp256k1::new();
+    let alice_keypair = Keypair::new(&secp, &mut rand::thread_rng());
+    let eve_keypair = Keypair::new(&secp, &mut rand::thread_rng());
+    let alice_xonly = alice_keypair.x_only_public_key().0;
+    let eve_bls_sk = derive_test_key(42);
+    let eve_bls_pk = eve_bls_sk.sk_to_pk();
+    let schnorr_msg = {
+        let mut preimage = Vec::with_capacity(SCHNORR_BINDING_PREFIX.len() + 96);
+        preimage.extend_from_slice(SCHNORR_BINDING_PREFIX);
+        preimage.extend_from_slice(&eve_bls_pk.to_bytes());
+        let digest = sha256::Hash::hash(&preimage).to_byte_array();
+        Message::from_digest_slice(&digest).expect("32-byte digest")
+    };
+    let eve_schnorr_sig = secp.sign_schnorr(&schnorr_msg, &eve_keypair).serialize();
+    let bls_binding_msg = {
+        let mut msg = Vec::with_capacity(BLS_BINDING_PREFIX.len() + 32);
+        msg.extend_from_slice(BLS_BINDING_PREFIX);
+        msg.extend_from_slice(&alice_xonly.serialize());
+        msg
+    };
+    let eve_bls_binding_sig = eve_bls_sk
+        .sign(&bls_binding_msg, KONTOR_BLS_DST, &[])
+        .to_bytes();
+    let op = Inst::RegisterBlsKey {
+        bls_pubkey: eve_bls_pk.to_bytes().to_vec(),
+        schnorr_sig: eve_schnorr_sig.to_vec(),
+        bls_sig: eve_bls_binding_sig.to_vec(),
+    };
+    let insts = Insts {
+        ops: vec![op],
+        aggregate: Some(AggregateInfo {
+            signer_ids: vec![0],
+            signature: vec![0u8; 48],
+        }),
+    };
+    let err = validate_aggregate_shape(&insts)
+        .expect_err("aggregate RegisterBlsKey must be rejected before execution");
+    assert!(
+        err.to_string()
+            .contains("RegisterBlsKey is not allowed in aggregate"),
+        "aggregate registration path should be closed entirely"
+    );
+}

--- a/core/indexer/tests/bls_attack_vectors.rs
+++ b/core/indexer/tests/bls_attack_vectors.rs
@@ -7,19 +7,14 @@
 //! - Aggregate-level forgery with same vs distinct messages
 
 use anyhow::Result;
-use bitcoin::Network;
 use bitcoin::hashes::{Hash, sha256};
 use bitcoin::key::rand::RngCore;
-use bitcoin::key::{Keypair, Secp256k1, rand};
+use bitcoin::key::{Secp256k1, rand};
 use bitcoin::secp256k1::Message;
-use blst::BLST_ERROR;
 use blst::min_sig::SecretKey as BlsSecretKey;
-use blst::min_sig::{AggregatePublicKey, AggregateSignature, PublicKey as BlsPublicKey};
-use indexer::bls::{
-    BLS_BINDING_PREFIX, KONTOR_BLS_DST, RegistrationProof, SCHNORR_BINDING_PREFIX,
-    bls_derivation_path, derive_bls_secret_key_eip2333, validate_aggregate_shape,
-};
-use indexer_types::{AggregateInfo, Inst, Insts, Signer};
+use indexer::bls::{BLS_BINDING_PREFIX, KONTOR_BLS_DST, RegistrationProof, SCHNORR_BINDING_PREFIX};
+use indexer::test_utils::bls_test::construct_rogue_g2_pubkey;
+use indexer_types::{Inst, Signer};
 use testlib::{
     AnyhowError, ContractAddress, Decimal, Error, Integer, RawFileDescriptor, Runtime, TypedCall,
     import,
@@ -31,144 +26,6 @@ import!(
     tx_index = 0,
     path = "../../native-contracts/registry/wit",
 );
-
-fn derive_test_key(seed_byte: u8) -> blst::min_sig::SecretKey {
-    let seed = [seed_byte; 64];
-    derive_bls_secret_key_eip2333(&seed, &bls_derivation_path(Network::Regtest))
-        .expect("failed to derive EIP-2333 secret key")
-}
-
-/// Construct PK_rogue = PK_beta − PK_victim in G2.
-fn construct_rogue_g2_pubkey(
-    beta_pk_compressed: &[u8; 96],
-    victim_pk_compressed: &[u8; 96],
-) -> [u8; 96] {
-    let beta_pk = BlsPublicKey::key_validate(beta_pk_compressed).expect("beta pk must be valid G2");
-    let mut neg_victim_bytes = *victim_pk_compressed;
-    neg_victim_bytes[0] ^= 0x20;
-    let neg_victim_pk =
-        BlsPublicKey::key_validate(&neg_victim_bytes).expect("negated victim pk must be valid G2");
-    let agg = AggregatePublicKey::aggregate(&[&beta_pk, &neg_victim_pk], false)
-        .expect("aggregation must succeed");
-    agg.to_public_key().to_bytes()
-}
-
-#[test]
-fn rogue_key_forgery_succeeds_with_same_message() {
-    let victim_sk = derive_test_key(10);
-    let victim_pk = victim_sk.sk_to_pk();
-
-    let beta_sk = derive_test_key(11);
-    let beta_pk = beta_sk.sk_to_pk();
-
-    let rogue_pk_bytes = construct_rogue_g2_pubkey(&beta_pk.to_bytes(), &victim_pk.to_bytes());
-    let rogue_pk = blst::min_sig::PublicKey::key_validate(&rogue_pk_bytes)
-        .expect("rogue key must be valid G2");
-
-    let msg = b"identical-message";
-    let forged_sig = beta_sk.sign(msg, KONTOR_BLS_DST, &[]);
-
-    let result = forged_sig.aggregate_verify(
-        true,
-        &[msg.as_slice(), msg.as_slice()],
-        KONTOR_BLS_DST,
-        &[&rogue_pk, &victim_pk],
-        true,
-    );
-    assert_eq!(
-        result,
-        BLST_ERROR::BLST_SUCCESS,
-        "same-message rogue-key forgery must succeed (this is the attack)"
-    );
-}
-
-#[test]
-fn rogue_key_forgery_fails_with_distinct_messages() {
-    let victim_sk = derive_test_key(10);
-    let victim_pk = victim_sk.sk_to_pk();
-
-    let beta_sk = derive_test_key(11);
-    let beta_pk = beta_sk.sk_to_pk();
-
-    let rogue_pk_bytes = construct_rogue_g2_pubkey(&beta_pk.to_bytes(), &victim_pk.to_bytes());
-    let rogue_pk = blst::min_sig::PublicKey::key_validate(&rogue_pk_bytes)
-        .expect("rogue key must be valid G2");
-
-    let msg_attacker = b"attacker-op-data";
-    let msg_victim = b"victim-op-data";
-
-    let victim_sig = victim_sk.sign(msg_victim, KONTOR_BLS_DST, &[]);
-    let attacker_sig = beta_sk.sign(msg_attacker, KONTOR_BLS_DST, &[]);
-
-    let agg =
-        AggregateSignature::aggregate(&[&attacker_sig, &victim_sig], true).expect("aggregate");
-    let agg_sig = agg.to_signature();
-
-    let result = agg_sig.aggregate_verify(
-        true,
-        &[msg_attacker.as_slice(), msg_victim.as_slice()],
-        KONTOR_BLS_DST,
-        &[&rogue_pk, &victim_pk],
-        true,
-    );
-    assert_ne!(
-        result,
-        BLST_ERROR::BLST_SUCCESS,
-        "distinct-message rogue-key forgery must fail"
-    );
-}
-
-#[test]
-fn bls_attack_eve_registers_own_key_under_alice_identity_aggregate_rejected() {
-    let secp = Secp256k1::new();
-    let alice_keypair = Keypair::new(&secp, &mut rand::thread_rng());
-    let eve_keypair = Keypair::new(&secp, &mut rand::thread_rng());
-    let alice_xonly = alice_keypair.x_only_public_key().0;
-
-    let eve_bls_sk = derive_test_key(42);
-    let eve_bls_pk = eve_bls_sk.sk_to_pk();
-
-    let schnorr_msg = {
-        let mut preimage = Vec::with_capacity(SCHNORR_BINDING_PREFIX.len() + 96);
-        preimage.extend_from_slice(SCHNORR_BINDING_PREFIX);
-        preimage.extend_from_slice(&eve_bls_pk.to_bytes());
-        let digest = sha256::Hash::hash(&preimage).to_byte_array();
-        Message::from_digest_slice(&digest).expect("32-byte digest")
-    };
-    let eve_schnorr_sig = secp.sign_schnorr(&schnorr_msg, &eve_keypair).serialize();
-
-    let bls_binding_msg = {
-        let mut msg = Vec::with_capacity(BLS_BINDING_PREFIX.len() + 32);
-        msg.extend_from_slice(BLS_BINDING_PREFIX);
-        msg.extend_from_slice(&alice_xonly.serialize());
-        msg
-    };
-    let eve_bls_binding_sig = eve_bls_sk
-        .sign(&bls_binding_msg, KONTOR_BLS_DST, &[])
-        .to_bytes();
-
-    let op = Inst::RegisterBlsKey {
-        bls_pubkey: eve_bls_pk.to_bytes().to_vec(),
-        schnorr_sig: eve_schnorr_sig.to_vec(),
-        bls_sig: eve_bls_binding_sig.to_vec(),
-    };
-
-    let insts = Insts {
-        ops: vec![op],
-        aggregate: Some(AggregateInfo {
-            signer_ids: vec![0],
-            signature: vec![0u8; 48],
-        }),
-    };
-
-    let err = validate_aggregate_shape(&insts)
-        .expect_err("aggregate RegisterBlsKey must be rejected before execution");
-    assert!(
-        err.to_string()
-            .contains("RegisterBlsKey is not allowed in aggregate"),
-        "aggregate registration path should be closed entirely"
-    );
-}
 
 #[testlib::test(contracts_dir = "../../test-contracts", regtest_only)]
 async fn bls_attack_rogue_key_registration_rejected() -> Result<()> {

--- a/core/indexer/tests/compose_tests/compose_commit_unit.rs
+++ b/core/indexer/tests/compose_tests/compose_commit_unit.rs
@@ -4,55 +4,6 @@ use indexer::api::compose::{CommitInputs, ComposeInputs, InstructionInputs, comp
 use testlib::RegTester;
 use tracing::info;
 
-pub async fn test_compose_commit_unique_vout_mapping_even_with_identical_chunks(
-    reg_tester: &mut RegTester,
-) -> Result<()> {
-    info!("test_compose_commit_unique_vout_mapping_even_with_identical_chunks");
-    let identity = reg_tester.identity().await?;
-    let keypair = identity.keypair;
-    let addr = identity.address.clone();
-    let (internal_key, _parity) = keypair.x_only_public_key();
-    let utxos = reg_tester.fund_address(&addr, 2).await?;
-    let utxo1 = utxos[0].clone();
-    let utxo2 = utxos[1].clone();
-
-    // Two participants with identical script data to force identical tapscripts
-    let data = b"same".to_vec();
-
-    let inputs = ComposeInputs::builder()
-        .instructions(vec![
-            InstructionInputs::builder()
-                .address(addr.clone())
-                .x_only_public_key(internal_key)
-                .funding_utxos(vec![utxo1])
-                .instruction(data.clone())
-                .build(),
-            InstructionInputs::builder()
-                .address(addr.clone())
-                .x_only_public_key(internal_key)
-                .funding_utxos(vec![utxo2])
-                .instruction(data.clone())
-                .build(),
-        ])
-        .fee_rate(FeeRate::from_sat_per_vb(2).unwrap())
-        .envelope(546)
-        .build();
-    let commit = compose_commit(CommitInputs::from(inputs)).expect("commit");
-    // Ensure outpoints in reveal_inputs are unique
-    let vouts: std::collections::HashSet<u32> = commit
-        .reveal_inputs
-        .participants
-        .iter()
-        .map(|p| p.commit_outpoint.vout)
-        .collect();
-    assert_eq!(
-        vouts.len(),
-        2,
-        "each participant should map to a unique vout"
-    );
-    Ok(())
-}
-
 pub async fn test_compose_commit_psbt_inputs_have_metadata(
     reg_tester: &mut RegTester,
 ) -> Result<()> {

--- a/core/indexer/tests/compose_tests/multi_psbt_integration.rs
+++ b/core/indexer/tests/compose_tests/multi_psbt_integration.rs
@@ -65,14 +65,9 @@ pub async fn test_portal_coordinated_commit_reveal_flow_integration(
 
     let secp = Secp256k1::new();
 
-    // Fee environment
-    let mp = reg_tester.mempool_info().await?;
-    let min_btc_per_kvb = mp
-        .mempool_min_fee_btc_per_kvb
-        .max(mp.min_relay_tx_fee_btc_per_kvb);
-    let min_sat_per_vb: u64 = ((min_btc_per_kvb * 100_000_000.0) / 1000.0).ceil() as u64;
+    // Fee environment (regtest defaults: 1 sat/vbyte min relay fee)
+    let min_sat_per_vb: u64 = 2;
     let dust_limit_sat: u64 = 330;
-    info!("min_sat_per_vb={}", min_sat_per_vb);
 
     // Phase 1: Nodes sign up for agreement with address + x-only pubkey
     let (signups, node_secrets) = get_node_addresses(&mut reg_tester.clone()).await?;

--- a/core/indexer/tests/reactor_cluster.rs
+++ b/core/indexer/tests/reactor_cluster.rs
@@ -32,13 +32,58 @@ use testlib::ContractReader;
 use testlib::*;
 interface!(name = "counter", path = "../../test-contracts/counter/wit");
 
-fn shared_engine_and_cache() -> (wasmtime::Engine, ComponentCache) {
-    static ENGINE: OnceLock<wasmtime::Engine> = OnceLock::new();
-    static CACHE: OnceLock<ComponentCache> = OnceLock::new();
-    let engine = ENGINE
-        .get_or_init(|| Runtime::new_engine().expect("Failed to create shared engine"))
-        .clone();
-    let cache = CACHE.get_or_init(ComponentCache::new).clone();
+async fn shared_engine_and_cache() -> (wasmtime::Engine, ComponentCache) {
+    static ONCE: OnceLock<(wasmtime::Engine, ComponentCache)> = OnceLock::new();
+    if let Some(cached) = ONCE.get() {
+        return cached.clone();
+    }
+
+    // Pre-warm: compile all contracts once into the shared cache
+    let engine = Runtime::new_engine().expect("Failed to create shared engine");
+    let cache = ComponentCache::new();
+
+    let (_reader, writer, (_db_dir, _db_name)) = new_test_db().await.expect("test db");
+    let conn = writer.connection();
+    insert_block(
+        &conn,
+        BlockRow::builder()
+            .height(0)
+            .hash(new_mock_block_hash(0))
+            .relevant(true)
+            .build(),
+    )
+    .await
+    .expect("insert block");
+
+    let storage = Storage::builder().height(0).conn(conn).build();
+    let linker = Runtime::new_linker(&engine).expect("linker");
+    let mut runtime = Runtime::new_with(engine.clone(), linker, cache.clone(), storage)
+        .await
+        .expect("runtime");
+    let signer = Signer::XOnlyPubKey("prewarm".to_string());
+    runtime
+        .publish_native_contracts(&[])
+        .await
+        .expect("publish native");
+    runtime
+        .issuance(&signer)
+        .await
+        .expect("prewarm issuance");
+
+    let contract_reader = ContractReader::new("../../test-contracts")
+        .await
+        .expect("contract reader");
+    let counter_bytes = contract_reader
+        .read("counter")
+        .await
+        .expect("read counter")
+        .expect("counter not found");
+    runtime
+        .publish(&signer, "counter", &counter_bytes)
+        .await
+        .expect("publish counter");
+
+    let _ = ONCE.set((engine.clone(), cache.clone()));
     (engine, cache)
 }
 
@@ -220,9 +265,9 @@ impl Executor for LiteExecutor {
     }
 }
 
-fn allocate_port() -> Result<u16> {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
-    Ok(listener.local_addr()?.port())
+fn allocate_port() -> u16 {
+    static NEXT_PORT: std::sync::atomic::AtomicU16 = std::sync::atomic::AtomicU16::new(19000);
+    NEXT_PORT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
 }
 
 /// Collect events from a channel until `n` events match the predicate, or timeout.
@@ -311,16 +356,14 @@ impl ReactorCluster {
         let validator_set = ValidatorSet::new(validators);
         let genesis = Genesis { validator_set };
 
-        let ports: Vec<u16> = (0..total)
-            .map(|_| allocate_port().expect("Failed to allocate port"))
-            .collect();
+        let ports: Vec<u16> = (0..total).map(|_| allocate_port()).collect();
 
         let (mempool_tx, _) = broadcast::channel::<MempoolEvent>(256);
         let cancel = CancellationToken::new();
         let mut block_txs = Vec::new();
         let mock_bitcoin = Arc::new(Mutex::new(MockBitcoin::new(0)));
         let shared_pubkey = indexer::reg_tester::random_x_only_pubkey();
-        let (engine, component_cache) = shared_engine_and_cache();
+        let (engine, component_cache) = shared_engine_and_cache().await;
 
         let (decided_tx, decided_rx) = mpsc::channel(1024);
         let (finality_tx, finality_rx) = mpsc::channel(1024);
@@ -658,7 +701,7 @@ impl Drop for ReactorCluster {
 /// Basic test: 4 validators decide a batch with mempool txs.
 /// Same as consensus-sim's `validators_agree_on_values` but through the prod reactor.
 #[tokio::test]
-#[serial_test::serial]
+
 async fn prod_reactor_validators_agree_on_values() -> Result<()> {
     indexer::logging::setup();
 
@@ -709,7 +752,7 @@ async fn prod_reactor_validators_agree_on_values() -> Result<()> {
 /// After mining, the block is decided through consensus (Value::Block),
 /// and the next batch anchors at the new height.
 #[tokio::test]
-#[serial_test::serial]
+
 async fn prod_reactor_block_updates_anchor() -> Result<()> {
     indexer::logging::setup();
 
@@ -783,7 +826,7 @@ async fn prod_reactor_block_updates_anchor() -> Result<()> {
 /// Happy path finalization: batch txs are confirmed on chain within
 /// the finality window, and a BatchFinalized event is emitted.
 #[tokio::test]
-#[serial_test::serial]
+
 async fn prod_reactor_happy_path_finalization() -> Result<()> {
     indexer::logging::setup();
 
@@ -836,7 +879,7 @@ async fn prod_reactor_happy_path_finalization() -> Result<()> {
 /// Missing tx invalidation: a batched tx that is never confirmed on chain
 /// triggers a finality rollback when the deadline passes.
 #[tokio::test]
-#[serial_test::serial]
+
 async fn prod_reactor_missing_tx_invalidation() -> Result<()> {
     indexer::logging::setup();
 
@@ -937,7 +980,7 @@ async fn prod_reactor_missing_tx_invalidation() -> Result<()> {
 /// Cascade invalidation: a missing tx at anchor 0 also invalidates a
 /// second batch decided at anchor 1 (same finality window).
 #[tokio::test]
-#[serial_test::serial]
+
 async fn prod_reactor_cascade_invalidation() -> Result<()> {
     indexer::logging::setup();
 
@@ -1021,7 +1064,7 @@ async fn prod_reactor_cascade_invalidation() -> Result<()> {
 /// Cross-block cascade: a missing tx at anchor 1 invalidates batches at
 /// anchors 1, 2, and 3. Batch at anchor 0 (already finalized) survives.
 #[tokio::test]
-#[serial_test::serial]
+
 async fn prod_reactor_cross_block_cascade_invalidation() -> Result<()> {
     indexer::logging::setup();
 
@@ -1139,7 +1182,7 @@ async fn prod_reactor_cross_block_cascade_invalidation() -> Result<()> {
 /// The batch executes first (counter increments), then the block decision skips
 /// the already-batched txids via dedup.
 #[tokio::test]
-#[serial_test::serial]
+
 async fn prod_reactor_batch_before_unbatched_at_same_anchor() -> Result<()> {
     indexer::logging::setup();
 
@@ -1216,7 +1259,7 @@ async fn prod_reactor_batch_before_unbatched_at_same_anchor() -> Result<()> {
 /// Finality rollback from anchor 1 — checkpoint after rollback should match
 /// the checkpoint from right after the batch at anchor 0.
 #[tokio::test]
-#[serial_test::serial]
+
 async fn prod_reactor_rollback_preserves_pre_anchor_state() -> Result<()> {
     indexer::logging::setup();
 
@@ -1333,7 +1376,7 @@ async fn prod_reactor_rollback_preserves_pre_anchor_state() -> Result<()> {
 /// IGNORED: Checkpoint computation is non-deterministic across nodes due to
 /// autoincrement tx_id values differing per-node DB. Needs investigation.
 #[tokio::test]
-#[serial_test::serial]
+
 async fn prod_reactor_all_nodes_reach_same_checkpoint() -> Result<()> {
     indexer::logging::setup();
 
@@ -1446,7 +1489,7 @@ async fn prod_reactor_all_nodes_reach_same_checkpoint() -> Result<()> {
 /// Test 11: Multiple batches decided at the same anchor height.
 /// Two separate rounds of mempool txs both anchor at height 0 (no blocks mined between them).
 #[tokio::test]
-#[serial_test::serial]
+
 async fn prod_reactor_multi_batch_same_anchor() -> Result<()> {
     indexer::logging::setup();
 
@@ -1525,7 +1568,7 @@ async fn prod_reactor_multi_batch_same_anchor() -> Result<()> {
 /// Process blocks 1-3, then send a Rollback to height 1. Blocks 2-3 are deleted.
 /// New blocks 2-3 arrive with different hashes.
 #[tokio::test]
-#[serial_test::serial]
+
 async fn prod_reactor_bitcoin_rollback_reverts_state() -> Result<()> {
     indexer::logging::setup();
 
@@ -1600,7 +1643,7 @@ async fn prod_reactor_bitcoin_rollback_reverts_state() -> Result<()> {
 /// Late joiner: start 3 of 4 validators, process batches + blocks,
 /// then start the 4th. It syncs via Malachite and reaches the same checkpoint.
 #[tokio::test]
-#[serial_test::serial]
+
 async fn prod_reactor_late_joiner_syncs_to_same_checkpoint() -> Result<()> {
     indexer::logging::setup();
 

--- a/core/indexer/tests/reactor_cluster.rs
+++ b/core/indexer/tests/reactor_cluster.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::Result;
@@ -33,55 +33,26 @@ use testlib::*;
 interface!(name = "counter", path = "../../test-contracts/counter/wit");
 
 async fn shared_engine_and_cache() -> (wasmtime::Engine, ComponentCache) {
-    static ONCE: OnceLock<(wasmtime::Engine, ComponentCache)> = OnceLock::new();
-    if let Some(cached) = ONCE.get() {
-        return cached.clone();
-    }
-
-    // Pre-warm: compile all contracts once into the shared cache
-    let engine = Runtime::new_engine().expect("Failed to create shared engine");
-    let cache = ComponentCache::new();
-
-    let (_reader, writer, (_db_dir, _db_name)) = new_test_db().await.expect("test db");
-    let conn = writer.connection();
-    insert_block(
-        &conn,
-        BlockRow::builder()
-            .height(0)
-            .hash(new_mock_block_hash(0))
-            .relevant(true)
-            .build(),
-    )
+    static ONCE: tokio::sync::OnceCell<(wasmtime::Engine, ComponentCache)> =
+        tokio::sync::OnceCell::const_new();
+    ONCE.get_or_init(|| async {
+        let engine = Runtime::new_engine().expect("Failed to create shared engine");
+        let cache = ComponentCache::new();
+        let mock_btc = Arc::new(Mutex::new(MockBitcoin::new(0)));
+        let (_executor, runtime) = LiteExecutor::new(
+            mock_btc,
+            "prewarm".to_string(),
+            &[],
+            engine.clone(),
+            cache.clone(),
+        )
+        .await
+        .expect("pre-warm setup failed");
+        drop(runtime);
+        (engine, cache)
+    })
     .await
-    .expect("insert block");
-
-    let storage = Storage::builder().height(0).conn(conn).build();
-    let linker = Runtime::new_linker(&engine).expect("linker");
-    let mut runtime = Runtime::new_with(engine.clone(), linker, cache.clone(), storage)
-        .await
-        .expect("runtime");
-    let signer = Signer::XOnlyPubKey("prewarm".to_string());
-    runtime
-        .publish_native_contracts(&[])
-        .await
-        .expect("publish native");
-    runtime.issuance(&signer).await.expect("prewarm issuance");
-
-    let contract_reader = ContractReader::new("../../test-contracts")
-        .await
-        .expect("contract reader");
-    let counter_bytes = contract_reader
-        .read("counter")
-        .await
-        .expect("read counter")
-        .expect("counter not found");
-    runtime
-        .publish(&signer, "counter", &counter_bytes)
-        .await
-        .expect("publish counter");
-
-    let _ = ONCE.set((engine.clone(), cache.clone()));
-    (engine, cache)
+    .clone()
 }
 
 struct LiteExecutor {

--- a/core/indexer/tests/reactor_cluster.rs
+++ b/core/indexer/tests/reactor_cluster.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use anyhow::Result;
@@ -32,6 +32,16 @@ use testlib::ContractReader;
 use testlib::*;
 interface!(name = "counter", path = "../../test-contracts/counter/wit");
 
+fn shared_engine_and_cache() -> (wasmtime::Engine, ComponentCache) {
+    static ENGINE: OnceLock<wasmtime::Engine> = OnceLock::new();
+    static CACHE: OnceLock<ComponentCache> = OnceLock::new();
+    let engine = ENGINE
+        .get_or_init(|| Runtime::new_engine().expect("Failed to create shared engine"))
+        .clone();
+    let cache = CACHE.get_or_init(ComponentCache::new).clone();
+    (engine, cache)
+}
+
 struct LiteExecutor {
     _db_dir: tempfile::TempDir,
     counter_address: ContractAddress,
@@ -49,6 +59,8 @@ impl LiteExecutor {
         mock_bitcoin: Arc<Mutex<MockBitcoin>>,
         shared_pubkey: String,
         genesis_validators: &[indexer::runtime::GenesisValidator],
+        engine: wasmtime::Engine,
+        component_cache: ComponentCache,
     ) -> Result<(Self, Runtime)> {
         let (_reader, writer, (db_dir, _db_name)) = new_test_db().await?;
         let conn = writer.connection();
@@ -64,7 +76,8 @@ impl LiteExecutor {
         .await?;
 
         let storage = Storage::builder().height(0).conn(conn).build();
-        let mut runtime = Runtime::new(ComponentCache::new(), storage).await?;
+        let linker = Runtime::new_linker(&engine)?;
+        let mut runtime = Runtime::new_with(engine, linker, component_cache, storage).await?;
         runtime.publish_native_contracts(genesis_validators).await?;
 
         let signer = Signer::XOnlyPubKey(shared_pubkey);
@@ -257,6 +270,8 @@ struct ReactorCluster {
     private_keys: Vec<PrivateKey>,
     ports: Vec<u16>,
     shared_pubkey: String,
+    engine: wasmtime::Engine,
+    component_cache: ComponentCache,
     decided_tx: mpsc::Sender<DecidedBatch>,
     finality_tx: mpsc::Sender<FinalityEvent>,
     state_tx: mpsc::Sender<StateEvent>,
@@ -305,6 +320,7 @@ impl ReactorCluster {
         let mut block_txs = Vec::new();
         let mock_bitcoin = Arc::new(Mutex::new(MockBitcoin::new(0)));
         let shared_pubkey = indexer::reg_tester::random_x_only_pubkey();
+        let (engine, component_cache) = shared_engine_and_cache();
 
         let (decided_tx, decided_rx) = mpsc::channel(1024);
         let (finality_tx, finality_rx) = mpsc::channel(1024);
@@ -335,6 +351,8 @@ impl ReactorCluster {
                 ready_tx.clone(),
                 mock_bitcoin.clone(),
                 shared_pubkey.clone(),
+                engine.clone(),
+                component_cache.clone(),
                 &mut join_set,
             );
             started_nodes[i] = true;
@@ -356,6 +374,8 @@ impl ReactorCluster {
             private_keys,
             ports,
             shared_pubkey,
+            engine,
+            component_cache,
             decided_tx,
             finality_tx,
             state_tx,
@@ -407,13 +427,16 @@ impl ReactorCluster {
         rtx: mpsc::Sender<usize>,
         mock_btc: Arc<Mutex<MockBitcoin>>,
         pubkey: String,
+        engine: wasmtime::Engine,
+        component_cache: ComponentCache,
         join_set: &mut JoinSet<()>,
     ) {
         let genesis = genesis.clone();
         let genesis_vals = genesis_validators.to_vec();
         let ports = ports.to_vec();
         join_set.spawn(async move {
-            let (executor, runtime) = LiteExecutor::new(mock_btc, pubkey, &genesis_vals)
+            let (executor, runtime) =
+                LiteExecutor::new(mock_btc, pubkey, &genesis_vals, engine, component_cache)
                 .await
                 .expect("LiteExecutor setup failed");
 
@@ -519,6 +542,8 @@ impl ReactorCluster {
             self.ready_tx.clone(),
             self.mock_bitcoin.clone(),
             self.shared_pubkey.clone(),
+            self.engine.clone(),
+            self.component_cache.clone(),
             &mut self.join_set,
         );
 

--- a/core/indexer/tests/reactor_cluster.rs
+++ b/core/indexer/tests/reactor_cluster.rs
@@ -65,10 +65,7 @@ async fn shared_engine_and_cache() -> (wasmtime::Engine, ComponentCache) {
         .publish_native_contracts(&[])
         .await
         .expect("publish native");
-    runtime
-        .issuance(&signer)
-        .await
-        .expect("prewarm issuance");
+    runtime.issuance(&signer).await.expect("prewarm issuance");
 
     let contract_reader = ContractReader::new("../../test-contracts")
         .await

--- a/core/indexer/tests/reactor_cluster.rs
+++ b/core/indexer/tests/reactor_cluster.rs
@@ -714,7 +714,7 @@ async fn prod_reactor_validators_agree_on_values() -> Result<()> {
     let decisions = cluster
         .wait_for_decision_matching(
             |d| !d.value.batch_txids().is_empty(),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
     assert!(
@@ -769,7 +769,7 @@ async fn prod_reactor_block_updates_anchor() -> Result<()> {
                     && d.value.block_height() == 0
                     && !d.value.batch_txids().is_empty()
             },
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
     assert!(
@@ -784,7 +784,7 @@ async fn prod_reactor_block_updates_anchor() -> Result<()> {
     let block_decisions = cluster
         .wait_for_decision_matching(
             |d| d.value.is_block() && d.value.block_height() == 1,
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
     assert!(
@@ -806,7 +806,7 @@ async fn prod_reactor_block_updates_anchor() -> Result<()> {
                     && d.value.block_height() == 1
                     && !d.value.batch_txids().is_empty()
             },
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
     assert!(
@@ -838,7 +838,7 @@ async fn prod_reactor_happy_path_finalization() -> Result<()> {
     let decisions = cluster
         .wait_for_decision_matching(
             |d| !d.value.is_block() && !d.value.batch_txids().is_empty(),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
     assert!(
@@ -858,7 +858,7 @@ async fn prod_reactor_happy_path_finalization() -> Result<()> {
     let finality_events = cluster
         .wait_for_finality_event_matching(
             |e| matches!(e, FinalityEvent::BatchFinalized { anchor_height, .. } if *anchor_height == 0),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -889,7 +889,7 @@ async fn prod_reactor_missing_tx_invalidation() -> Result<()> {
     cluster
         .wait_for_decision_matching(
             |d| d.value.is_block() && d.value.block_height() == 1,
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -911,7 +911,7 @@ async fn prod_reactor_missing_tx_invalidation() -> Result<()> {
         .wait_for_n_state_events_matching(
             cluster.node_count,
             |e| matches!(e, StateEvent::BatchApplied { txid_count, .. } if *txid_count > 0),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -927,11 +927,11 @@ async fn prod_reactor_missing_tx_invalidation() -> Result<()> {
         cluster.mine_empty_and_send();
     }
 
-    // Wait for finality rollback event
+    // Wait for finality rollback event (longer timeout for concurrent test execution)
     let finality_events = cluster
         .wait_for_finality_event_matching(
             |e| matches!(e, FinalityEvent::Rollback { missing_txids, .. } if missing_txids.contains(&missing_txid)),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -948,7 +948,7 @@ async fn prod_reactor_missing_tx_invalidation() -> Result<()> {
     let all_events = cluster
         .wait_for_state_event_matching(
             |e| matches!(e, StateEvent::BatchApplied { txid_count, .. } if *txid_count == 2),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -991,7 +991,7 @@ async fn prod_reactor_cascade_invalidation() -> Result<()> {
     cluster
         .wait_for_decision_matching(
             |d| !d.value.is_block() && !d.value.batch_txids().is_empty(),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1002,7 +1002,7 @@ async fn prod_reactor_cascade_invalidation() -> Result<()> {
     cluster
         .wait_for_decision_matching(
             |d| d.value.is_block() && d.value.block_height() == 1,
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1017,7 +1017,7 @@ async fn prod_reactor_cascade_invalidation() -> Result<()> {
                     && d.value.block_height() == 1
                     && !d.value.batch_txids().is_empty()
             },
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1030,7 +1030,7 @@ async fn prod_reactor_cascade_invalidation() -> Result<()> {
     let finality_events = cluster
         .wait_for_finality_event_matching(
             |e| matches!(e, FinalityEvent::Rollback { .. }),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1075,7 +1075,7 @@ async fn prod_reactor_cross_block_cascade_invalidation() -> Result<()> {
     let decisions = cluster
         .wait_for_decision_matching(
             |d| !d.value.is_block() && !d.value.batch_txids().is_empty(),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
     let batch0_txids = decisions
@@ -1091,7 +1091,7 @@ async fn prod_reactor_cross_block_cascade_invalidation() -> Result<()> {
     cluster
         .wait_for_decision_matching(
             |d| d.value.is_block() && d.value.block_height() == 1,
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1106,7 +1106,7 @@ async fn prod_reactor_cross_block_cascade_invalidation() -> Result<()> {
                     && d.value.block_height() == 1
                     && !d.value.batch_txids().is_empty()
             },
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1115,7 +1115,7 @@ async fn prod_reactor_cross_block_cascade_invalidation() -> Result<()> {
     cluster
         .wait_for_decision_matching(
             |d| d.value.is_block() && d.value.block_height() == 2,
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1130,7 +1130,7 @@ async fn prod_reactor_cross_block_cascade_invalidation() -> Result<()> {
                     && d.value.block_height() == 2
                     && !d.value.batch_txids().is_empty()
             },
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1146,7 +1146,7 @@ async fn prod_reactor_cross_block_cascade_invalidation() -> Result<()> {
     let finality_events = cluster
         .wait_for_finality_event_matching(
             |e| matches!(e, FinalityEvent::Rollback { from_anchor, .. } if *from_anchor == 1),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1203,7 +1203,7 @@ async fn prod_reactor_batch_before_unbatched_at_same_anchor() -> Result<()> {
     cluster
         .wait_for_decision_matching(
             |d| !d.value.is_block() && !d.value.batch_txids().is_empty(),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1211,7 +1211,7 @@ async fn prod_reactor_batch_before_unbatched_at_same_anchor() -> Result<()> {
     cluster
         .wait_for_state_event_matching(
             |e| matches!(e, StateEvent::BatchApplied { .. }),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1222,7 +1222,7 @@ async fn prod_reactor_batch_before_unbatched_at_same_anchor() -> Result<()> {
     cluster
         .wait_for_decision_matching(
             |d| d.value.is_block() && d.value.block_height() == 1,
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1230,7 +1230,7 @@ async fn prod_reactor_batch_before_unbatched_at_same_anchor() -> Result<()> {
     let block_events = cluster
         .wait_for_state_event_matching(
             |e| matches!(e, StateEvent::BlockProcessed { height, .. } if *height == 1),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
     let block_processed = block_events
@@ -1270,7 +1270,7 @@ async fn prod_reactor_rollback_preserves_pre_anchor_state() -> Result<()> {
     cluster
         .wait_for_decision_matching(
             |d| !d.value.is_block() && !d.value.batch_txids().is_empty(),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1286,7 +1286,7 @@ async fn prod_reactor_rollback_preserves_pre_anchor_state() -> Result<()> {
                     }
                 )
             },
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1295,7 +1295,7 @@ async fn prod_reactor_rollback_preserves_pre_anchor_state() -> Result<()> {
     cluster
         .wait_for_decision_matching(
             |d| d.value.is_block() && d.value.block_height() == 1,
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1310,7 +1310,7 @@ async fn prod_reactor_rollback_preserves_pre_anchor_state() -> Result<()> {
                     && d.value.block_height() == 1
                     && !d.value.batch_txids().is_empty()
             },
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1323,7 +1323,7 @@ async fn prod_reactor_rollback_preserves_pre_anchor_state() -> Result<()> {
     cluster
         .wait_for_finality_event_matching(
             |e| matches!(e, FinalityEvent::Rollback { from_anchor, .. } if *from_anchor == 1),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1331,7 +1331,7 @@ async fn prod_reactor_rollback_preserves_pre_anchor_state() -> Result<()> {
     let rollback_events = cluster
         .wait_for_state_event_matching(
             |e| matches!(e, StateEvent::RollbackExecuted { .. }),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
     let rollback_event = rollback_events
@@ -1388,14 +1388,14 @@ async fn prod_reactor_all_nodes_reach_same_checkpoint() -> Result<()> {
     cluster
         .wait_for_decision_matching(
             |d| !d.value.is_block() && !d.value.batch_txids().is_empty(),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
     cluster.mine_and_send(&[]);
     cluster
         .wait_for_decision_matching(
             |d| d.value.is_block() && d.value.block_height() == 1,
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1404,7 +1404,7 @@ async fn prod_reactor_all_nodes_reach_same_checkpoint() -> Result<()> {
         .wait_for_n_state_events_matching(
             num_nodes,
             |e| matches!(e, StateEvent::BlockProcessed { height: 1, .. }),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
     let checkpoints: Vec<_> = events
@@ -1439,14 +1439,14 @@ async fn prod_reactor_all_nodes_reach_same_checkpoint() -> Result<()> {
                     && d.value.block_height() == 1
                     && !d.value.batch_txids().is_empty()
             },
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
     cluster.mine_and_send(&[]);
     cluster
         .wait_for_decision_matching(
             |d| d.value.is_block() && d.value.block_height() == 2,
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1455,7 +1455,7 @@ async fn prod_reactor_all_nodes_reach_same_checkpoint() -> Result<()> {
         .wait_for_n_state_events_matching(
             num_nodes,
             |e| matches!(e, StateEvent::BlockProcessed { height: 2, .. }),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
     let checkpoints: Vec<_> = events
@@ -1500,7 +1500,7 @@ async fn prod_reactor_multi_batch_same_anchor() -> Result<()> {
     cluster
         .wait_for_decision_matching(
             |d| !d.value.is_block() && !d.value.batch_txids().is_empty(),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1508,7 +1508,7 @@ async fn prod_reactor_multi_batch_same_anchor() -> Result<()> {
     cluster
         .wait_for_state_event_matching(
             |e| matches!(e, StateEvent::BatchApplied { .. }),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1519,7 +1519,7 @@ async fn prod_reactor_multi_batch_same_anchor() -> Result<()> {
     let decisions = cluster
         .wait_for_decision_matching(
             |d| !d.value.is_block() && d.value.batch_txids().len() >= 3,
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1538,7 +1538,7 @@ async fn prod_reactor_multi_batch_same_anchor() -> Result<()> {
     cluster
         .wait_for_state_event_matching(
             |e| matches!(e, StateEvent::BatchApplied { .. }),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1547,13 +1547,13 @@ async fn prod_reactor_multi_batch_same_anchor() -> Result<()> {
     cluster
         .wait_for_decision_matching(
             |d| d.value.is_block() && d.value.block_height() == 1,
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
     cluster
         .wait_for_state_event_matching(
             |e| matches!(e, StateEvent::BlockProcessed { height: 1, .. }),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1578,7 +1578,7 @@ async fn prod_reactor_bitcoin_rollback_reverts_state() -> Result<()> {
         cluster
             .wait_for_decision_matching(
                 |d| d.value.is_block() && d.value.block_height() == expected_height,
-                Duration::from_secs(30),
+                Duration::from_secs(60),
             )
             .await;
         cluster
@@ -1586,7 +1586,7 @@ async fn prod_reactor_bitcoin_rollback_reverts_state() -> Result<()> {
                 |e| {
                     matches!(e, StateEvent::BlockProcessed { height, .. } if *height == expected_height)
                 },
-                Duration::from_secs(30),
+                Duration::from_secs(60),
             )
             .await;
     }
@@ -1602,19 +1602,19 @@ async fn prod_reactor_bitcoin_rollback_reverts_state() -> Result<()> {
     cluster
         .wait_for_state_event_matching(
             |e| matches!(e, StateEvent::RollbackExecuted { to_anchor: 1, .. }),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
     cluster
         .wait_for_decision_matching(
             |d| d.value.is_block() && d.value.block_height() == 2,
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
     cluster
         .wait_for_state_event_matching(
             |e| matches!(e, StateEvent::BlockProcessed { height: 2, .. }),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1623,13 +1623,13 @@ async fn prod_reactor_bitcoin_rollback_reverts_state() -> Result<()> {
     cluster
         .wait_for_decision_matching(
             |d| d.value.is_block() && d.value.block_height() == 3,
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
     cluster
         .wait_for_state_event_matching(
             |e| matches!(e, StateEvent::BlockProcessed { height: 3, .. }),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1655,7 +1655,7 @@ async fn prod_reactor_late_joiner_syncs_to_same_checkpoint() -> Result<()> {
     cluster
         .wait_for_decision_matching(
             |d| !d.value.is_block() && !d.value.batch_txids().is_empty(),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1664,7 +1664,7 @@ async fn prod_reactor_late_joiner_syncs_to_same_checkpoint() -> Result<()> {
     cluster
         .wait_for_decision_matching(
             |d| d.value.is_block() && d.value.block_height() == 1,
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 
@@ -1673,7 +1673,7 @@ async fn prod_reactor_late_joiner_syncs_to_same_checkpoint() -> Result<()> {
         .wait_for_n_state_events_matching(
             3,
             |e| matches!(e, StateEvent::BlockProcessed { height: 1, .. }),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
     let pre_join_checkpoints: Vec<_> = pre_join_events

--- a/core/indexer/tests/reactor_cluster.rs
+++ b/core/indexer/tests/reactor_cluster.rs
@@ -476,6 +476,10 @@ impl ReactorCluster {
                 genesis,
                 engine_output.address,
             );
+            state.timeouts = malachitebft_core_types::LinearTimeouts {
+                propose: Duration::from_millis(500),
+                ..Default::default()
+            };
             state.observation = Some(ObservationChannels {
                 decided_tx: dtx,
                 finality_tx: ftx,
@@ -560,7 +564,6 @@ impl ReactorCluster {
         for _ in 0..self.node_count {
             let _ = self.ready_rx.recv().await;
         }
-        tokio::time::sleep(Duration::from_secs(2)).await;
     }
 
     fn send_block_event(&self, event: BlockEvent) {

--- a/core/indexer/tests/reactor_cluster.rs
+++ b/core/indexer/tests/reactor_cluster.rs
@@ -437,8 +437,8 @@ impl ReactorCluster {
         join_set.spawn(async move {
             let (executor, runtime) =
                 LiteExecutor::new(mock_btc, pubkey, &genesis_vals, engine, component_cache)
-                .await
-                .expect("LiteExecutor setup failed");
+                    .await
+                    .expect("LiteExecutor setup failed");
 
             let engine_config = EngineConfig {
                 private_key,
@@ -659,7 +659,7 @@ impl Drop for ReactorCluster {
 async fn prod_reactor_validators_agree_on_values() -> Result<()> {
     indexer::logging::setup();
 
-    let mut cluster = ReactorCluster::start(4).await?;
+    let mut cluster = ReactorCluster::start(3).await?;
     cluster.wait_for_ready().await;
 
     // Insert mempool txs
@@ -679,10 +679,10 @@ async fn prod_reactor_validators_agree_on_values() -> Result<()> {
         "Expected a batch decision with txids"
     );
 
-    // Wait for all 4 nodes to produce BatchApplied
+    // Wait for all nodes to produce BatchApplied
     let state_events = cluster
         .wait_for_n_state_events_matching(
-            4,
+            cluster.node_count,
             |e| matches!(e, StateEvent::BatchApplied { .. }),
             Duration::from_secs(10),
         )
@@ -693,8 +693,9 @@ async fn prod_reactor_validators_agree_on_values() -> Result<()> {
         .filter(|e| matches!(e, StateEvent::BatchApplied { .. }))
         .count();
     assert!(
-        batch_applied_count >= 4,
-        "Expected at least 4 BatchApplied events (one per node), got {batch_applied_count}"
+        batch_applied_count >= cluster.node_count,
+        "Expected at least {} BatchApplied events (one per node), got {batch_applied_count}",
+        cluster.node_count
     );
 
     cluster.shutdown().await;
@@ -709,7 +710,7 @@ async fn prod_reactor_validators_agree_on_values() -> Result<()> {
 async fn prod_reactor_block_updates_anchor() -> Result<()> {
     indexer::logging::setup();
 
-    let mut cluster = ReactorCluster::start(4).await?;
+    let mut cluster = ReactorCluster::start(3).await?;
     cluster.wait_for_ready().await;
 
     // Insert mempool txs and wait for a batch at anchor 0
@@ -783,7 +784,7 @@ async fn prod_reactor_block_updates_anchor() -> Result<()> {
 async fn prod_reactor_happy_path_finalization() -> Result<()> {
     indexer::logging::setup();
 
-    let mut cluster = ReactorCluster::start(4).await?;
+    let mut cluster = ReactorCluster::start(3).await?;
     cluster.wait_for_ready().await;
 
     // Insert mempool txs and wait for batch at anchor 0
@@ -836,7 +837,7 @@ async fn prod_reactor_happy_path_finalization() -> Result<()> {
 async fn prod_reactor_missing_tx_invalidation() -> Result<()> {
     indexer::logging::setup();
 
-    let mut cluster = ReactorCluster::start(4).await?;
+    let mut cluster = ReactorCluster::start(3).await?;
     cluster.wait_for_ready().await;
 
     // Mine block 1 (empty) so the batch anchors at height 1 (not 0)
@@ -865,7 +866,7 @@ async fn prod_reactor_missing_tx_invalidation() -> Result<()> {
     // Wait for all 3 txids to be batched (may be across multiple batches)
     cluster
         .wait_for_n_state_events_matching(
-            4, // 4 nodes each emit BatchApplied
+            cluster.node_count,
             |e| matches!(e, StateEvent::BatchApplied { txid_count, .. } if *txid_count > 0),
             Duration::from_secs(30),
         )
@@ -937,7 +938,7 @@ async fn prod_reactor_missing_tx_invalidation() -> Result<()> {
 async fn prod_reactor_cascade_invalidation() -> Result<()> {
     indexer::logging::setup();
 
-    let mut cluster = ReactorCluster::start(4).await?;
+    let mut cluster = ReactorCluster::start(3).await?;
     cluster.wait_for_ready().await;
 
     // Batch 1 at anchor 0
@@ -1021,7 +1022,7 @@ async fn prod_reactor_cascade_invalidation() -> Result<()> {
 async fn prod_reactor_cross_block_cascade_invalidation() -> Result<()> {
     indexer::logging::setup();
 
-    let mut cluster = ReactorCluster::start(4).await?;
+    let mut cluster = ReactorCluster::start(3).await?;
     cluster.wait_for_ready().await;
 
     // Batch at anchor 0 — will be confirmed and finalized
@@ -1139,7 +1140,7 @@ async fn prod_reactor_cross_block_cascade_invalidation() -> Result<()> {
 async fn prod_reactor_batch_before_unbatched_at_same_anchor() -> Result<()> {
     indexer::logging::setup();
 
-    let mut cluster = ReactorCluster::start(4).await?;
+    let mut cluster = ReactorCluster::start(3).await?;
     cluster.wait_for_ready().await;
 
     // Generate mempool txs
@@ -1216,7 +1217,7 @@ async fn prod_reactor_batch_before_unbatched_at_same_anchor() -> Result<()> {
 async fn prod_reactor_rollback_preserves_pre_anchor_state() -> Result<()> {
     indexer::logging::setup();
 
-    let mut cluster = ReactorCluster::start(4).await?;
+    let mut cluster = ReactorCluster::start(3).await?;
     cluster.wait_for_ready().await;
 
     // Batch at anchor 0: 2 txs
@@ -1333,7 +1334,7 @@ async fn prod_reactor_rollback_preserves_pre_anchor_state() -> Result<()> {
 async fn prod_reactor_all_nodes_reach_same_checkpoint() -> Result<()> {
     indexer::logging::setup();
 
-    let num_nodes = 4;
+    let num_nodes = 3;
     let mut cluster = ReactorCluster::start(num_nodes).await?;
     cluster.wait_for_ready().await;
 
@@ -1446,7 +1447,7 @@ async fn prod_reactor_all_nodes_reach_same_checkpoint() -> Result<()> {
 async fn prod_reactor_multi_batch_same_anchor() -> Result<()> {
     indexer::logging::setup();
 
-    let mut cluster = ReactorCluster::start(4).await?;
+    let mut cluster = ReactorCluster::start(3).await?;
     cluster.wait_for_ready().await;
 
     // First batch of mempool txs
@@ -1525,7 +1526,7 @@ async fn prod_reactor_multi_batch_same_anchor() -> Result<()> {
 async fn prod_reactor_bitcoin_rollback_reverts_state() -> Result<()> {
     indexer::logging::setup();
 
-    let mut cluster = ReactorCluster::start(4).await?;
+    let mut cluster = ReactorCluster::start(3).await?;
     cluster.wait_for_ready().await;
 
     // Mine and decide blocks 1-3

--- a/core/indexer/tests/regtester_cluster.rs
+++ b/core/indexer/tests/regtester_cluster.rs
@@ -20,7 +20,7 @@ fn active_count_is(expected: u64) -> impl Fn(&str) -> bool {
 /// Basic cluster test: start 4 validators, publish a counter contract,
 /// increment via consensus batch, verify all nodes agree on state.
 #[tokio::test]
-#[serial_test::serial]
+
 async fn cluster_counter_increment_via_consensus() -> Result<()> {
     let _ = tracing_subscriber::fmt().with_env_filter("info").try_init();
 
@@ -127,7 +127,7 @@ async fn cluster_counter_increment_via_consensus() -> Result<()> {
 /// Multi-batch convergence: submit 5 increments in rapid succession,
 /// verify all nodes converge, then mine to confirm and verify dedup.
 #[tokio::test]
-#[serial_test::serial]
+
 async fn cluster_multi_batch_convergence() -> Result<()> {
     let _ = tracing_subscriber::fmt().with_env_filter("info").try_init();
 
@@ -239,7 +239,7 @@ async fn cluster_multi_batch_convergence() -> Result<()> {
 /// Node restart: kill a node, continue batching on remaining 3,
 /// restart the killed node, verify it catches up via sync.
 #[tokio::test]
-#[serial_test::serial]
+
 async fn cluster_node_restart_recovery() -> Result<()> {
     let _ = tracing_subscriber::fmt().with_env_filter("info").try_init();
 
@@ -363,7 +363,7 @@ async fn cluster_node_restart_recovery() -> Result<()> {
 /// Late joiner: start 3 of 4 validators, process batches + blocks,
 /// then start the 4th from scratch. It syncs via Malachite and converges.
 #[tokio::test]
-#[serial_test::serial]
+
 async fn cluster_late_joiner_sync() -> Result<()> {
     let _ = tracing_subscriber::fmt().with_env_filter("info").try_init();
 
@@ -469,7 +469,7 @@ async fn cluster_late_joiner_sync() -> Result<()> {
 /// Validator lifecycle: register a new validator, activate it, verify participation,
 /// then unstake and verify deactivation.
 #[tokio::test]
-#[serial_test::serial]
+
 async fn cluster_validator_lifecycle() -> Result<()> {
     let _ = tracing_subscriber::fmt().with_env_filter("info").try_init();
 

--- a/core/macros/src/regtest.rs
+++ b/core/macros/src/regtest.rs
@@ -162,7 +162,6 @@ pub fn generate(config: Config) -> TokenStream {
         #(#mod_decls)*
 
         #[tokio::test(flavor = "multi_thread")]
-        #[serial_test::serial]
         async fn regtest_all() -> Result<()> {
             let _ = tracing_subscriber::fmt().with_env_filter("info").try_init();
 

--- a/core/testlib/src/lib.rs
+++ b/core/testlib/src/lib.rs
@@ -16,7 +16,6 @@ use indexer::{
 };
 pub use indexer::{logging::setup as logging, testlib_exports::*};
 use indexer_types::{Inst, Insts, TransactionRow};
-pub use serial_test;
 use std::{cell::Cell, collections::HashMap, path::PathBuf, rc::Rc};
 use tempfile::TempDir;
 pub use tokio;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches regtest harness plumbing (dynamic `bitcoind` ports/ZMQ wiring and mining behavior) and rewrites several integration tests for parallel execution, which could introduce new flakes if assumptions about timing/ports are wrong.
> 
> **Overview**
> Speeds up and stabilizes regtest/cluster test execution by **removing `serial_test` usage**, reducing cluster sizes (generally 4→3), and lengthening decision/finality timeouts to tolerate parallelism.
> 
> Refactors the regtest harness to start `bitcoind` with **allocated RPC/ZMQ/P2P ports** and plumbs the derived `bitcoin_rpc_url`/`--zmq-address` through `run_kontor` and `RegTesterCluster` (removing the old `cluster_mode` switch and always mining only when required for `Publish`).
> 
> Adds shared BLS test helpers in `test_utils::bls_test`, moves unit-level rogue-key coverage into a new `bls_attack_unit.rs`, and simplifies some compose/multi-PSBT tests by relying on fixed regtest fee assumptions instead of querying mempool fee state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3185935dbcc95356194784ae071f4661586159e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->