### PR TITLE
Consensus cleanup cont.

### DIFF
--- a/core/indexer/src/reactor/consensus.rs
+++ b/core/indexer/src/reactor/consensus.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use bitcoin::Txid;
 use bitcoin::hashes::Hash;
 use tokio::sync::mpsc;
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 
 use malachitebft_app_channel::app::streaming::{StreamContent, StreamId, StreamMessage};
 use malachitebft_app_channel::app::types::codec::Codec;
@@ -394,16 +394,12 @@ impl ConsensusState {
         }
     }
 
-    async fn get_decided_from_anchor(&self, from_anchor: u64) -> Vec<DeferredDecision> {
-        let batches = match select_batches_from_anchor(&self.conn, from_anchor as i64).await {
-            Ok(r) => r,
-            Err(e) => {
-                error!(%e, "Failed to query batches from anchor");
-                return Vec::new();
-            }
-        };
+    async fn get_decided_from_anchor(&self, from_anchor: u64) -> Result<Vec<DeferredDecision>> {
+        let batches = select_batches_from_anchor(&self.conn, from_anchor as i64)
+            .await
+            .context("Failed to query batches from anchor")?;
 
-        batches
+        Ok(batches
             .into_iter()
             .filter_map(|b| {
                 let anchor_hash = b.anchor_hash.parse::<bitcoin::BlockHash>().ok()?;
@@ -419,7 +415,7 @@ impl ConsensusState {
                     certificate: b.certificate,
                 })
             })
-            .collect()
+            .collect())
     }
 
     pub async fn block_hash_at_height(&self, height: u64) -> Option<bitcoin::BlockHash> {
@@ -497,8 +493,11 @@ impl ConsensusState {
         executor: &mut impl Executor,
         from_anchor: u64,
         excluded_txids: HashSet<Txid>,
-    ) {
-        let replay_batches = self.get_decided_from_anchor(from_anchor).await;
+    ) -> Result<()> {
+        let replay_batches = self
+            .get_decided_from_anchor(from_anchor)
+            .await
+            .context("Failed to load replay batches for rollback")?;
 
         info!(
             from_anchor,
@@ -519,7 +518,11 @@ impl ConsensusState {
         self.unfinalized_batches
             .retain(|b| b.anchor_height < from_anchor);
 
-        executor.replay_blocks_from(from_anchor).await;
+        executor
+            .replay_blocks_from(from_anchor)
+            .await
+            .context("Failed to send replay request")?;
+        Ok(())
     }
 
     /// Run finality checks. Returns (rollback_anchor, excluded_txids) if a rollback is needed.
@@ -776,9 +779,9 @@ pub async fn handle_consensus_msg(
             let start_height = state.current_height;
             info!(%start_height, "Consensus is ready");
 
-            if reply.send((start_height, state.height_params())).is_err() {
-                error!("Failed to send ConsensusReady reply");
-            }
+            reply
+                .send((start_height, state.height_params()))
+                .map_err(|_| anyhow::anyhow!("Failed to send ConsensusReady reply"))?;
         }
 
         AppMsg::StartedRound {
@@ -799,9 +802,9 @@ pub async fn handle_consensus_msg(
                 .into_iter()
                 .collect();
 
-            if reply_value.send(proposals).is_err() {
-                error!("Failed to send StartedRound reply");
-            }
+            reply_value
+                .send(proposals)
+                .map_err(|_| anyhow::anyhow!("Failed to send StartedRound reply"))?;
         }
 
         AppMsg::GetValue {
@@ -825,9 +828,9 @@ pub async fn handle_consensus_msg(
                         .await
                         .context("Failed to send proposal part to network")?;
                 }
-                if reply.send(proposal).is_err() {
-                    error!("Failed to send GetValue reply");
-                }
+                reply
+                    .send(proposal)
+                    .map_err(|_| anyhow::anyhow!("Failed to send GetValue reply"))?;
             } else if let Some(value) = state.make_value(executor, last_height, last_hash).await {
                 let proposed = ProposedValue {
                     height,
@@ -846,9 +849,9 @@ pub async fn handle_consensus_msg(
                         .await
                         .context("Failed to send proposal part to network")?;
                 }
-                if reply.send(proposal).is_err() {
-                    error!("Failed to send GetValue reply");
-                }
+                reply
+                    .send(proposal)
+                    .map_err(|_| anyhow::anyhow!("Failed to send GetValue reply"))?;
             } else {
                 // Nothing to propose — drop reply so Malachite times out the round
                 info!(%height, %round, "Nothing to propose, skipping round");
@@ -888,21 +891,21 @@ pub async fn handle_consensus_msg(
                 }
             };
 
-            if reply.send(proposed).is_err() {
-                error!("Failed to send ReceivedProposalPart reply");
-            }
+            reply
+                .send(proposed)
+                .map_err(|_| anyhow::anyhow!("Failed to send ReceivedProposalPart reply"))?;
         }
 
         AppMsg::ExtendVote { reply, .. } => {
-            if reply.send(None).is_err() {
-                error!("Failed to send ExtendVote reply");
-            }
+            reply
+                .send(None)
+                .map_err(|_| anyhow::anyhow!("Failed to send ExtendVote reply"))?;
         }
 
         AppMsg::VerifyVoteExtension { reply, .. } => {
-            if reply.send(Ok(())).is_err() {
-                error!("Failed to send VerifyVoteExtension reply");
-            }
+            reply
+                .send(Ok(()))
+                .map_err(|_| anyhow::anyhow!("Failed to send VerifyVoteExtension reply"))?;
         }
 
         AppMsg::Decided {
@@ -1076,16 +1079,16 @@ pub async fn handle_consensus_msg(
 
             let next = Next::Start(state.current_height, state.height_params());
 
-            if reply.send(next).is_err() {
-                error!("Failed to send Finalized reply");
-            }
+            reply
+                .send(next)
+                .map_err(|_| anyhow::anyhow!("Failed to send Finalized reply"))?;
         }
 
         AppMsg::GetHistoryMinHeight { reply } => {
             let min = state.min_decided_height().await.unwrap_or(Height::new(1));
-            if reply.send(min).is_err() {
-                error!("Failed to send GetHistoryMinHeight reply");
-            }
+            reply
+                .send(min)
+                .map_err(|_| anyhow::anyhow!("Failed to send GetHistoryMinHeight reply"))?;
         }
 
         AppMsg::GetDecidedValues { range, reply } => {
@@ -1104,9 +1107,9 @@ pub async fn handle_consensus_msg(
                 }
                 h = h.increment();
             }
-            if reply.send(values).is_err() {
-                error!("Failed to send GetDecidedValues reply");
-            }
+            reply
+                .send(values)
+                .map_err(|_| anyhow::anyhow!("Failed to send GetDecidedValues reply"))?;
         }
 
         AppMsg::ProcessSyncedValue {
@@ -1135,9 +1138,9 @@ pub async fn handle_consensus_msg(
                     None
                 };
 
-            if reply.send(result).is_err() {
-                error!("Failed to send ProcessSyncedValue reply");
-            }
+            reply
+                .send(result)
+                .map_err(|_| anyhow::anyhow!("Failed to send ProcessSyncedValue reply"))?;
         }
 
         AppMsg::RestreamProposal {

--- a/core/indexer/src/reactor/executor.rs
+++ b/core/indexer/src/reactor/executor.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use bitcoin::Txid;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
@@ -53,7 +54,7 @@ pub trait Executor {
     );
 
     /// Signal the block source to re-deliver blocks starting from `height`.
-    async fn replay_blocks_from(&mut self, height: u64);
+    async fn replay_blocks_from(&mut self, height: u64) -> Result<()>;
 
     /// Parse a bitcoin::Transaction into an indexer_types::Transaction.
     fn parse_transaction(&self, tx: &bitcoin::Transaction) -> Option<indexer_types::Transaction>;
@@ -80,7 +81,9 @@ impl Executor for NoopExecutor {
         _tx: &indexer_types::Transaction,
     ) {
     }
-    async fn replay_blocks_from(&mut self, _height: u64) {}
+    async fn replay_blocks_from(&mut self, _height: u64) -> Result<()> {
+        Ok(())
+    }
     fn parse_transaction(&self, _tx: &bitcoin::Transaction) -> Option<indexer_types::Transaction> {
         None
     }
@@ -202,12 +205,13 @@ impl Executor for RuntimeExecutor {
             .await;
         }
     }
-    async fn replay_blocks_from(&mut self, height: u64) {
-        if let Some(tx) = &self.replay_tx
-            && let Err(e) = tx.send(height).await
-        {
-            tracing::error!(%e, height, "Failed to send replay request to poller");
+    async fn replay_blocks_from(&mut self, height: u64) -> Result<()> {
+        if let Some(tx) = &self.replay_tx {
+            tx.send(height)
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to send replay request to poller: {e}"))?;
         }
+        Ok(())
     }
 
     fn parse_transaction(&self, tx: &bitcoin::Transaction) -> Option<indexer_types::Transaction> {

--- a/core/indexer/src/reactor/lite_executor.rs
+++ b/core/indexer/src/reactor/lite_executor.rs
@@ -201,7 +201,7 @@ impl Executor for LiteExecutor {
         }
     }
 
-    async fn replay_blocks_from(&mut self, height: u64) {
+    async fn replay_blocks_from(&mut self, height: u64) -> anyhow::Result<()> {
         let events = self.mock_bitcoin.lock().unwrap().get_all_block_events();
         for event in events {
             if let crate::bitcoin_follower::event::BlockEvent::BlockInsert { block, .. } = &event
@@ -210,6 +210,7 @@ impl Executor for LiteExecutor {
                 let _ = self.block_tx.send(event).await;
             }
         }
+        Ok(())
     }
 
     fn parse_transaction(&self, tx: &bitcoin::Transaction) -> Option<indexer_types::Transaction> {

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -739,7 +739,19 @@ impl<E: Executor> Reactor<E> {
 
     #[tracing::instrument(skip_all, fields(node = %self.runtime.node_label))]
     pub async fn run(&mut self) -> Result<()> {
-        self.run_event_loop().await
+        let result = self.run_event_loop().await;
+
+        // Gracefully stop the Malachite consensus engine and wait for cleanup
+        if let Some(handle) = &self.consensus_handle {
+            let _ = handle
+                ._engine_handle
+                .actor
+                .get_cell()
+                .stop_and_wait(Some("Reactor shutting down".to_string()), None)
+                .await;
+        }
+
+        result
     }
 }
 

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -141,14 +141,11 @@ impl<E: Executor> Reactor<E> {
         rollback_to_height(&self.db_conn(), height)
             .await
             .context("rollback_to_height failed")?;
-        if let Err(e) = self
-            .runtime
+        self.runtime
             .file_ledger
             .force_resync_from_db(&self.runtime.storage.conn)
             .await
-        {
-            error!("file_ledger resync after rollback failed: {e}");
-        }
+            .context("file_ledger resync after rollback failed")?;
         self.last_height = height;
 
         if let Ok(Some(row)) = select_block_at_height(&self.db_conn(), height as i64).await {
@@ -697,7 +694,8 @@ impl<E: Executor> Reactor<E> {
                                     &mut self.executor,
                                     rollback_anchor,
                                     excluded,
-                                ).await;
+                                ).await
+                                .context("initiate_rollback failed")?;
 
                                 // Rollback to before the invalid anchor so all state at the
                                 // anchor height (including invalid tx effects) is wiped cleanly.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes convert several previously-logged failures into propagated `Result` errors in consensus/rollback paths, which can now abort the reactor event loop if triggered. It also adds explicit Malachite engine shutdown, which could impact lifecycle behavior if stop/wait hangs or fails.
> 
> **Overview**
> **Consensus/reactor error handling is tightened.** Rollback replay loading and executor replay signaling now return `Result` with contextual errors (instead of logging and continuing), and Malachite `AppMsg` reply sends now fail the handler on send errors rather than silently logging.
> 
> **Lifecycle behavior changes.** `rollback()` now treats `file_ledger` resync failures as fatal, and `Reactor::run()` now explicitly stops the Malachite engine via `stop_and_wait()` on shutdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a681d1c0987352aa2b0f19382f3cb4f2d5b2c57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->