### PR TITLE
Consensus timeout improvements

### DIFF
--- a/core/indexer/src/bitcoin_follower/event.rs
+++ b/core/indexer/src/bitcoin_follower/event.rs
@@ -9,7 +9,7 @@ pub enum BlockEvent {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum MempoolEvent {
-    Sync(Vec<bitcoin::Transaction>),
-    Insert(bitcoin::Transaction),
+    Sync(Vec<(bitcoin::Transaction, indexer_types::Transaction)>),
+    Insert(bitcoin::Transaction, indexer_types::Transaction),
     Remove(Txid),
 }

--- a/core/indexer/src/bitcoin_follower/listener.rs
+++ b/core/indexer/src/bitcoin_follower/listener.rs
@@ -297,7 +297,7 @@ async fn fetch_mempool<C: BitcoinRpc>(
     bitcoin: &C,
     f: TransactionFilterMap,
     cancel_token: &CancellationToken,
-) -> Result<(Vec<bitcoin::Transaction>, u64)> {
+) -> Result<(Vec<(bitcoin::Transaction, indexer_types::Transaction)>, u64)> {
     let snapshot = retry(
         || bitcoin.get_raw_mempool_sequence(),
         "get raw mempool",
@@ -337,15 +337,15 @@ async fn fetch_mempool<C: BitcoinRpc>(
         );
     }
 
-    // Filter through TransactionFilterMap to only keep relevant txs, but return
-    // the raw bitcoin::Transaction (not the parsed indexer_types::Transaction).
-    let filtered: Vec<bitcoin::Transaction> = task::spawn_blocking(move || {
-        txs.into_par_iter()
-            .enumerate()
-            .filter_map(|(i, tx)| f((i, tx.clone())).map(|_| tx))
-            .collect()
-    })
-    .await?;
+    // Filter and parse transactions in parallel, keeping both raw and parsed forms.
+    let filtered: Vec<(bitcoin::Transaction, indexer_types::Transaction)> =
+        task::spawn_blocking(move || {
+            txs.into_par_iter()
+                .enumerate()
+                .filter_map(|(i, tx)| f((i, tx.clone())).map(|parsed| (tx, parsed)))
+                .collect()
+        })
+        .await?;
 
     Ok((filtered, mempool_sequence))
 }
@@ -373,8 +373,11 @@ async fn process_delta<C: BitcoinRpc>(
             .await
             {
                 Ok(tx) => {
-                    if f((0, tx.clone())).is_some()
-                        && event_tx.send(MempoolEvent::Insert(tx)).await.is_err()
+                    if let Some(parsed) = f((0, tx.clone()))
+                        && event_tx
+                            .send(MempoolEvent::Insert(tx, parsed))
+                            .await
+                            .is_err()
                     {
                         return Ok(false);
                     }
@@ -575,7 +578,7 @@ mod tests {
 
         let (result, _) = fetch_mempool(&mock, f, &cancel).await.unwrap();
         assert_eq!(result.len(), 2);
-        let txids: Vec<_> = result.iter().map(|t| t.compute_txid()).collect();
+        let txids: Vec<_> = result.iter().map(|(t, _)| t.compute_txid()).collect();
         assert!(txids.contains(&txid1));
         assert!(txids.contains(&txid3));
     }
@@ -592,7 +595,7 @@ mod tests {
 
         assert_eq!(result.len(), 5);
         for txid in &expected_txids {
-            assert!(result.iter().any(|t| t.compute_txid() == *txid));
+            assert!(result.iter().any(|(t, _)| t.compute_txid() == *txid));
         }
     }
 
@@ -669,7 +672,7 @@ mod tests {
         assert!(open);
 
         match event_rx.try_recv().unwrap() {
-            MempoolEvent::Insert(t) => assert_eq!(t.compute_txid(), txid),
+            MempoolEvent::Insert(t, _) => assert_eq!(t.compute_txid(), txid),
             other => panic!("Expected MempoolInsert, got {:?}", other),
         }
     }
@@ -908,7 +911,7 @@ mod tests {
 
         let events = collect_events(&mut event_rx);
         assert!(matches!(&events[0], MempoolEvent::Sync(txs) if txs.len() == 3));
-        assert!(matches!(&events[1], MempoolEvent::Insert(t) if t.compute_txid() == txid3));
+        assert!(matches!(&events[1], MempoolEvent::Insert(t, _) if t.compute_txid() == txid3));
         assert_eq!(events.len(), 2);
     }
 
@@ -983,7 +986,7 @@ mod tests {
         assert!(matches!(&events[0], MempoolEvent::Sync(_)));
         // Only tx3 replayed (stale ones skipped)
         assert_eq!(events.len(), 2);
-        assert!(matches!(&events[1], MempoolEvent::Insert(t) if t.compute_txid() == txid3));
+        assert!(matches!(&events[1], MempoolEvent::Insert(t, _) if t.compute_txid() == txid3));
     }
 
     #[tokio::test]

--- a/core/indexer/src/database/queries.rs
+++ b/core/indexer/src/database/queries.rs
@@ -572,6 +572,18 @@ pub async fn select_batches_from_anchor(
     query_batches(conn, &format!("WHERE b.anchor_height >= {from_anchor}")).await
 }
 
+pub async fn select_batches_in_range(
+    conn: &Connection,
+    start: i64,
+    end: i64,
+) -> Result<Vec<BatchQueryResult>, Error> {
+    query_batches(
+        conn,
+        &format!("WHERE b.consensus_height >= {start} AND b.consensus_height <= {end}"),
+    )
+    .await
+}
+
 async fn query_batches(
     conn: &Connection,
     where_clause: &str,

--- a/core/indexer/src/reactor/consensus.rs
+++ b/core/indexer/src/reactor/consensus.rs
@@ -157,6 +157,7 @@ impl ConsensusState {
         self.pending_blocks.clear();
         self.deferred_decisions.clear();
         self.unfinalized_batches.clear();
+        self.pending_proposal = None;
     }
 
     fn validator_set(&self) -> ValidatorSet {

--- a/core/indexer/src/reactor/consensus.rs
+++ b/core/indexer/src/reactor/consensus.rs
@@ -66,7 +66,7 @@ pub struct ConsensusState {
     pub conn: libsql::Connection,
     pub signing_provider: Ed25519Provider,
     pub address: Address,
-    pub pending_transactions: HashMap<Txid, bitcoin::Transaction>,
+    pub pending_transactions: HashMap<Txid, (bitcoin::Transaction, indexer_types::Transaction)>,
     pub current_height: Height,
     pub current_round: Round,
     pub undecided: BTreeMap<(Height, Round), ProposedValue<Ctx>>,
@@ -275,13 +275,13 @@ impl ConsensusState {
         // Per-tx validation — remove invalid txs from the pool
         let mut txs = Vec::new();
         let mut invalid_txids = Vec::new();
-        for tx in self.pending_transactions.values() {
-            let txid = tx.compute_txid();
+        for (raw_tx, _parsed) in self.pending_transactions.values() {
+            let txid = raw_tx.compute_txid();
             if !unbatched_set.contains(&txid) {
                 continue;
             }
-            if executor.validate_transaction(tx).await.is_some() {
-                txs.push(tx.clone());
+            if executor.validate_transaction(raw_tx).await.is_some() {
+                txs.push(raw_tx.clone());
             } else {
                 invalid_txids.push(txid);
             }
@@ -590,6 +590,34 @@ impl ConsensusState {
             "Processing decided batch"
         );
 
+        // Empty batch — just record for sync, no execution or finality tracking
+        if batch_txs.is_empty() {
+            insert_batch(
+                &self.conn,
+                consensus_height.as_u64() as i64,
+                anchor_height as i64,
+                &anchor_hash.to_string(),
+                certificate,
+                false,
+            )
+            .await
+            .context("Failed to insert empty batch")?;
+
+            self.emit_state_event(StateEvent::BatchApplied {
+                consensus_height,
+                anchor_height,
+                txid_count: 0,
+                checkpoint: self.get_checkpoint().await,
+            });
+
+            info!(
+                anchor = anchor_height,
+                consensus_height = %consensus_height,
+                "Empty batch recorded"
+            );
+            return Ok(());
+        }
+
         let parsed_txs: Vec<indexer_types::Transaction> = batch_txs
             .iter()
             .filter_map(|btx| executor.parse_transaction(btx))
@@ -685,21 +713,28 @@ impl ConsensusState {
         last_height: u64,
         last_hash: bitcoin::BlockHash,
     ) -> Result<bool> {
-        let pending = match &self.pending_proposal {
-            Some(p) => p,
+        let (past_deadline, pending_height, pending_round) = match &self.pending_proposal {
+            Some(p) => {
+                let hard_deadline = p
+                    .timeout
+                    .saturating_sub(std::time::Duration::from_secs(1));
+                (p.created_at.elapsed() >= hard_deadline, p.height, p.round)
+            }
             None => return Ok(false),
         };
 
-        // Don't try to fulfill if we've exceeded the hard deadline — Malachite's
-        // propose timeout is about to fire. StartedRound will clean up the stale reply.
-        let hard_deadline = pending
-            .timeout
-            .saturating_sub(std::time::Duration::from_secs(1));
-        if pending.created_at.elapsed() >= hard_deadline {
-            return Ok(false);
-        }
-
-        let Some(value) = self.make_value(executor, last_height, last_hash).await else {
+        let value = if let Some(value) = self.make_value(executor, last_height, last_hash).await {
+            value
+        } else if past_deadline {
+            // Hard deadline reached with no transactions — propose an empty batch
+            // so Malachite gets a clean reply and the height advances.
+            info!(
+                height = %pending_height,
+                round = %pending_round,
+                "Proposing empty batch at hard deadline"
+            );
+            Value::new_batch_raw(last_height, last_hash, vec![])
+        } else {
             return Ok(false);
         };
 
@@ -738,9 +773,6 @@ async fn validate_batch(
     last_height: u64,
     last_hash: bitcoin::BlockHash,
 ) -> Option<&'static str> {
-    if txids.is_empty() {
-        return Some("batch is empty");
-    }
     if !state.pending_blocks.is_empty() {
         return Some("block is pending");
     }
@@ -816,9 +848,16 @@ async fn validate_and_accept_proposal(
                 return None;
             }
             for tx in transactions {
-                if executor.validate_transaction(tx).await.is_none() {
+                let txid = tx.compute_txid();
+                if let Some(parsed) = executor.validate_transaction(tx).await {
+                    // Add to pending_transactions if not already present
+                    state
+                        .pending_transactions
+                        .entry(txid)
+                        .or_insert_with(|| (tx.clone(), parsed));
+                } else {
                     warn!(
-                        txid = %tx.compute_txid(),
+                        %txid,
                         "Rejecting proposal: transaction failed validation"
                     );
                     return None;

--- a/core/indexer/src/reactor/consensus.rs
+++ b/core/indexer/src/reactor/consensus.rs
@@ -1238,6 +1238,7 @@ pub async fn handle_consensus_msg(
 
             state.current_height = certificate.height.increment();
             state.current_round = Round::Nil;
+            state.pending_proposal = None;
 
             let next = Next::Start(state.current_height, state.height_params());
 

--- a/core/indexer/src/reactor/consensus.rs
+++ b/core/indexer/src/reactor/consensus.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use bitcoin::Txid;
@@ -57,8 +58,16 @@ pub struct PendingProposal {
     pub height: Height,
     pub round: Round,
     pub reply: tokio::sync::oneshot::Sender<LocallyProposedValue<Ctx>>,
-    pub timeout: std::time::Duration,
-    pub created_at: std::time::Instant,
+    pub timeout: Duration,
+    pub created_at: Instant,
+}
+
+impl PendingProposal {
+    /// Deadline at which we must propose (even an empty batch) before
+    /// Malachite's propose timeout fires. Uses 80% of the propose timeout.
+    pub fn hard_deadline(&self) -> Instant {
+        self.created_at + self.timeout * 4 / 5
+    }
 }
 
 /// All consensus-related state for the reactor.
@@ -737,10 +746,7 @@ impl ConsensusState {
         last_hash: bitcoin::BlockHash,
     ) -> Result<bool> {
         let (past_deadline, pending_height, pending_round) = match &self.pending_proposal {
-            Some(p) => {
-                let hard_deadline = p.timeout.saturating_sub(std::time::Duration::from_secs(1));
-                (p.created_at.elapsed() >= hard_deadline, p.height, p.round)
-            }
+            Some(p) => (Instant::now() >= p.hard_deadline(), p.height, p.round),
             None => return Ok(false),
         };
 
@@ -1016,7 +1022,7 @@ pub async fn handle_consensus_msg(
                     round,
                     reply,
                     timeout,
-                    created_at: std::time::Instant::now(),
+                    created_at: Instant::now(),
                 });
             }
         }

--- a/core/indexer/src/reactor/consensus.rs
+++ b/core/indexer/src/reactor/consensus.rs
@@ -276,12 +276,12 @@ impl ConsensusState {
         // Per-tx validation — remove invalid txs from the pool
         let mut txs = Vec::new();
         let mut invalid_txids = Vec::new();
-        for (raw_tx, _parsed) in self.pending_transactions.values() {
+        for (raw_tx, parsed) in self.pending_transactions.values() {
             let txid = raw_tx.compute_txid();
             if !unbatched_set.contains(&txid) {
                 continue;
             }
-            if executor.validate_transaction(raw_tx).await.is_some() {
+            if executor.validate_transaction(raw_tx, parsed).await {
                 txs.push(raw_tx.clone());
             } else {
                 invalid_txids.push(txid);
@@ -870,19 +870,24 @@ async fn validate_and_accept_proposal(
             }
             for tx in transactions {
                 let txid = tx.compute_txid();
-                if let Some(parsed) = executor.validate_transaction(tx).await {
-                    // Add to pending_transactions if not already present
-                    state
-                        .pending_transactions
-                        .entry(txid)
-                        .or_insert_with(|| (tx.clone(), parsed));
+                // Use cached parse from pending_transactions, or parse fresh
+                let parsed = if let Some((_, cached)) = state.pending_transactions.get(&txid) {
+                    cached.clone()
+                } else if let Some(p) = executor.parse_transaction(tx) {
+                    p
                 } else {
-                    warn!(
-                        %txid,
-                        "Rejecting proposal: transaction failed validation"
-                    );
+                    warn!(%txid, "Rejecting proposal: transaction failed to parse");
+                    return None;
+                };
+                if !executor.validate_transaction(tx, &parsed).await {
+                    warn!(%txid, "Rejecting proposal: transaction failed validation");
                     return None;
                 }
+                // Add to pending_transactions if not already present
+                state
+                    .pending_transactions
+                    .entry(txid)
+                    .or_insert_with(|| (tx.clone(), parsed));
             }
             Value::new_batch_raw(*anchor_height, *anchor_hash, transactions.clone())
         }

--- a/core/indexer/src/reactor/consensus.rs
+++ b/core/indexer/src/reactor/consensus.rs
@@ -52,12 +52,21 @@ pub struct DeferredDecision {
     pub certificate: Vec<u8>,
 }
 
+/// A GetValue reply that we're holding until transactions arrive.
+pub struct PendingProposal {
+    pub height: Height,
+    pub round: Round,
+    pub reply: tokio::sync::oneshot::Sender<LocallyProposedValue<Ctx>>,
+    pub timeout: std::time::Duration,
+    pub created_at: std::time::Instant,
+}
+
 /// All consensus-related state for the reactor.
 pub struct ConsensusState {
     pub conn: libsql::Connection,
     pub signing_provider: Ed25519Provider,
     pub address: Address,
-    pub mempool: HashMap<Txid, bitcoin::Transaction>,
+    pub pending_transactions: HashMap<Txid, bitcoin::Transaction>,
     pub current_height: Height,
     pub current_round: Round,
     pub undecided: BTreeMap<(Height, Round), ProposedValue<Ctx>>,
@@ -83,6 +92,9 @@ pub struct ConsensusState {
 
     // Consensus timeouts — defaults to LinearTimeouts::default() (3s propose).
     pub timeouts: LinearTimeouts,
+
+    // Held GetValue reply — waiting for pending_transactions to arrive.
+    pub pending_proposal: Option<PendingProposal>,
 }
 
 pub struct ObservationChannels {
@@ -125,7 +137,7 @@ impl ConsensusState {
             conn,
             signing_provider,
             address,
-            mempool: std::collections::HashMap::new(),
+            pending_transactions: std::collections::HashMap::new(),
             current_height,
             current_round: Round::new(0),
             undecided: BTreeMap::new(),
@@ -135,6 +147,7 @@ impl ConsensusState {
             current_validator_set,
             observation: None,
             timeouts: LinearTimeouts::default(),
+            pending_proposal: None,
         }
     }
 
@@ -241,27 +254,40 @@ impl ConsensusState {
             return Some(Value::new_block(height, block.hash));
         }
 
-        // Pre-filter already-processed txids from mempool to avoid unnecessary validation
-        let mempool_txids: Vec<Txid> = self.mempool.keys().copied().collect();
-        let txid_strs: Vec<String> = mempool_txids.iter().map(|t| t.to_string()).collect();
+        // Pre-filter already-processed txids to avoid unnecessary validation
+        let pending_txids: Vec<Txid> = self.pending_transactions.keys().copied().collect();
+        let txid_strs: Vec<String> = pending_txids.iter().map(|t| t.to_string()).collect();
         let existing = select_existing_txids(&self.conn, &txid_strs)
             .await
             .unwrap_or_default();
-        let unbatched_set: HashSet<Txid> = mempool_txids
+        let unbatched_set: HashSet<Txid> = pending_txids
             .into_iter()
             .filter(|t| !existing.contains(&t.to_string()))
             .collect();
 
-        // Per-tx validation
+        // Remove already-processed txids from the pool
+        for txid_str in &existing {
+            if let Ok(txid) = txid_str.parse::<Txid>() {
+                self.pending_transactions.remove(&txid);
+            }
+        }
+
+        // Per-tx validation — remove invalid txs from the pool
         let mut txs = Vec::new();
-        for tx in self.mempool.values() {
+        let mut invalid_txids = Vec::new();
+        for tx in self.pending_transactions.values() {
             let txid = tx.compute_txid();
             if !unbatched_set.contains(&txid) {
                 continue;
             }
             if executor.validate_transaction(tx).await.is_some() {
                 txs.push(tx.clone());
+            } else {
+                invalid_txids.push(txid);
             }
+        }
+        for txid in &invalid_txids {
+            self.pending_transactions.remove(txid);
         }
         if txs.is_empty() {
             return None;
@@ -648,6 +674,59 @@ impl ConsensusState {
 
         Ok(())
     }
+
+    /// Try to fulfill a pending GetValue reply with a new batch.
+    /// Called from the reactor event loop when pending transactions arrive.
+    /// Returns true if the proposal was sent.
+    pub async fn try_fulfill_pending_proposal(
+        &mut self,
+        executor: &impl Executor,
+        channels: &mut Channels<Ctx>,
+        last_height: u64,
+        last_hash: bitcoin::BlockHash,
+    ) -> Result<bool> {
+        let pending = match &self.pending_proposal {
+            Some(p) => p,
+            None => return Ok(false),
+        };
+
+        // Don't try to fulfill if we've exceeded the hard deadline — Malachite's
+        // propose timeout is about to fire. StartedRound will clean up the stale reply.
+        let hard_deadline = pending
+            .timeout
+            .saturating_sub(std::time::Duration::from_secs(1));
+        if pending.created_at.elapsed() >= hard_deadline {
+            return Ok(false);
+        }
+
+        let Some(value) = self.make_value(executor, last_height, last_hash).await else {
+            return Ok(false);
+        };
+
+        let pending = self.pending_proposal.take().unwrap();
+        let proposed = ProposedValue {
+            height: pending.height,
+            round: pending.round,
+            valid_round: Round::Nil,
+            proposer: self.address,
+            value: value.clone(),
+            validity: Validity::Valid,
+        };
+        self.undecided
+            .insert((pending.height, pending.round), proposed);
+        let proposal = LocallyProposedValue::new(pending.height, pending.round, value);
+        for stream_msg in self.stream_proposal(&proposal, Round::Nil) {
+            channels
+                .network
+                .send(NetworkMsg::PublishProposalPart(stream_msg))
+                .await
+                .context("Failed to send proposal part to network")?;
+        }
+        // Reply may fail if Malachite already moved on — that's fine
+        let _ = pending.reply.send(proposal);
+
+        Ok(true)
+    }
 }
 
 /// Validate batch-level rules. Returns a rejection reason if any rule fails.
@@ -795,6 +874,18 @@ pub async fn handle_consensus_msg(
             state.current_height = height;
             state.current_round = round;
 
+            // Clear any stale pending proposal from a previous round
+            if let Some(pending) = &state.pending_proposal
+                && (pending.height != height || pending.round != round)
+            {
+                info!(
+                    pending_height = %pending.height,
+                    pending_round = %pending.round,
+                    "Clearing stale pending proposal"
+                );
+                state.pending_proposal = None;
+            }
+
             let proposals: Vec<_> = state
                 .undecided
                 .get(&(height, round))
@@ -810,7 +901,7 @@ pub async fn handle_consensus_msg(
         AppMsg::GetValue {
             height,
             round,
-            timeout: _,
+            timeout,
             reply,
         } => {
             info!(%height, %round, "Building value to propose");
@@ -853,9 +944,15 @@ pub async fn handle_consensus_msg(
                     .send(proposal)
                     .map_err(|_| anyhow::anyhow!("Failed to send GetValue reply"))?;
             } else {
-                // Nothing to propose — drop reply so Malachite times out the round
-                info!(%height, %round, "Nothing to propose, skipping round");
-                drop(reply);
+                // Nothing to propose yet — hold the reply and wait for transactions
+                info!(%height, %round, "Nothing to propose, holding reply for pending transactions");
+                state.pending_proposal = Some(PendingProposal {
+                    height,
+                    round,
+                    reply,
+                    timeout,
+                    created_at: std::time::Instant::now(),
+                });
             }
         }
 
@@ -963,6 +1060,11 @@ pub async fn handle_consensus_msg(
                                     }
                                 }
                             }
+                        }
+
+                        // Remove decided txids from pending_transactions
+                        for tx in &full_txs {
+                            state.pending_transactions.remove(&tx.compute_txid());
                         }
 
                         let cert_bytes = encode_commit_certificate(&certificate)

--- a/core/indexer/src/reactor/consensus.rs
+++ b/core/indexer/src/reactor/consensus.rs
@@ -29,8 +29,8 @@ use crate::consensus::{
 };
 use crate::database::queries::{
     delete_batches_above_anchor, get_checkpoint_latest, get_transaction_by_txid, insert_batch,
-    insert_transaction, insert_unconfirmed_batch_tx, select_batch, select_batches_from_anchor,
-    select_block_at_height, select_block_latest, select_existing_txids,
+    insert_transaction, insert_unconfirmed_batch_tx, select_batches_from_anchor,
+    select_batches_in_range, select_block_at_height, select_block_latest, select_existing_txids,
     select_latest_consensus_height, select_min_batch_height, select_unconfirmed_batch_txs,
 };
 
@@ -470,30 +470,17 @@ impl ConsensusState {
         if txs.is_empty() { None } else { Some(txs) }
     }
 
-    async fn get_decided(
+    fn batch_to_decided(
         &self,
-        height: Height,
+        b: &crate::database::types::BatchQueryResult,
     ) -> Option<(Value, crate::consensus::CommitCertificate<Ctx>)> {
-        let consensus_height = height.as_u64() as i64;
-        let b = select_batch(&self.conn, consensus_height)
-            .await
-            .ok()
-            .flatten()?;
-
         let anchor_hash = b.anchor_hash.parse::<bitcoin::BlockHash>().ok()?;
 
         let value = if b.is_block {
             Value::new_block(b.anchor_height as u64, anchor_hash)
         } else {
             let txids: Vec<Txid> = b.txids.iter().filter_map(|s| s.parse().ok()).collect();
-            let raw_txs = self
-                .load_raw_txs_if_unfinalized(b.anchor_height, consensus_height)
-                .await;
-            let mut v = Value::new_batch(b.anchor_height as u64, anchor_hash, txids);
-            if let Some(raw_txs) = raw_txs {
-                v.set_raw_txs(raw_txs);
-            }
-            v
+            Value::new_batch(b.anchor_height as u64, anchor_hash, txids)
         };
 
         let proto =
@@ -501,6 +488,41 @@ impl ConsensusState {
         let certificate = decode_commit_certificate(proto).ok()?;
 
         Some((value, certificate))
+    }
+
+    async fn get_decided_range(
+        &self,
+        start: Height,
+        end: Height,
+    ) -> Vec<(Value, crate::consensus::CommitCertificate<Ctx>)> {
+        let batches =
+            match select_batches_in_range(&self.conn, start.as_u64() as i64, end.as_u64() as i64)
+                .await
+            {
+                Ok(b) => b,
+                Err(e) => {
+                    warn!(%e, "Failed to query batches for sync range");
+                    return Vec::new();
+                }
+            };
+
+        let mut results = Vec::new();
+        for b in &batches {
+            let Some((mut value, cert)) = self.batch_to_decided(b) else {
+                continue;
+            };
+
+            if !b.is_block
+                && let Some(raw_txs) = self
+                    .load_raw_txs_if_unfinalized(b.anchor_height, b.consensus_height)
+                    .await
+            {
+                value.set_raw_txs(raw_txs);
+            }
+
+            results.push((value, cert));
+        }
+        results
     }
 
     async fn min_decided_height(&self) -> Option<Height> {
@@ -715,9 +737,7 @@ impl ConsensusState {
     ) -> Result<bool> {
         let (past_deadline, pending_height, pending_round) = match &self.pending_proposal {
             Some(p) => {
-                let hard_deadline = p
-                    .timeout
-                    .saturating_sub(std::time::Duration::from_secs(1));
+                let hard_deadline = p.timeout.saturating_sub(std::time::Duration::from_secs(1));
                 (p.created_at.elapsed() >= hard_deadline, p.height, p.round)
             }
             None => return Ok(false),
@@ -1233,21 +1253,19 @@ pub async fn handle_consensus_msg(
         }
 
         AppMsg::GetDecidedValues { range, reply } => {
-            let mut values = Vec::new();
-            let start = *range.start();
-            let end = *range.end();
-            let mut h = start;
-            while h <= end {
-                if let Some((value, cert)) = state.get_decided(h).await
-                    && let Ok(encoded) = ProtobufCodec.encode(&value)
-                {
-                    values.push(RawDecidedValue {
-                        certificate: cert,
-                        value_bytes: encoded,
-                    });
-                }
-                h = h.increment();
-            }
+            let decided = state.get_decided_range(*range.start(), *range.end()).await;
+            let values: Vec<_> = decided
+                .into_iter()
+                .filter_map(|(value, cert)| {
+                    ProtobufCodec
+                        .encode(&value)
+                        .ok()
+                        .map(|encoded| RawDecidedValue {
+                            certificate: cert,
+                            value_bytes: encoded,
+                        })
+                })
+                .collect();
             reply
                 .send(values)
                 .map_err(|_| anyhow::anyhow!("Failed to send GetDecidedValues reply"))?;

--- a/core/indexer/src/reactor/executor.rs
+++ b/core/indexer/src/reactor/executor.rs
@@ -31,13 +31,14 @@ pub fn is_batchable(inputs: &[indexer_types::TransactionInput]) -> bool {
 /// `run_finality_checks`) calls these methods instead of directly manipulating state.
 #[allow(async_fn_in_trait)]
 pub trait Executor {
-    /// Validate a transaction and parse its Kontor ops.
-    /// Returns the parsed transaction if valid, None otherwise.
-    /// Implementations may also propagate the tx to the local bitcoind mempool.
+    /// Validate a pre-parsed transaction for batching.
+    /// Checks batchability and may propagate the tx to the local bitcoind mempool.
+    /// Returns true if the transaction is valid for inclusion in a batch.
     async fn validate_transaction(
         &self,
-        tx: &bitcoin::Transaction,
-    ) -> Option<indexer_types::Transaction>;
+        raw: &bitcoin::Transaction,
+        parsed: &indexer_types::Transaction,
+    ) -> bool;
 
     /// Resolve a txid to a full bitcoin::Transaction. Used to fetch transaction
     /// data for batch execution — batches carry only txids.
@@ -66,9 +67,10 @@ pub struct NoopExecutor;
 impl Executor for NoopExecutor {
     async fn validate_transaction(
         &self,
-        _tx: &bitcoin::Transaction,
-    ) -> Option<indexer_types::Transaction> {
-        None
+        _raw: &bitcoin::Transaction,
+        _parsed: &indexer_types::Transaction,
+    ) -> bool {
+        false
     }
     async fn resolve_transaction(&self, _txid: &Txid) -> Option<bitcoin::Transaction> {
         None
@@ -120,12 +122,11 @@ impl RuntimeExecutor {
 impl Executor for RuntimeExecutor {
     async fn validate_transaction(
         &self,
-        tx: &bitcoin::Transaction,
-    ) -> Option<indexer_types::Transaction> {
-        let parsed = self.parse_transaction(tx)?;
-
+        raw: &bitcoin::Transaction,
+        parsed: &indexer_types::Transaction,
+    ) -> bool {
         if !is_batchable(&parsed.inputs) {
-            return None;
+            return false;
         }
 
         // Push to local bitcoind mempool (idempotent, succeeds if already present).
@@ -134,7 +135,7 @@ impl Executor for RuntimeExecutor {
         // -27 (RPC_VERIFY_ALREADY_IN_UTXO_SET): tx already confirmed — treat as success
         // All other errors (network, node loading) are retried via unlimited backoff.
         if let Some(client) = &self.bitcoin_client {
-            let raw_hex = bitcoin::consensus::encode::serialize_hex(tx);
+            let raw_hex = bitcoin::consensus::encode::serialize_hex(raw);
             let result = retry(
                 || async {
                     match client.send_raw_transaction(&raw_hex).await {
@@ -157,17 +158,17 @@ impl Executor for RuntimeExecutor {
             match result {
                 Ok(true) => {}
                 Ok(false) => {
-                    warn!(txid = %tx.compute_txid(), "Transaction rejected by bitcoind");
-                    return None;
+                    warn!(txid = %raw.compute_txid(), "Transaction rejected by bitcoind");
+                    return false;
                 }
                 Err(e) => {
-                    warn!(txid = %tx.compute_txid(), %e, "send_raw_transaction failed");
-                    return None;
+                    warn!(txid = %raw.compute_txid(), %e, "send_raw_transaction failed");
+                    return false;
                 }
             }
         }
 
-        Some(parsed)
+        true
     }
     async fn resolve_transaction(&self, txid: &Txid) -> Option<bitcoin::Transaction> {
         // Fall back to Bitcoin RPC (via tx cache)

--- a/core/indexer/src/reactor/executor.rs
+++ b/core/indexer/src/reactor/executor.rs
@@ -89,15 +89,12 @@ impl Executor for NoopExecutor {
     }
 }
 
-type ParsedTxCache = moka::sync::Cache<Txid, indexer_types::Transaction>;
-
 /// Production executor: handles transaction validation, resolution, and op execution.
 /// Does NOT own the Runtime — the reactor owns it and passes &mut Runtime when needed.
 pub struct RuntimeExecutor {
     bitcoin_client: Option<Client>,
     replay_tx: Option<tokio::sync::mpsc::Sender<u64>>,
     cancel_token: CancellationToken,
-    parsed_tx_cache: ParsedTxCache,
 }
 
 impl RuntimeExecutor {
@@ -106,7 +103,6 @@ impl RuntimeExecutor {
             bitcoin_client: None,
             replay_tx: None,
             cancel_token,
-            parsed_tx_cache: moka::sync::Cache::builder().max_capacity(10_000).build(),
         }
     }
 
@@ -215,13 +211,7 @@ impl Executor for RuntimeExecutor {
     }
 
     fn parse_transaction(&self, tx: &bitcoin::Transaction) -> Option<indexer_types::Transaction> {
-        let txid = tx.compute_txid();
-        if let Some(parsed) = self.parsed_tx_cache.get(&txid) {
-            return Some(parsed);
-        }
-        let parsed = filter_map((0, tx.clone()))?;
-        self.parsed_tx_cache.insert(txid, parsed.clone());
-        Some(parsed)
+        filter_map((0, tx.clone()))
     }
 }
 

--- a/core/indexer/src/reactor/lite_executor.rs
+++ b/core/indexer/src/reactor/lite_executor.rs
@@ -157,14 +157,10 @@ impl LiteExecutor {
 impl Executor for LiteExecutor {
     async fn validate_transaction(
         &self,
-        tx: &bitcoin::Transaction,
-    ) -> Option<indexer_types::Transaction> {
-        Some(indexer_types::Transaction {
-            txid: tx.compute_txid(),
-            index: 0,
-            inputs: Vec::new(),
-            op_return_data: Default::default(),
-        })
+        _raw: &bitcoin::Transaction,
+        _parsed: &indexer_types::Transaction,
+    ) -> bool {
+        true
     }
 
     async fn resolve_transaction(&self, txid: &Txid) -> Option<bitcoin::Transaction> {

--- a/core/indexer/src/reactor/mock_bitcoin.rs
+++ b/core/indexer/src/reactor/mock_bitcoin.rs
@@ -70,7 +70,13 @@ impl MockBitcoin {
         for _ in 0..count {
             self.tx_counter += 1;
             let tx = make_tx(self.tx_counter);
-            events.push(MempoolEvent::Insert(tx.clone()));
+            let parsed = indexer_types::Transaction {
+                txid: tx.compute_txid(),
+                index: 0,
+                inputs: vec![],
+                op_return_data: Default::default(),
+            };
+            events.push(MempoolEvent::Insert(tx.clone(), parsed));
             self.mempool.push(tx);
         }
         events

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -544,7 +544,7 @@ impl<E: Executor> Reactor<E> {
                 if let Some(handle) = self.consensus_handle.as_mut() {
                     let txids: Vec<_> = block.transactions.iter().map(|tx| tx.txid).collect();
                     for txid in &txids {
-                        handle.state.mempool.remove(txid);
+                        handle.state.pending_transactions.remove(txid);
                     }
                 }
                 info!("Block {}/{} {}", block.height, target_height, block.hash);
@@ -568,6 +568,21 @@ impl<E: Executor> Reactor<E> {
                         .await
                         .context("handle_block failed (no consensus)")?;
                 }
+                // A pending block may be what we're waiting to propose
+                if let Some(handle) = self.consensus_handle.as_mut()
+                    && handle.state.pending_proposal.is_some()
+                {
+                    handle
+                        .state
+                        .try_fulfill_pending_proposal(
+                            &self.executor,
+                            &mut handle.channels,
+                            self.last_height,
+                            self.last_hash.unwrap_or(BlockHash::all_zeros()),
+                        )
+                        .await
+                        .context("try_fulfill_pending_proposal failed after block insert")?;
+                }
             }
             BlockEvent::Rollback { to_height } => {
                 info!(to_height, "Bitcoin rollback — truncating state");
@@ -590,6 +605,9 @@ impl<E: Executor> Reactor<E> {
 
     async fn run_event_loop(&mut self) -> Result<()> {
         self.ready_tx.take().map(|tx| tx.send(true));
+
+        let debounce_duration = std::time::Duration::from_millis(500);
+        let mut debounce_deadline: Option<tokio::time::Instant> = None;
 
         loop {
             // Drain pending block events before entering select
@@ -615,6 +633,13 @@ impl<E: Executor> Reactor<E> {
                 }
             };
 
+            let debounce_sleep = async {
+                match debounce_deadline {
+                    Some(deadline) => tokio::time::sleep_until(deadline).await,
+                    None => pending().await,
+                }
+            };
+
             select! {
                 _ = self.cancel_token.cancelled() => {
                     info!("Cancelled");
@@ -630,22 +655,38 @@ impl<E: Executor> Reactor<E> {
                         match event {
                             MempoolEvent::Sync(txs) => {
                                 let count = txs.len();
-                                handle.state.mempool.clear();
+                                handle.state.pending_transactions.clear();
                                 for tx in txs {
-                                    handle.state.mempool.insert(tx.compute_txid(), tx);
+                                    handle.state.pending_transactions.insert(tx.compute_txid(), tx);
                                 }
                                 info!("MempoolSync {}", count);
                             },
                             MempoolEvent::Insert(tx) => {
                                 let txid = tx.compute_txid();
-                                handle.state.mempool.insert(txid, tx);
+                                handle.state.pending_transactions.insert(txid, tx);
                                 debug!("MempoolInsert {}", txid);
                             },
                             MempoolEvent::Remove(txid) => {
-                                handle.state.mempool.remove(&txid);
+                                handle.state.pending_transactions.remove(&txid);
                                 debug!("MempoolRemove {}", txid);
                             },
                         }
+                        // Reset debounce timer if we're holding a pending proposal
+                        if handle.state.pending_proposal.is_some() {
+                            debounce_deadline = Some(tokio::time::Instant::now() + debounce_duration);
+                        }
+                    }
+                }
+                _ = debounce_sleep => {
+                    debounce_deadline = None;
+                    if let Some(handle) = self.consensus_handle.as_mut() {
+                        handle.state.try_fulfill_pending_proposal(
+                            &self.executor,
+                            &mut handle.channels,
+                            self.last_height,
+                            self.last_hash.unwrap_or(BlockHash::all_zeros()),
+                        ).await
+                        .context("try_fulfill_pending_proposal failed")?;
                     }
                 }
                 Some(msg) = consensus_rx => {

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -622,8 +622,7 @@ impl<E: Executor> Reactor<E> {
                 .as_ref()
                 .and_then(|h| h.state.pending_proposal.as_ref())
                 .map(|p| {
-                    let deadline =
-                        p.created_at + p.timeout.saturating_sub(std::time::Duration::from_secs(1));
+                    let deadline = p.hard_deadline();
                     let remaining = deadline.saturating_duration_since(std::time::Instant::now());
                     tokio::time::Instant::now() + remaining
                 });

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -622,8 +622,8 @@ impl<E: Executor> Reactor<E> {
                 .as_ref()
                 .and_then(|h| h.state.pending_proposal.as_ref())
                 .map(|p| {
-                    let deadline = p.created_at
-                        + p.timeout.saturating_sub(std::time::Duration::from_secs(1));
+                    let deadline =
+                        p.created_at + p.timeout.saturating_sub(std::time::Duration::from_secs(1));
                     let remaining = deadline.saturating_duration_since(std::time::Instant::now());
                     tokio::time::Instant::now() + remaining
                 });

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -617,6 +617,17 @@ impl<E: Executor> Reactor<E> {
                     .context("process_block_event failed (try_recv drain)")?;
             }
 
+            let hard_deadline_instant = self
+                .consensus_handle
+                .as_ref()
+                .and_then(|h| h.state.pending_proposal.as_ref())
+                .map(|p| {
+                    let deadline = p.created_at
+                        + p.timeout.saturating_sub(std::time::Duration::from_secs(1));
+                    let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+                    tokio::time::Instant::now() + remaining
+                });
+
             let simulate_rx = async {
                 if let Some(rx) = self.simulate_rx.as_mut() {
                     rx.recv().await
@@ -640,6 +651,13 @@ impl<E: Executor> Reactor<E> {
                 }
             };
 
+            let hard_deadline_sleep = async {
+                match hard_deadline_instant {
+                    Some(deadline) => tokio::time::sleep_until(deadline).await,
+                    None => pending().await,
+                }
+            };
+
             select! {
                 _ = self.cancel_token.cancelled() => {
                     info!("Cancelled");
@@ -656,14 +674,17 @@ impl<E: Executor> Reactor<E> {
                             MempoolEvent::Sync(txs) => {
                                 let count = txs.len();
                                 handle.state.pending_transactions.clear();
-                                for tx in txs {
-                                    handle.state.pending_transactions.insert(tx.compute_txid(), tx);
+                                for (raw, parsed) in txs {
+                                    handle.state.pending_transactions.insert(
+                                        raw.compute_txid(),
+                                        (raw, parsed),
+                                    );
                                 }
                                 info!("MempoolSync {}", count);
                             },
-                            MempoolEvent::Insert(tx) => {
+                            MempoolEvent::Insert(tx, parsed) => {
                                 let txid = tx.compute_txid();
-                                handle.state.pending_transactions.insert(txid, tx);
+                                handle.state.pending_transactions.insert(txid, (tx, parsed));
                                 debug!("MempoolInsert {}", txid);
                             },
                             MempoolEvent::Remove(txid) => {
@@ -686,7 +707,18 @@ impl<E: Executor> Reactor<E> {
                             self.last_height,
                             self.last_hash.unwrap_or(BlockHash::all_zeros()),
                         ).await
-                        .context("try_fulfill_pending_proposal failed")?;
+                        .context("try_fulfill_pending_proposal failed (debounce)")?;
+                    }
+                }
+                _ = hard_deadline_sleep => {
+                    if let Some(handle) = self.consensus_handle.as_mut() {
+                        handle.state.try_fulfill_pending_proposal(
+                            &self.executor,
+                            &mut handle.channels,
+                            self.last_height,
+                            self.last_hash.unwrap_or(BlockHash::all_zeros()),
+                        ).await
+                        .context("try_fulfill_pending_proposal failed (hard deadline)")?;
                     }
                 }
                 Some(msg) = consensus_rx => {

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -681,20 +681,22 @@ impl<E: Executor> Reactor<E> {
                                     );
                                 }
                                 info!("MempoolSync {}", count);
+                                if handle.state.pending_proposal.is_some() {
+                                    debounce_deadline = Some(tokio::time::Instant::now() + debounce_duration);
+                                }
                             },
                             MempoolEvent::Insert(tx, parsed) => {
                                 let txid = tx.compute_txid();
                                 handle.state.pending_transactions.insert(txid, (tx, parsed));
                                 debug!("MempoolInsert {}", txid);
+                                if handle.state.pending_proposal.is_some() {
+                                    debounce_deadline = Some(tokio::time::Instant::now() + debounce_duration);
+                                }
                             },
                             MempoolEvent::Remove(txid) => {
                                 handle.state.pending_transactions.remove(&txid);
                                 debug!("MempoolRemove {}", txid);
                             },
-                        }
-                        // Reset debounce timer if we're holding a pending proposal
-                        if handle.state.pending_proposal.is_some() {
-                            debounce_deadline = Some(tokio::time::Instant::now() + debounce_duration);
                         }
                     }
                 }

--- a/core/indexer/src/reactor/reactor_cluster_tests.rs
+++ b/core/indexer/src/reactor/reactor_cluster_tests.rs
@@ -317,7 +317,7 @@ impl ReactorCluster {
             )
             .await;
             state.timeouts = LinearTimeouts {
-                propose: Duration::from_millis(500),
+                propose: Duration::from_secs(10),
                 ..Default::default()
             };
             state.observation = Some(ObservationChannels {
@@ -784,7 +784,7 @@ async fn prod_reactor_missing_tx_invalidation() -> Result<()> {
     let all_txids: Vec<bitcoin::Txid> = mempool_events
         .iter()
         .filter_map(|e| match e {
-            MempoolEvent::Insert(tx) => Some(tx.compute_txid()),
+            MempoolEvent::Insert(tx, _) => Some(tx.compute_txid()),
             _ => None,
         })
         .collect();
@@ -970,7 +970,7 @@ async fn prod_reactor_batch_before_unbatched_at_same_anchor() -> Result<()> {
     let batch_txids: Vec<bitcoin::Txid> = mempool_events
         .iter()
         .filter_map(|e| match e {
-            MempoolEvent::Insert(tx) => Some(tx.compute_txid()),
+            MempoolEvent::Insert(tx, _) => Some(tx.compute_txid()),
             _ => None,
         })
         .collect();

--- a/core/indexer/src/reg_tester.rs
+++ b/core/indexer/src/reg_tester.rs
@@ -162,7 +162,7 @@ async fn run_kontor(
             .arg("--genesis-file")
             .arg(&c.genesis_file)
             .arg("--consensus-propose-timeout-ms")
-            .arg("500");
+            .arg("10000");
         for peer in &c.peers {
             cmd.arg("--consensus-peers").arg(peer);
         }

--- a/core/indexer/src/test_utils.rs
+++ b/core/indexer/src/test_utils.rs
@@ -706,7 +706,13 @@ pub mod reactor_harness {
 
         /// Send a mempool transaction.
         pub async fn send_mempool_tx(&self, tx: bitcoin::Transaction) {
-            let _ = self.mempool_tx.send(MempoolEvent::Insert(tx)).await;
+            let parsed = indexer_types::Transaction {
+                txid: tx.compute_txid(),
+                index: 0,
+                inputs: vec![],
+                op_return_data: Default::default(),
+            };
+            let _ = self.mempool_tx.send(MempoolEvent::Insert(tx, parsed)).await;
         }
 
         /// Wait for state events.

--- a/core/indexer/tests/contracts/file_storage_tests/native_filestorage_contract.rs
+++ b/core/indexer/tests/contracts/file_storage_tests/native_filestorage_contract.rs
@@ -33,9 +33,12 @@ async fn filestorage_defaults(runtime: &mut Runtime) -> Result<()> {
     assert_eq!(filestorage::get_blocks_per_year(runtime).await?, 52560);
     assert_eq!(filestorage::get_s_chal(runtime).await?, 100);
 
-    // With no generated challenges, this should be empty.
-    let active = filestorage::get_active_challenges(runtime).await?;
-    assert!(active.is_empty());
+    // In local mode, no challenges should exist yet.
+    // In regtest mode, prior tests on the shared cluster may have generated challenges.
+    if runtime.reg_tester().is_none() {
+        let active = filestorage::get_active_challenges(runtime).await?;
+        assert!(active.is_empty());
+    }
 
     // Unknown IDs should be safe.
     assert!(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes consensus proposal timing by holding `GetValue` replies and potentially proposing empty batches at a hard deadline, which can affect liveness and batching behavior. Also refactors transaction validation/parsing and mempool event payloads, touching core consensus/mempool pathways.
> 
> **Overview**
> Updates mempool handling so `MempoolEvent::Sync`/`Insert` carry both the raw `bitcoin::Transaction` and the parsed `indexer_types::Transaction`, and refactors the `Executor::validate_transaction` API to validate *pre-parsed* transactions while caching parsed results in `ConsensusState`.
> 
> Consensus proposal flow is changed to **hold `GetValue` replies** when there’s nothing to propose, then **debounce** and attempt to fulfill the proposal once mempool/block events arrive; if the wait approaches the propose timeout, it will **propose an empty batch** and record empty batches in the DB.
> 
> Sync/history code is optimized by adding `select_batches_in_range` and fetching decided values in bulk, and test/regtest defaults are adjusted (notably increasing propose timeout to `10s` and loosening a filestorage assertion in regtest).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0a7c965134735dc3ecc3803fbb15cdcba59d6b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->