### PR TITLE
Fix /api/blocks/latest

### DIFF
--- a/core/indexer/src/main.rs
+++ b/core/indexer/src/main.rs
@@ -67,12 +67,14 @@ async fn main() -> Result<()> {
         .await?,
     );
 
-    let conn = &*reader.connection().await?;
-    let recent_blocks = select_recent_blocks(conn, 50).await?;
-    let known_hashes: Vec<_> = recent_blocks
-        .iter()
-        .map(|b| (b.height as u64, b.hash))
-        .collect();
+    let known_hashes = {
+        let conn = reader.connection().await?;
+        let recent_blocks = select_recent_blocks(&*conn, 50).await?;
+        recent_blocks
+            .iter()
+            .map(|b| (b.height as u64, b.hash))
+            .collect::<Vec<_>>()
+    };
 
     let (bitcoin_event_rx, follower_handle) = bitcoin_follower::run(
         bitcoin.clone(),

--- a/core/indexer/src/main.rs
+++ b/core/indexer/src/main.rs
@@ -69,7 +69,7 @@ async fn main() -> Result<()> {
 
     let known_hashes = {
         let conn = reader.connection().await?;
-        let recent_blocks = select_recent_blocks(&*conn, 50).await?;
+        let recent_blocks = select_recent_blocks(&conn, 50).await?;
         recent_blocks
             .iter()
             .map(|b| (b.height as u64, b.hash))


### PR DESCRIPTION
Release reader pool connection after loading recent block hashes (avoid holding deadpool guard for main’s lifetime)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes connection/borrow lifetime when fetching recent block hashes, reducing the chance of exhausting the reader pool without altering query logic.
> 
> **Overview**
> Fixes startup logic to **avoid holding a `deadpool` reader connection for the lifetime of `main`** when building `known_hashes`.
> 
> `core/indexer/src/main.rs` now scopes the `reader.connection()` guard to just the `select_recent_blocks` call, ensuring the connection is released before starting the bitcoin follower/API work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d957656c841ddf10faef766fd9d38556ab3cc81e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->