### PR TITLE
Consensus cleanup cont.

### DIFF
--- a/core/indexer/src/api/handlers.rs
+++ b/core/indexer/src/api/handlers.rs
@@ -201,8 +201,10 @@ pub async fn post_transaction_hex_inspect(
 ) -> Result<Vec<OpWithResult>> {
     let btx = encode::deserialize_hex::<bitcoin::Transaction>(&hex)
         .map_err(|e| HttpError::BadRequest(e.to_string()))?;
+    let tx = crate::block::filter_map((0, btx))
+        .ok_or_else(|| HttpError::BadRequest("Not a valid Kontor transaction".to_string()))?;
     let conn = env.reader.connection().await?;
-    Ok(inspect(&conn, btx).await?.into())
+    Ok(inspect(&conn, &tx).await?.into())
 }
 
 pub async fn get_transaction_inspect(
@@ -212,8 +214,10 @@ pub async fn get_transaction_inspect(
     let txid = bitcoin::Txid::from_str(&txid)
         .map_err(|e| HttpError::BadRequest(format!("Invalid txid: {}", e)))?;
     let btx = env.bitcoin.get_raw_transaction(&txid).await?;
+    let tx = crate::block::filter_map((0, btx))
+        .ok_or_else(|| HttpError::BadRequest("Not a valid Kontor transaction".to_string()))?;
     let conn = env.reader.connection().await?;
-    Ok(inspect(&conn, btx).await?.into())
+    Ok(inspect(&conn, &tx).await?.into())
 }
 
 pub async fn post_simulate(
@@ -222,8 +226,10 @@ pub async fn post_simulate(
 ) -> Result<Vec<OpWithResult>> {
     let btx = encode::deserialize_hex::<bitcoin::Transaction>(&hex)
         .map_err(|e| HttpError::BadRequest(e.to_string()))?;
+    let tx = crate::block::filter_map((0, btx))
+        .ok_or_else(|| HttpError::BadRequest("Not a valid Kontor transaction".to_string()))?;
     let (ret_tx, ret_rx) = tokio::sync::oneshot::channel();
-    env.simulate_tx.send((btx, ret_tx)).await?;
+    env.simulate_tx.send((tx, ret_tx)).await?;
     Ok(ret_rx
         .await?
         .map_err(|e| HttpError::BadRequest(e.to_string()))?

--- a/core/indexer/src/block.rs
+++ b/core/indexer/src/block.rs
@@ -124,27 +124,25 @@ pub fn filter_map((tx_index, tx): (usize, bitcoin::Transaction)) -> Option<Trans
 
 pub async fn inspect(
     conn: &Connection,
-    btx: bitcoin::Transaction,
+    tx: &indexer_types::Transaction,
 ) -> anyhow::Result<Vec<OpWithResult>> {
     let mut ops = Vec::new();
-    if let Some(tx) = filter_map((0, btx)) {
-        for input in &tx.inputs {
-            if !input.insts.is_aggregate() {
-                let metadata = OpMetadata {
-                    previous_output: input.previous_output,
-                    input_index: input.input_index,
-                    signer: input.witness_signer.clone(),
-                };
-                for (op_index, inst) in input.insts.ops.iter().enumerate() {
-                    let op = op_from_inst(inst.clone(), metadata.clone());
-                    let id = OpResultId::builder()
-                        .txid(tx.txid.to_string())
-                        .input_index(input.input_index)
-                        .op_index(op_index as i64)
-                        .build();
-                    let result = get_op_result(conn, &id).await?.map(Into::into);
-                    ops.push(OpWithResult { op, result });
-                }
+    for input in &tx.inputs {
+        if !input.insts.is_aggregate() {
+            let metadata = OpMetadata {
+                previous_output: input.previous_output,
+                input_index: input.input_index,
+                signer: input.witness_signer.clone(),
+            };
+            for (op_index, inst) in input.insts.ops.iter().enumerate() {
+                let op = op_from_inst(inst.clone(), metadata.clone());
+                let id = OpResultId::builder()
+                    .txid(tx.txid.to_string())
+                    .input_index(input.input_index)
+                    .op_index(op_index as i64)
+                    .build();
+                let result = get_op_result(conn, &id).await?.map(Into::into);
+                ops.push(OpWithResult { op, result });
             }
         }
     }

--- a/core/indexer/src/database/queries.rs
+++ b/core/indexer/src/database/queries.rs
@@ -522,6 +522,16 @@ pub async fn insert_batch(
     Ok(())
 }
 
+pub async fn delete_batches_above_anchor(conn: &Connection, max_anchor: i64) -> Result<u64, Error> {
+    let rows = conn
+        .execute(
+            "DELETE FROM batches WHERE anchor_height > ?",
+            params![max_anchor],
+        )
+        .await?;
+    Ok(rows)
+}
+
 pub async fn select_latest_consensus_height(conn: &Connection) -> Result<Option<i64>, Error> {
     Ok(conn
         .query("SELECT MAX(consensus_height) FROM batches", ())

--- a/core/indexer/src/database/queries.rs
+++ b/core/indexer/src/database/queries.rs
@@ -34,7 +34,7 @@ pub enum Error {
 
 pub async fn insert_block(conn: &Connection, block: BlockRow) -> Result<i64, Error> {
     conn.execute(
-        "INSERT OR REPLACE INTO blocks (height, hash, relevant) VALUES (?, ?, ?)",
+        "INSERT INTO blocks (height, hash, relevant) VALUES (?, ?, ?)",
         (block.height, block.hash.to_string(), block.relevant),
     )
     .await?;
@@ -373,7 +373,7 @@ pub async fn contract_has_state(conn: &Connection, contract_id: i64) -> Result<b
 pub async fn insert_contract(conn: &Connection, row: ContractRow) -> Result<i64, Error> {
     conn.execute(
         r#"
-            INSERT OR REPLACE INTO contracts (
+            INSERT INTO contracts (
                 name,
                 height,
                 tx_index,
@@ -1029,7 +1029,7 @@ pub async fn insert_contract_result(
 ) -> Result<i64, Error> {
     conn.execute(
         r#"
-            INSERT OR REPLACE INTO contract_results (
+            INSERT INTO contract_results (
                 contract_id,
                 size,
                 func,

--- a/core/indexer/src/logging.rs
+++ b/core/indexer/src/logging.rs
@@ -21,21 +21,24 @@ pub fn setup() {
         let log_format = Config::try_parse()
             .map(|c| c.log_format)
             .unwrap_or(Format::Plain);
+        let base_filter = filter::Targets::new()
+            .with_default(LevelFilter::INFO)
+            .with_target("arc_malachitebft", Level::WARN);
+
         match log_format {
             Format::JSON => {
                 let layer = tracing_stackdriver::layer();
-                let filter = filter::Targets::new()
-                    .with_default(LevelFilter::INFO)
-                    .with_target("kontor", Level::INFO)
-                    .with_target("indexer", Level::INFO);
-                let subscriber = Registry::default().with(layer).with(filter);
+                let subscriber = Registry::default().with(layer).with(base_filter);
                 let _ = tracing::subscriber::set_global_default(subscriber);
             }
             Format::Plain => {
-                let filter = EnvFilter::builder()
+                let env_filter = EnvFilter::builder()
                     .with_default_directive(LevelFilter::INFO.into())
-                    .from_env_lossy();
-                let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
+                    .from_env_lossy()
+                    .add_directive("arc_malachitebft=warn".parse().unwrap());
+                let _ = tracing_subscriber::fmt()
+                    .with_env_filter(env_filter)
+                    .try_init();
             }
         }
     });

--- a/core/indexer/src/reactor/consensus.rs
+++ b/core/indexer/src/reactor/consensus.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use bitcoin::Txid;
 use bitcoin::hashes::Hash;
 use tokio::sync::mpsc;
@@ -30,8 +30,8 @@ use crate::consensus::{
 use crate::database::queries::{
     get_checkpoint_latest, get_transaction_by_txid, insert_batch, insert_transaction,
     insert_unconfirmed_batch_tx, select_batch, select_batches_from_anchor, select_block_at_height,
-    select_block_latest, select_existing_txids, select_min_batch_height,
-    select_unconfirmed_batch_txs,
+    select_block_latest, select_existing_txids, select_latest_consensus_height,
+    select_min_batch_height, select_unconfirmed_batch_txs,
 };
 
 use super::executor::Executor;
@@ -92,19 +92,27 @@ pub struct ObservationChannels {
 }
 
 impl ConsensusState {
-    pub fn new(
+    pub async fn new(
         conn: libsql::Connection,
         signing_provider: Ed25519Provider,
         genesis: Genesis,
         address: Address,
     ) -> Self {
         let current_validator_set = genesis.validator_set;
+        let current_height = match select_latest_consensus_height(&conn).await {
+            Ok(Some(h)) => {
+                let resume = Height::new(h as u64 + 1);
+                info!(%resume, "Resuming consensus from DB");
+                resume
+            }
+            _ => Height::new(1),
+        };
         Self {
             conn,
             signing_provider,
             address,
             mempool: std::collections::HashMap::new(),
-            current_height: Height::new(1),
+            current_height,
             current_round: Round::new(0),
             undecided: BTreeMap::new(),
             unfinalized_batches: Vec::new(),
@@ -135,7 +143,13 @@ impl ConsensusState {
     fn stream_id(&self) -> StreamId {
         let mut bytes = Vec::with_capacity(12);
         bytes.extend_from_slice(&self.current_height.as_u64().to_be_bytes());
-        bytes.extend_from_slice(&self.current_round.as_u32().unwrap().to_be_bytes());
+        bytes.extend_from_slice(
+            &self
+                .current_round
+                .as_u32()
+                .expect("stream_id called during active round, current_round must not be Nil")
+                .to_be_bytes(),
+        );
         StreamId::new(bytes.into())
     }
 
@@ -510,7 +524,7 @@ impl ConsensusState {
         consensus_height: Height,
         certificate: &[u8],
         batch_txs: &[bitcoin::Transaction],
-    ) {
+    ) -> Result<()> {
         let parsed_txs: Vec<indexer_types::Transaction> = batch_txs
             .iter()
             .filter_map(|btx| executor.parse_transaction(btx))
@@ -530,7 +544,7 @@ impl ConsensusState {
             .storage
             .savepoint()
             .await
-            .expect("Failed to begin batch transaction");
+            .context("Failed to begin batch transaction")?;
 
         insert_batch(
             &self.conn,
@@ -541,23 +555,24 @@ impl ConsensusState {
             false,
         )
         .await
-        .expect("Failed to insert batch");
+        .context("Failed to insert batch")?;
 
         // Store raw txs for replay/sync recovery
         for raw_tx in batch_txs {
             let txid = raw_tx.compute_txid();
             let serialized = bitcoin::consensus::serialize(raw_tx);
-            let _ = insert_unconfirmed_batch_tx(
+            insert_unconfirmed_batch_tx(
                 &self.conn,
                 &txid.to_string(),
                 consensus_height.as_u64() as i64,
                 &serialized,
             )
-            .await;
+            .await
+            .context("Failed to insert unconfirmed batch tx")?;
         }
 
         for t in &parsed_txs {
-            let tx_id = match insert_transaction(
+            let tx_id = insert_transaction(
                 &self.conn,
                 indexer_types::TransactionRow::builder()
                     .height(anchor_height as i64)
@@ -566,13 +581,7 @@ impl ConsensusState {
                     .build(),
             )
             .await
-            {
-                Ok(id) => id,
-                Err(e) => {
-                    error!("insert_transaction error: {e}");
-                    continue;
-                }
-            };
+            .context("Failed to insert transaction")?;
 
             executor
                 .execute_transaction(runtime, anchor_height as i64, tx_id, t)
@@ -583,7 +592,7 @@ impl ConsensusState {
             .storage
             .commit()
             .await
-            .expect("Failed to commit batch transaction");
+            .context("Failed to commit batch transaction")?;
 
         self.emit_state_event(StateEvent::BatchApplied {
             consensus_height,
@@ -597,6 +606,8 @@ impl ConsensusState {
             consensus_height = %consensus_height,
             "Batch processing complete"
         );
+
+        Ok(())
     }
 }
 
@@ -728,7 +739,8 @@ pub async fn handle_consensus_msg(
                     channels
                         .network
                         .send(NetworkMsg::PublishProposalPart(stream_msg))
-                        .await?;
+                        .await
+                        .context("Failed to send proposal part to network")?;
                 }
                 if reply.send(proposal).is_err() {
                     error!("Failed to send GetValue reply");
@@ -748,7 +760,8 @@ pub async fn handle_consensus_msg(
                     channels
                         .network
                         .send(NetworkMsg::PublishProposalPart(stream_msg))
-                        .await?;
+                        .await
+                        .context("Failed to send proposal part to network")?;
                 }
                 if reply.send(proposal).is_err() {
                     error!("Failed to send GetValue reply");
@@ -912,7 +925,7 @@ pub async fn handle_consensus_msg(
                                 "Skipping stale batch — anchor below current height"
                             );
                             // Still record the batch for sync protocol
-                            let _ = insert_batch(
+                            insert_batch(
                                 &state.conn,
                                 certificate.height.as_u64() as i64,
                                 *anchor_height as i64,
@@ -920,7 +933,8 @@ pub async fn handle_consensus_msg(
                                 &cert_bytes,
                                 false,
                             )
-                            .await;
+                            .await
+                            .context("Failed to record stale batch for sync")?;
                         } else if *anchor_height > last_height {
                             info!(
                                 anchor = anchor_height,
@@ -944,7 +958,8 @@ pub async fn handle_consensus_msg(
                                     &cert_bytes,
                                     &full_txs,
                                 )
-                                .await;
+                                .await
+                                .context("process_decided_batch failed in Finalized handler")?;
                             result = ConsensusResult::BatchProcessed {
                                 txids: full_txs
                                     .iter()
@@ -1090,7 +1105,8 @@ pub async fn handle_consensus_msg(
                     channels
                         .network
                         .send(NetworkMsg::PublishProposalPart(stream_msg))
-                        .await?;
+                        .await
+                        .context("Failed to send proposal part to network")?;
                 }
             }
         }

--- a/core/indexer/src/reactor/consensus.rs
+++ b/core/indexer/src/reactor/consensus.rs
@@ -227,10 +227,8 @@ impl ConsensusState {
             return Some(Value::new_block(height, block.hash));
         }
 
-        // Collect candidate txids from the mempool
+        // Pre-filter already-processed txids from mempool to avoid unnecessary validation
         let mempool_txids: Vec<Txid> = self.mempool.keys().copied().collect();
-
-        // Filter out txids already in the system (batched or confirmed)
         let txid_strs: Vec<String> = mempool_txids.iter().map(|t| t.to_string()).collect();
         let existing = select_existing_txids(&self.conn, &txid_strs)
             .await
@@ -240,6 +238,7 @@ impl ConsensusState {
             .filter(|t| !existing.contains(&t.to_string()))
             .collect();
 
+        // Per-tx validation
         let mut txs = Vec::new();
         for tx in self.mempool.values() {
             let txid = tx.compute_txid();
@@ -250,9 +249,24 @@ impl ConsensusState {
                 txs.push(tx.clone());
             }
         }
-        // Don't propose empty batches — avoids flooding consensus heights
-        // and allows lagging nodes to catch up via sync
         if txs.is_empty() {
+            return None;
+        }
+
+        // Batch-level validation (already-processed check will pass since we pre-filtered)
+        let candidate_txids: Vec<String> =
+            txs.iter().map(|tx| tx.compute_txid().to_string()).collect();
+        if let Some(reason) = validate_batch(
+            self,
+            last_height,
+            last_hash,
+            &candidate_txids,
+            last_height,
+            last_hash,
+        )
+        .await
+        {
+            info!("Not proposing batch: {reason}");
             return None;
         }
 
@@ -611,6 +625,39 @@ impl ConsensusState {
     }
 }
 
+/// Validate batch-level rules. Returns a rejection reason if any rule fails.
+async fn validate_batch(
+    state: &ConsensusState,
+    anchor_height: u64,
+    anchor_hash: bitcoin::BlockHash,
+    txids: &[String],
+    last_height: u64,
+    last_hash: bitcoin::BlockHash,
+) -> Option<&'static str> {
+    if txids.is_empty() {
+        return Some("batch is empty");
+    }
+    if !state.pending_blocks.is_empty() {
+        return Some("block is pending");
+    }
+    if state.deferred_decisions.iter().any(|d| d.value.is_block()) {
+        return Some("deferred block decision waiting");
+    }
+    if anchor_height != last_height {
+        return Some("anchor height mismatch");
+    }
+    if anchor_hash != last_hash {
+        return Some("anchor hash mismatch");
+    }
+    let existing = select_existing_txids(&state.conn, txids)
+        .await
+        .unwrap_or_default();
+    if !existing.is_empty() {
+        return Some("contains already-processed transactions");
+    }
+    None
+}
+
 /// Validate a received proposal and accept it. Returns None if validation fails.
 async fn validate_and_accept_proposal(
     state: &mut ConsensusState,
@@ -618,6 +665,8 @@ async fn validate_and_accept_proposal(
     data: &ProposalData,
     height: Height,
     round: Round,
+    last_height: u64,
+    last_hash: bitcoin::BlockHash,
 ) -> Option<ProposedValue<Ctx>> {
     let value = match data {
         ProposalData::Block { height, hash } => {
@@ -645,9 +694,21 @@ async fn validate_and_accept_proposal(
             anchor_hash,
             transactions,
         } => {
-            // Reject batch proposals when a block is pending
-            if !state.pending_blocks.is_empty() {
-                warn!("Rejecting batch proposal: block is pending");
+            let txid_strs: Vec<String> = transactions
+                .iter()
+                .map(|tx| tx.compute_txid().to_string())
+                .collect();
+            if let Some(reason) = validate_batch(
+                state,
+                *anchor_height,
+                *anchor_hash,
+                &txid_strs,
+                last_height,
+                last_hash,
+            )
+            .await
+            {
+                warn!("Rejecting batch proposal: {reason}");
                 return None;
             }
             for tx in transactions {
@@ -787,50 +848,16 @@ pub async fn handle_consensus_msg(
                 match &part.content {
                     StreamContent::Data(ProposalPart::Data(data)) => {
                         if !state.undecided.contains_key(&(height, round)) {
-                            match data {
-                                ProposalData::Block { .. } => {
-                                    validate_and_accept_proposal(
-                                        state, executor, data, height, round,
-                                    )
-                                    .await
-                                }
-                                ProposalData::Batch {
-                                    anchor_height,
-                                    anchor_hash,
-                                    ..
-                                } => {
-                                    if *anchor_height != last_height {
-                                        warn!(
-                                            anchor = anchor_height,
-                                            tip = last_height,
-                                            "Rejecting proposal with stale or unknown anchor height"
-                                        );
-                                        None
-                                    } else if let Some(local_hash) =
-                                        state.block_hash_at_height(*anchor_height).await
-                                    {
-                                        if local_hash != *anchor_hash {
-                                            warn!(
-                                                anchor = anchor_height,
-                                                proposed = %anchor_hash,
-                                                local = %local_hash,
-                                                "Rejecting proposal with mismatched anchor hash"
-                                            );
-                                            None
-                                        } else {
-                                            validate_and_accept_proposal(
-                                                state, executor, data, height, round,
-                                            )
-                                            .await
-                                        }
-                                    } else {
-                                        validate_and_accept_proposal(
-                                            state, executor, data, height, round,
-                                        )
-                                        .await
-                                    }
-                                }
-                            }
+                            validate_and_accept_proposal(
+                                state,
+                                executor,
+                                data,
+                                height,
+                                round,
+                                last_height,
+                                last_hash,
+                            )
+                            .await
                         } else {
                             None
                         }

--- a/core/indexer/src/reactor/consensus.rs
+++ b/core/indexer/src/reactor/consensus.rs
@@ -28,10 +28,10 @@ use crate::consensus::{
     ValidatorSet, Value,
 };
 use crate::database::queries::{
-    get_checkpoint_latest, get_transaction_by_txid, insert_batch, insert_transaction,
-    insert_unconfirmed_batch_tx, select_batch, select_batches_from_anchor, select_block_at_height,
-    select_block_latest, select_existing_txids, select_latest_consensus_height,
-    select_min_batch_height, select_unconfirmed_batch_txs,
+    delete_batches_above_anchor, get_checkpoint_latest, get_transaction_by_txid, insert_batch,
+    insert_transaction, insert_unconfirmed_batch_tx, select_batch, select_batches_from_anchor,
+    select_block_at_height, select_block_latest, select_existing_txids,
+    select_latest_consensus_height, select_min_batch_height, select_unconfirmed_batch_txs,
 };
 
 use super::executor::Executor;
@@ -97,8 +97,25 @@ impl ConsensusState {
         signing_provider: Ed25519Provider,
         genesis: Genesis,
         address: Address,
+        last_block_height: u64,
     ) -> Self {
         let current_validator_set = genesis.validator_set;
+
+        // Delete batch decisions that reference anchor heights above what we've
+        // actually processed. These were committed to the batches table but never
+        // executed before the node shut down.
+        if let Ok(deleted) =
+            delete_batches_above_anchor(&conn, last_block_height as i64).await
+        {
+            if deleted > 0 {
+                info!(
+                    deleted,
+                    last_block_height,
+                    "Deleted unprocessed batches above last block height"
+                );
+            }
+        }
+
         let current_height = match select_latest_consensus_height(&conn).await {
             Ok(Some(h)) => {
                 let resume = Height::new(h as u64 + 1);

--- a/core/indexer/src/reactor/consensus.rs
+++ b/core/indexer/src/reactor/consensus.rs
@@ -104,16 +104,13 @@ impl ConsensusState {
         // Delete batch decisions that reference anchor heights above what we've
         // actually processed. These were committed to the batches table but never
         // executed before the node shut down.
-        if let Ok(deleted) =
-            delete_batches_above_anchor(&conn, last_block_height as i64).await
+        if let Ok(deleted) = delete_batches_above_anchor(&conn, last_block_height as i64).await
+            && deleted > 0
         {
-            if deleted > 0 {
-                info!(
-                    deleted,
-                    last_block_height,
-                    "Deleted unprocessed batches above last block height"
-                );
-            }
+            info!(
+                deleted,
+                last_block_height, "Deleted unprocessed batches above last block height"
+            );
         }
 
         let current_height = match select_latest_consensus_height(&conn).await {
@@ -556,6 +553,14 @@ impl ConsensusState {
         certificate: &[u8],
         batch_txs: &[bitcoin::Transaction],
     ) -> Result<()> {
+        info!(
+            %consensus_height,
+            anchor_height,
+            %anchor_hash,
+            num_txs = batch_txs.len(),
+            "Processing decided batch"
+        );
+
         let parsed_txs: Vec<indexer_types::Transaction> = batch_txs
             .iter()
             .filter_map(|btx| executor.parse_transaction(btx))
@@ -1020,6 +1025,12 @@ pub async fn handle_consensus_msg(
                         // Remove from pending if present (may not be if we received
                         // the decision via sync before the block arrived from poller)
                         if let Some(block) = state.pending_blocks.remove(height) {
+                            info!(
+                                block_height = height,
+                                block_hash = %hash,
+                                consensus_height = %certificate.height,
+                                "Block decided and ready to process"
+                            );
                             result = ConsensusResult::Block(
                                 block,
                                 DeferredDecision {
@@ -1040,6 +1051,7 @@ pub async fn handle_consensus_msg(
                                 info!(
                                     block_height = height,
                                     block_hash = %hash,
+                                    consensus_height = %certificate.height,
                                     "Block decided but not yet received — deferring"
                                 );
                                 state.deferred_decisions.push_back(DeferredDecision {

--- a/core/indexer/src/reactor/engine.rs
+++ b/core/indexer/src/reactor/engine.rs
@@ -12,7 +12,7 @@ use malachitebft_app_channel::{
 
 use crate::consensus::codec::ProtobufCodec;
 use crate::consensus::signing::{Ed25519Provider, PrivateKey};
-use crate::consensus::{Address, Ctx, Genesis};
+use crate::consensus::{Address, Ctx};
 
 pub struct EngineConfig {
     pub private_key: PrivateKey,
@@ -55,7 +55,7 @@ pub struct EngineOutput {
 }
 
 /// Start the Malachite consensus engine and return channels + metadata.
-pub async fn start(config: EngineConfig, _genesis: &Genesis) -> Result<EngineOutput> {
+pub async fn start(config: EngineConfig) -> Result<EngineOutput> {
     let public_key = config.private_key.public_key();
     let address = Address::from_public_key(&public_key);
     let keypair = Keypair::ed25519_from_bytes(config.private_key.inner().to_bytes())?;

--- a/core/indexer/src/reactor/engine.rs
+++ b/core/indexer/src/reactor/engine.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use malachitebft_app_channel::app::config::*;
 use malachitebft_app_channel::app::net::Multiaddr;
@@ -58,14 +58,19 @@ pub struct EngineOutput {
 pub async fn start(config: EngineConfig) -> Result<EngineOutput> {
     let public_key = config.private_key.public_key();
     let address = Address::from_public_key(&public_key);
-    let keypair = Keypair::ed25519_from_bytes(config.private_key.inner().to_bytes())?;
+    let keypair = Keypair::ed25519_from_bytes(config.private_key.inner().to_bytes())
+        .context("Failed to create Ed25519 keypair from private key")?;
 
-    let listen_addr: Multiaddr = config.listen_addr.parse()?;
+    let listen_addr: Multiaddr = config
+        .listen_addr
+        .parse()
+        .context("Failed to parse consensus listen address")?;
     let persistent_peers: Vec<Multiaddr> = config
         .persistent_peers
         .iter()
         .map(|s| s.parse())
-        .collect::<Result<_, _>>()?;
+        .collect::<Result<_, _>>()
+        .context("Failed to parse persistent peer address")?;
 
     let node_config = MalachiteNodeConfig {
         moniker: format!("kontor-{}", &address.to_string()[..8]),
@@ -83,7 +88,8 @@ pub async fn start(config: EngineConfig) -> Result<EngineOutput> {
     };
 
     let ctx = Ctx::new();
-    std::fs::create_dir_all(&config.data_dir)?;
+    std::fs::create_dir_all(&config.data_dir)
+        .context("Failed to create consensus data directory")?;
     let wal_path = config.data_dir.join("consensus.wal");
 
     let identity = NetworkIdentity::new(

--- a/core/indexer/src/reactor/executor.rs
+++ b/core/indexer/src/reactor/executor.rs
@@ -316,7 +316,11 @@ async fn process_aggregate_input(
         }
     };
 
-    let agg = input.insts.aggregate.as_ref().unwrap();
+    let agg = input
+        .insts
+        .aggregate
+        .as_ref()
+        .expect("aggregate must be present after successful verification");
 
     for (op_index, (inst, &signer_id)) in input
         .insts

--- a/core/indexer/src/reactor/executor.rs
+++ b/core/indexer/src/reactor/executor.rs
@@ -91,9 +91,9 @@ type ParsedTxCache = moka::sync::Cache<Txid, indexer_types::Transaction>;
 /// Production executor: handles transaction validation, resolution, and op execution.
 /// Does NOT own the Runtime — the reactor owns it and passes &mut Runtime when needed.
 pub struct RuntimeExecutor {
-    pub bitcoin_client: Option<Client>,
-    pub replay_tx: Option<tokio::sync::mpsc::Sender<u64>>,
-    pub cancel_token: CancellationToken,
+    bitcoin_client: Option<Client>,
+    replay_tx: Option<tokio::sync::mpsc::Sender<u64>>,
+    cancel_token: CancellationToken,
     parsed_tx_cache: ParsedTxCache,
 }
 

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -669,7 +669,7 @@ impl<E: Executor> Reactor<E> {
 
                                 // Rollback to before the invalid anchor so all state at the
                                 // anchor height (including invalid tx effects) is wiped cleanly.
-                                self.rollback(rollback_anchor - 1)
+                                self.rollback(rollback_anchor.saturating_sub(1))
                                     .await
                                     .context("rollback failed during finality rollback")?;
 

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -412,7 +412,13 @@ impl<E: Executor> Reactor<E> {
                 warn!("Event receiver dropped, cannot send Processed event");
             }
         }
-        info!("Block processed (unbatched_count={unbatched_count})");
+        info!(
+            height,
+            %hash,
+            unbatched_count,
+            tx_count = block.transactions.len(),
+            "Block processed"
+        );
 
         Ok(())
     }
@@ -436,11 +442,21 @@ impl<E: Executor> Reactor<E> {
                         handle.state.pending_blocks.remove(&bh)
                     };
                     if let Some(block) = block {
+                        info!(
+                            block_height = bh,
+                            consensus_height = %decision.consensus_height,
+                            "Draining deferred block decision"
+                        );
                         self.handle_block_with_decision(block, &decision)
                             .await
                             .context("handle_block_with_decision failed in deferred drain")?;
                     } else {
                         // Block data not yet available — put back and stop
+                        info!(
+                            block_height = bh,
+                            consensus_height = %decision.consensus_height,
+                            "Deferred block still waiting for data"
+                        );
                         let handle = self.consensus_handle.as_mut().unwrap();
                         handle.state.deferred_decisions.push_front(decision);
                         break;
@@ -453,6 +469,12 @@ impl<E: Executor> Reactor<E> {
                     ..
                 } => {
                     if *anchor_height <= self.last_height {
+                        info!(
+                            anchor_height = *anchor_height,
+                            consensus_height = %decision.consensus_height,
+                            num_txs = txs.len(),
+                            "Draining deferred batch decision"
+                        );
                         let anchor_height = *anchor_height;
                         let anchor_hash = *anchor_hash;
                         let mut resolved_txs = Vec::with_capacity(txs.len());
@@ -500,7 +522,12 @@ impl<E: Executor> Reactor<E> {
                             }
                         }
                     } else {
-                        // Anchor not yet processed — put back and stop
+                        info!(
+                            anchor_height = *anchor_height,
+                            last_height = self.last_height,
+                            consensus_height = %decision.consensus_height,
+                            "Deferred batch still waiting for anchor"
+                        );
                         let handle = self.consensus_handle.as_mut().unwrap();
                         handle.state.deferred_decisions.push_front(decision);
                         break;
@@ -526,6 +553,12 @@ impl<E: Executor> Reactor<E> {
                 info!("Block {}/{} {}", block.height, target_height, block.hash);
 
                 if let Some(handle) = self.consensus_handle.as_mut() {
+                    info!(
+                        block_height = block.height,
+                        %block.hash,
+                        pending_count = handle.state.pending_blocks.len() + 1,
+                        "Adding block to pending_blocks"
+                    );
                     handle
                         .state
                         .pending_blocks
@@ -706,6 +739,7 @@ impl<E: Executor> Reactor<E> {
         Ok(())
     }
 
+    #[tracing::instrument(skip_all, fields(node = %self.runtime.node_label))]
     pub async fn run(&mut self) -> Result<()> {
         self.run_event_loop().await
     }
@@ -925,9 +959,15 @@ pub fn run(
                 });
                 let consensus_handle = if let Some(engine_cfg) = engine_config {
                     Some(
-                        start_consensus(engine_cfg, &mut runtime, observation_channels, timeouts, last_height)
-                            .await
-                            .context("start_consensus failed")?,
+                        start_consensus(
+                            engine_cfg,
+                            &mut runtime,
+                            observation_channels,
+                            timeouts,
+                            last_height,
+                        )
+                        .await
+                        .context("start_consensus failed")?,
                     )
                 } else {
                     None

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -54,7 +54,7 @@ use crate::block;
 use executor::Executor;
 
 pub type Simulation = (
-    bitcoin::Transaction,
+    indexer_types::Transaction,
     oneshot::Sender<Result<Vec<OpWithResult>>>,
 );
 
@@ -233,9 +233,8 @@ impl<E: Executor> Reactor<E> {
     }
 
     /// Simulate a transaction: execute in a temporary block, inspect results, then rollback.
-    async fn simulate(&mut self, btx: bitcoin::Transaction) -> Result<Vec<OpWithResult>> {
-        let tx =
-            block::filter_map((0, btx.clone())).ok_or(anyhow::anyhow!("Invalid transaction"))?;
+    /// The caller (API layer) must validate with block::filter_map before sending.
+    async fn simulate(&mut self, tx: indexer_types::Transaction) -> Result<Vec<OpWithResult>> {
         self.runtime
             .storage
             .savepoint()
@@ -256,7 +255,7 @@ impl<E: Executor> Reactor<E> {
         self.execute_block(&block)
             .await
             .context("execute_block failed during simulation")?;
-        let result = block::inspect(&self.db_conn(), btx).await;
+        let result = block::inspect(&self.db_conn(), &block.transactions[0]).await;
         self.runtime
             .storage
             .rollback()
@@ -692,8 +691,8 @@ impl<E: Executor> Reactor<E> {
                     tokio::task::yield_now().await;
                 }
                 option_event = simulate_rx => {
-                    if let Some((btx, ret_tx)) = option_event {
-                        let result = self.simulate(btx).await;
+                    if let Some((tx, ret_tx)) = option_event {
+                        let result = self.simulate(tx).await;
                         let err_msg = result.as_ref().err().map(|e| format!("{e:#}"));
                         let _ = ret_tx.send(result);
                         if let Some(msg) = err_msg {

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -780,7 +780,7 @@ pub async fn start_consensus(
 ) -> Result<ConsensusHandle> {
     let genesis = build_genesis_from_staking(runtime).await?;
 
-    let engine_output = engine::start(engine_config, &genesis).await?;
+    let engine_output = engine::start(engine_config).await?;
     info!(address = %engine_output.address, "Consensus engine started");
 
     let validator_index = genesis
@@ -1180,8 +1180,8 @@ mod tests {
     /// Proves that rolling back a block containing a BLS key registration
     /// reverts the registry contract_state created by that registration.
     ///
-    /// This exercises the full pipeline: reactor → block_handler →
-    /// process_transaction → WASM runtime (registry contract execution) →
+    /// This exercises the full pipeline: reactor → execute_block →
+    /// executor.execute_transaction → WASM runtime (registry contract execution) →
     /// contract_state write, then rollback → CASCADE delete → state gone.
     #[tokio::test]
     async fn test_reactor_rollback_reverts_registration_state() -> Result<()> {

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -851,6 +851,7 @@ pub async fn start_consensus(
     runtime: &mut Runtime,
     observation_channels: Option<consensus::ObservationChannels>,
     timeouts: Option<LinearTimeouts>,
+    last_block_height: u64,
 ) -> Result<ConsensusHandle> {
     let genesis = build_genesis_from_staking(runtime)
         .await
@@ -872,6 +873,7 @@ pub async fn start_consensus(
         engine_output.signing_provider,
         genesis,
         engine_output.address,
+        last_block_height,
     )
     .await;
     state.observation = observation_channels;
@@ -923,7 +925,7 @@ pub fn run(
                 });
                 let consensus_handle = if let Some(engine_cfg) = engine_config {
                     Some(
-                        start_consensus(engine_cfg, &mut runtime, observation_channels, timeouts)
+                        start_consensus(engine_cfg, &mut runtime, observation_channels, timeouts, last_height)
                             .await
                             .context("start_consensus failed")?,
                     )

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -8,7 +8,7 @@ pub mod mock_bitcoin;
 mod reactor_cluster_tests;
 pub mod types;
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use futures_util::future::pending;
 use indexer_types::{Block, BlockRow, Event, OpWithResult};
 use tokio::{
@@ -138,7 +138,9 @@ impl<E: Executor> Reactor<E> {
     }
 
     async fn rollback(&mut self, height: u64) -> Result<()> {
-        rollback_to_height(&self.db_conn(), height).await?;
+        rollback_to_height(&self.db_conn(), height)
+            .await
+            .context("rollback_to_height failed")?;
         if let Err(e) = self
             .runtime
             .file_ledger
@@ -168,17 +170,19 @@ impl<E: Executor> Reactor<E> {
             handle.state.current_validator_set = vs;
         }
 
-        if let Some(tx) = &self.event_tx {
-            let _ = tx.send(Event::Rolledback { height }).await;
+        if let Some(tx) = &self.event_tx
+            && tx.send(Event::Rolledback { height }).await.is_err()
+        {
+            warn!("Event receiver dropped, cannot send Rolledback event");
         }
 
         Ok(())
     }
 
-    /// Execute a block: insert block row, process transactions, run lifecycle.
+    /// Execute a block: insert block row, process transactions.
     /// Returns the number of unbatched (non-deduped) transactions.
-    async fn execute_block(&mut self, block: &Block) -> usize {
-        let _ = insert_block(
+    async fn execute_block(&mut self, block: &Block) -> Result<usize> {
+        insert_block(
             &self.db_conn(),
             BlockRow::builder()
                 .height(block.height as i64)
@@ -186,24 +190,29 @@ impl<E: Executor> Reactor<E> {
                 .relevant(!block.transactions.is_empty())
                 .build(),
         )
-        .await;
+        .await
+        .context("insert_block failed")?;
 
         let mut unbatched_count = 0;
         for (i, t) in block.transactions.iter().enumerate() {
-            if let Ok(Some(_)) = get_transaction_by_txid(&self.db_conn(), &t.txid.to_string()).await
+            if get_transaction_by_txid(&self.db_conn(), &t.txid.to_string())
+                .await
+                .context("get_transaction_by_txid failed")?
+                .is_some()
             {
-                let _ = confirm_transaction(
+                confirm_transaction(
                     &self.db_conn(),
                     &t.txid.to_string(),
                     block.height as i64,
                     i as i64,
                 )
-                .await;
+                .await
+                .context("confirm_transaction failed")?;
                 continue;
             }
 
             unbatched_count += 1;
-            let tx_id = match insert_transaction(
+            let tx_id = insert_transaction(
                 &self.db_conn(),
                 indexer_types::TransactionRow::builder()
                     .height(block.height as i64)
@@ -213,28 +222,28 @@ impl<E: Executor> Reactor<E> {
                     .build(),
             )
             .await
-            {
-                Ok(id) => id,
-                Err(e) => {
-                    error!("insert_transaction error: {e}");
-                    continue;
-                }
-            };
+            .context("insert_transaction failed")?;
 
             self.executor
                 .execute_transaction(&mut self.runtime, block.height as i64, tx_id, t)
                 .await;
         }
 
-        unbatched_count
+        Ok(unbatched_count)
     }
 
     /// Simulate a transaction: execute in a temporary block, inspect results, then rollback.
     async fn simulate(&mut self, btx: bitcoin::Transaction) -> Result<Vec<OpWithResult>> {
         let tx =
             block::filter_map((0, btx.clone())).ok_or(anyhow::anyhow!("Invalid transaction"))?;
-        self.runtime.storage.savepoint().await?;
-        let block_row = select_block_latest(&self.db_conn()).await?;
+        self.runtime
+            .storage
+            .savepoint()
+            .await
+            .context("Failed to begin simulation savepoint")?;
+        let block_row = select_block_latest(&self.db_conn())
+            .await
+            .context("Failed to query latest block for simulation")?;
         let height = block_row.as_ref().map_or(1, |row| row.height as u64 + 1);
         let block = Block {
             height,
@@ -244,18 +253,20 @@ impl<E: Executor> Reactor<E> {
                 .map_or(new_mock_block_hash(0), |row| row.hash),
             transactions: vec![tx],
         };
-        self.execute_block(&block).await;
+        self.execute_block(&block)
+            .await
+            .context("execute_block failed during simulation")?;
         let result = block::inspect(&self.db_conn(), btx).await;
         self.runtime
             .storage
             .rollback()
             .await
-            .expect("Failed to rollback simulation");
+            .context("Failed to rollback simulation")?;
         result
     }
 
     /// Run block lifecycle operations: challenge expiry/generation and epoch transitions.
-    async fn run_block_lifecycle(&mut self, block: &Block) {
+    async fn run_block_lifecycle(&mut self, block: &Block) -> Result<()> {
         let core_signer = Signer::Core(Box::new(Signer::Nobody));
         let block_hash: Vec<u8> = block.hash.to_byte_array().to_vec();
         self.runtime
@@ -263,7 +274,7 @@ impl<E: Executor> Reactor<E> {
             .await;
         expire_challenges(&mut self.runtime, &core_signer, block.height)
             .await
-            .expect("Failed to expire challenges");
+            .context("Failed to expire challenges")?;
         let challenges = generate_challenges_for_block(
             &mut self.runtime,
             &core_signer,
@@ -271,7 +282,7 @@ impl<E: Executor> Reactor<E> {
             block_hash,
         )
         .await
-        .expect("Failed to generate challenges");
+        .context("Failed to generate challenges")?;
         if !challenges.is_empty() {
             info!(
                 "Generated {} challenges at block height {}",
@@ -282,14 +293,16 @@ impl<E: Executor> Reactor<E> {
 
         let change = process_pending_validators(&mut self.runtime, &core_signer, block.height)
             .await
-            .expect("Failed to call process_pending_validators")
-            .expect("process_pending_validators returned error");
+            .context("Failed to call process_pending_validators")?
+            .map_err(|e| anyhow::anyhow!("{e:?}"))
+            .context("process_pending_validators returned error")?;
         if change.activated > 0 || change.deactivated > 0 {
             info!(
                 "Validator set change at height {}: {} activated, {} deactivated",
                 block.height, change.activated, change.deactivated
             );
         }
+        Ok(())
     }
 
     async fn handle_block_with_decision(
@@ -297,7 +310,7 @@ impl<E: Executor> Reactor<E> {
         block: Block,
         decision: &consensus::DeferredDecision,
     ) -> Result<()> {
-        if let Err(e) = insert_batch(
+        insert_batch(
             &self.db_conn(),
             decision.consensus_height.as_u64() as i64,
             block.height as i64,
@@ -306,10 +319,11 @@ impl<E: Executor> Reactor<E> {
             true,
         )
         .await
-        {
-            error!("insert_batch (block) error: {e}");
-        }
-        self.handle_block(block).await
+        .context("Failed to insert block batch decision")?;
+        self.handle_block(block)
+            .await
+            .context("handle_block failed after block batch decision")?;
+        Ok(())
     }
 
     async fn handle_block(&mut self, block: Block) -> Result<()> {
@@ -347,16 +361,21 @@ impl<E: Executor> Reactor<E> {
             .storage
             .savepoint()
             .await
-            .expect("Failed to begin block transaction");
+            .context("Failed to begin block transaction")?;
 
-        let unbatched_count = self.execute_block(&block).await;
-        self.run_block_lifecycle(&block).await;
+        let unbatched_count = self
+            .execute_block(&block)
+            .await
+            .context("execute_block failed")?;
+        self.run_block_lifecycle(&block)
+            .await
+            .context("run_block_lifecycle failed")?;
 
         self.runtime
             .storage
             .commit()
             .await
-            .expect("Failed to commit block transaction");
+            .context("Failed to commit block transaction")?;
 
         if let Some(handle) = &mut self.consensus_handle {
             // Update cached validator set after block execution
@@ -383,12 +402,16 @@ impl<E: Executor> Reactor<E> {
                 .iter()
                 .map(|t| t.txid.to_string())
                 .collect();
-            let _ = tx
+            if tx
                 .send(Event::Processed {
                     block: (&block).into(),
                     txids,
                 })
-                .await;
+                .await
+                .is_err()
+            {
+                warn!("Event receiver dropped, cannot send Processed event");
+            }
         }
         info!("Block processed (unbatched_count={unbatched_count})");
 
@@ -414,7 +437,9 @@ impl<E: Executor> Reactor<E> {
                         handle.state.pending_blocks.remove(&bh)
                     };
                     if let Some(block) = block {
-                        self.handle_block_with_decision(block, &decision).await?;
+                        self.handle_block_with_decision(block, &decision)
+                            .await
+                            .context("handle_block_with_decision failed in deferred drain")?;
                     } else {
                         // Block data not yet available — put back and stop
                         let handle = self.consensus_handle.as_mut().unwrap();
@@ -464,13 +489,16 @@ impl<E: Executor> Reactor<E> {
                                 &decision.certificate,
                                 &resolved_txs,
                             )
-                            .await;
+                            .await
+                            .context("process_decided_batch failed in deferred drain")?;
                         if let Some(tx) = &self.event_tx {
                             let txids: Vec<String> = resolved_txs
                                 .iter()
                                 .map(|tx| tx.compute_txid().to_string())
                                 .collect();
-                            let _ = tx.send(Event::BatchProcessed { txids }).await;
+                            if tx.send(Event::BatchProcessed { txids }).await.is_err() {
+                                warn!("Event receiver dropped, cannot send BatchProcessed event");
+                            }
                         }
                     } else {
                         // Anchor not yet processed — put back and stop
@@ -503,14 +531,20 @@ impl<E: Executor> Reactor<E> {
                         .state
                         .pending_blocks
                         .insert(block.height, block.clone());
-                    self.drain_deferred_decisions().await?;
+                    self.drain_deferred_decisions()
+                        .await
+                        .context("drain_deferred_decisions failed after block insert")?;
                 } else {
-                    self.handle_block(block).await?;
+                    self.handle_block(block)
+                        .await
+                        .context("handle_block failed (no consensus)")?;
                 }
             }
             BlockEvent::Rollback { to_height } => {
                 info!(to_height, "Bitcoin rollback — truncating state");
-                self.rollback(to_height).await?;
+                self.rollback(to_height)
+                    .await
+                    .context("rollback failed during Bitcoin reorg")?;
                 if let Some(handle) = &mut self.consensus_handle {
                     handle.state.clear_on_rollback();
                     let checkpoint = handle.state.get_checkpoint().await;
@@ -531,7 +565,9 @@ impl<E: Executor> Reactor<E> {
         loop {
             // Drain pending block events before entering select
             while let Ok(event) = self.block_rx.try_recv() {
-                self.process_block_event(event).await?;
+                self.process_block_event(event)
+                    .await
+                    .context("process_block_event failed (try_recv drain)")?;
             }
 
             let simulate_rx = async {
@@ -556,7 +592,9 @@ impl<E: Executor> Reactor<E> {
                     break;
                 }
                 Some(event) = self.block_rx.recv() => {
-                    self.process_block_event(event).await?;
+                    self.process_block_event(event)
+                        .await
+                        .context("process_block_event failed")?;
                 }
                 Some(event) = self.mempool_rx.recv() => {
                     if let Some(handle) = self.consensus_handle.as_mut() {
@@ -594,19 +632,26 @@ impl<E: Executor> Reactor<E> {
                         validator_index,
                         self.last_height,
                         self.last_hash.unwrap_or(BlockHash::all_zeros()),
-                    ).await?;
+                    ).await
+                    .context("handle_consensus_msg failed")?;
                     if let consensus::ConsensusResult::BatchProcessed { txids } = &consensus_result
                         && let Some(tx) = &self.event_tx
-                    {
-                        let _ = tx
+                        && tx
                             .send(Event::BatchProcessed {
                                 txids: txids.clone(),
                             })
-                            .await;
+                            .await
+                            .is_err()
+                    {
+                        warn!("Event receiver dropped, cannot send BatchProcessed event");
                     }
                     if let consensus::ConsensusResult::Block(block, decision) = consensus_result {
-                        self.handle_block_with_decision(block, &decision).await?;
-                        self.drain_deferred_decisions().await?;
+                        self.handle_block_with_decision(block, &decision)
+                            .await
+                            .context("handle_block_with_decision failed after consensus block")?;
+                        self.drain_deferred_decisions()
+                            .await
+                            .context("drain_deferred_decisions failed after consensus block")?;
                         // Check finality after block execution — batch txids may now be confirmed
                         let handle = self.consensus_handle.as_mut().unwrap();
                         if handle.state
@@ -624,7 +669,9 @@ impl<E: Executor> Reactor<E> {
 
                                 // Rollback to before the invalid anchor so all state at the
                                 // anchor height (including invalid tx effects) is wiped cleanly.
-                                self.rollback(rollback_anchor - 1).await?;
+                                self.rollback(rollback_anchor - 1)
+                                    .await
+                                    .context("rollback failed during finality rollback")?;
 
                                 // Emit rollback event
                                 let handle = self.consensus_handle.as_mut().unwrap();
@@ -636,7 +683,9 @@ impl<E: Executor> Reactor<E> {
                                 });
 
                                 // Process deferred decisions using already-cached blocks
-                                self.drain_deferred_decisions().await?;
+                                self.drain_deferred_decisions()
+                                    .await
+                                    .context("drain_deferred_decisions failed after finality rollback")?;
                             }
                     }
                     // Yield to allow other channels (block_rx, mempool_rx) to be polled
@@ -644,9 +693,12 @@ impl<E: Executor> Reactor<E> {
                 }
                 option_event = simulate_rx => {
                     if let Some((btx, ret_tx)) = option_event {
-                        let _ = ret_tx.send(
-                            self.simulate(btx).await
-                        );
+                        let result = self.simulate(btx).await;
+                        let err_msg = result.as_ref().err().map(|e| format!("{e:#}"));
+                        let _ = ret_tx.send(result);
+                        if let Some(msg) = err_msg {
+                            bail!("simulation failed: {msg}");
+                        }
                     }
                 }
 
@@ -662,7 +714,9 @@ impl<E: Executor> Reactor<E> {
 
 /// Query the staking contract and build a ValidatorSet from the active validators.
 async fn build_validator_set(runtime: &mut Runtime) -> Result<ValidatorSet> {
-    let active_set = get_active_set(runtime).await?;
+    let active_set = get_active_set(runtime)
+        .await
+        .context("Failed to query active validator set from staking contract")?;
 
     let validators: Vec<Validator> = active_set
         .into_iter()
@@ -677,7 +731,16 @@ async fn build_validator_set(runtime: &mut Runtime) -> Result<ValidatorSet> {
             let mut key_bytes = [0u8; 32];
             key_bytes.copy_from_slice(&v.ed25519_pubkey);
             let public_key = PublicKey::from_bytes(key_bytes);
-            let voting_power = stake_to_voting_power(v.stake);
+            let voting_power = match stake_to_voting_power(v.stake) {
+                Ok(vp) => vp,
+                Err(e) => {
+                    warn!(
+                        xonly = v.x_only_pubkey,
+                        "Skipping validator with invalid stake: {e}"
+                    );
+                    return None;
+                }
+            };
             Some(Validator::new(public_key, voting_power))
         })
         .collect();
@@ -685,13 +748,16 @@ async fn build_validator_set(runtime: &mut Runtime) -> Result<ValidatorSet> {
     Ok(ValidatorSet::new(validators))
 }
 
-fn stake_to_voting_power(stake: Decimal) -> VotingPower {
+fn stake_to_voting_power(stake: Decimal) -> Result<VotingPower> {
     let s = decimal_to_string(stake);
-    s.split('.')
+    let integer_part = s
+        .split('.')
         .next()
-        .expect("decimal string should have integer part")
+        .context("decimal string missing integer part")?;
+    let power = integer_part
         .parse::<u64>()
-        .expect("stake should be a valid u64")
+        .context("stake integer part is not a valid u64")?;
+    Ok(power)
 }
 
 /// Build a Genesis from the staking contract's active validator set.
@@ -709,7 +775,10 @@ pub async fn create_runtime_executor(
     genesis_validators: &[crate::runtime::GenesisValidator],
 ) -> Result<(executor::RuntimeExecutor, Runtime, u64, Option<BlockHash>)> {
     let conn = writer.connection();
-    let (last_height, last_hash) = match select_block_latest(&conn).await? {
+    let (last_height, last_hash) = match select_block_latest(&conn)
+        .await
+        .context("Failed to query latest block during startup")?
+    {
         Some(block) => {
             let block_height = block.height as u64;
             if block_height < starting_block_height - 1 {
@@ -738,7 +807,7 @@ pub async fn create_runtime_executor(
     // ensure 0 (native) block exists
     if select_block_at_height(&conn, 0)
         .await
-        .expect("Failed to select block at height 0")
+        .context("Failed to check for native block at height 0")?
         .is_none()
     {
         info!("Creating native block");
@@ -750,15 +819,21 @@ pub async fn create_runtime_executor(
                 .relevant(true)
                 .build(),
         )
-        .await?;
+        .await
+        .context("Failed to insert native block at height 0")?;
     }
     let storage = Storage::builder()
         .height(0)
         .conn(writer.connection())
         .build();
 
-    let mut runtime = Runtime::new(ComponentCache::new(), storage).await?;
-    runtime.publish_native_contracts(genesis_validators).await?;
+    let mut runtime = Runtime::new(ComponentCache::new(), storage)
+        .await
+        .context("Failed to initialize runtime")?;
+    runtime
+        .publish_native_contracts(genesis_validators)
+        .await
+        .context("Failed to publish native contracts")?;
 
     let mut exec = executor::RuntimeExecutor::new(cancel_token);
 
@@ -778,9 +853,13 @@ pub async fn start_consensus(
     observation_channels: Option<consensus::ObservationChannels>,
     timeouts: Option<LinearTimeouts>,
 ) -> Result<ConsensusHandle> {
-    let genesis = build_genesis_from_staking(runtime).await?;
+    let genesis = build_genesis_from_staking(runtime)
+        .await
+        .context("Failed to build genesis from staking contract")?;
 
-    let engine_output = engine::start(engine_config).await?;
+    let engine_output = engine::start(engine_config)
+        .await
+        .context("Failed to start Malachite consensus engine")?;
     info!(address = %engine_output.address, "Consensus engine started");
 
     let validator_index = genesis
@@ -794,7 +873,8 @@ pub async fn start_consensus(
         engine_output.signing_provider,
         genesis,
         engine_output.address,
-    );
+    )
+    .await;
     state.observation = observation_channels;
     if let Some(t) = timeouts {
         state.timeouts = t;
@@ -835,7 +915,8 @@ pub fn run(
                     replay_tx,
                     &genesis_validators,
                 )
-                .await?;
+                .await
+                .context("create_runtime_executor failed")?;
 
                 let timeouts = consensus_propose_timeout_ms.map(|ms| LinearTimeouts {
                     propose: std::time::Duration::from_millis(ms),
@@ -844,7 +925,8 @@ pub fn run(
                 let consensus_handle = if let Some(engine_cfg) = engine_config {
                     Some(
                         start_consensus(engine_cfg, &mut runtime, observation_channels, timeouts)
-                            .await?,
+                            .await
+                            .context("start_consensus failed")?,
                     )
                 } else {
                     None
@@ -869,7 +951,7 @@ pub fn run(
             .await;
 
             if let Err(e) = result {
-                error!("Reactor error: {}, exiting", e);
+                error!("Reactor error: {e:#}, exiting");
                 cancel_token.cancel();
             }
 

--- a/core/indexer/src/reactor/reactor_cluster_tests.rs
+++ b/core/indexer/src/reactor/reactor_cluster_tests.rs
@@ -313,7 +313,7 @@ impl ReactorCluster {
             let _ = rtx.send(i).await;
 
             if let Err(e) = reactor.run().await {
-                tracing::error!(node = i, %e, "Reactor error");
+                tracing::error!(node = i, e = format!("{e:#}"), "Reactor error");
             }
         });
     }

--- a/core/indexer/src/reactor/reactor_cluster_tests.rs
+++ b/core/indexer/src/reactor/reactor_cluster_tests.rs
@@ -256,7 +256,7 @@ impl ReactorCluster {
 
             let conn = runtime.get_storage_conn();
 
-            let engine_output = match engine::start(engine_config, &genesis).await {
+            let engine_output = match engine::start(engine_config).await {
                 Ok(o) => o,
                 Err(e) => {
                     tracing::error!(node = i, %e, "Failed to start engine");

--- a/core/indexer/src/reactor/reactor_cluster_tests.rs
+++ b/core/indexer/src/reactor/reactor_cluster_tests.rs
@@ -277,7 +277,8 @@ impl ReactorCluster {
                 engine_output.signing_provider,
                 genesis,
                 engine_output.address,
-            );
+            )
+            .await;
             state.timeouts = LinearTimeouts {
                 propose: Duration::from_millis(500),
                 ..Default::default()

--- a/core/indexer/src/reactor/reactor_cluster_tests.rs
+++ b/core/indexer/src/reactor/reactor_cluster_tests.rs
@@ -277,6 +277,7 @@ impl ReactorCluster {
                 engine_output.signing_provider,
                 genesis,
                 engine_output.address,
+                0,
             )
             .await;
             state.timeouts = LinearTimeouts {

--- a/core/indexer/tests/contracts/shared_cluster.rs
+++ b/core/indexer/tests/contracts/shared_cluster.rs
@@ -21,8 +21,17 @@ pub async fn get() -> Arc<RegTesterCluster> {
 
 #[ctor::dtor]
 fn cleanup() {
-    if let Ok(mut guard) = CLUSTER.lock() {
-        drop(guard.take());
+    let cluster = {
+        let mut guard = match CLUSTER.lock() {
+            Ok(g) => g,
+            Err(e) => e.into_inner(),
+        };
+        guard.take().and_then(|arc| Arc::try_unwrap(arc).ok())
+    };
+    if let Some(cluster) = cluster
+        && let Ok(rt) = tokio::runtime::Runtime::new()
+    {
+        let _ = rt.block_on(cluster.teardown());
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches consensus execution/resumption and database write semantics (removing `INSERT OR REPLACE`), which can affect recovery behavior and persistence correctness. Changes are mostly defensive (validation, cleanup, better error propagation) but could surface as startup or batch-processing regressions if assumptions differ from existing data.
> 
> **Overview**
> Consensus/reactor startup is made more robust: `ConsensusState::new` becomes async, prunes `batches` entries whose `anchor_height` is above the last processed block, and resumes `current_height` from the latest persisted `consensus_height`.
> 
> Batch proposing/acceptance is tightened with a shared `validate_batch` path (anchor height/hash checks, pending/deferred block gating, and DB dedupe of already-processed txids), plus mempool pre-filtering to avoid redundant validation.
> 
> Execution paths are refactored to pass parsed `indexer_types::Transaction` (API `inspect`/`simulate`, `block::inspect`, simulation channel type), and many previously ignored errors are now propagated with `anyhow::Context` and improved logging/telemetry.
> 
> Database writes for `blocks`, `contracts`, and `contract_results` switch from `INSERT OR REPLACE` to `INSERT`, and a new query `delete_batches_above_anchor` is added; logging defaults also quiet `arc_malachitebft`, and test cluster teardown is made more reliable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ecaef03bf670262a8ef901d4c2fd83f406c42c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->