### PR TITLE
Rename registry API to /signers and add BLS pubkey lookup

### DIFF
--- a/core/indexer-types/src/lib.rs
+++ b/core/indexer-types/src/lib.rs
@@ -575,11 +575,11 @@ pub fn op_return_data_bytes_to_json(bytes: Vec<u8>) -> String {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[ts(export, export_to = "../../../kontor-ts/src/bindings.d.ts")]
-pub struct RegistryEntryResponse {
+pub struct SignerResponse {
     #[ts(type = "number")]
     pub signer_id: u64,
-    pub x_only_pubkey: String,
+    pub x_only_pubkey: Option<String>,
     pub bls_pubkey: Option<Vec<u8>>,
-    #[ts(type = "number")]
-    pub next_nonce: u64,
+    #[ts(type = "number | null")]
+    pub next_nonce: Option<u64>,
 }

--- a/core/indexer/src/api/client.rs
+++ b/core/indexer/src/api/client.rs
@@ -1,7 +1,7 @@
 use anyhow::{Result, anyhow};
 use indexer_types::{
     ComposeOutputs, ComposeQuery, ContractResponse, ErrorResponse, Info, OpWithResult,
-    RegistryEntryResponse, ResultResponse, ResultRow, RevealOutputs, RevealQuery, TransactionHex,
+    ResultResponse, ResultRow, RevealOutputs, RevealQuery, SignerResponse, TransactionHex,
     ViewExpr, ViewResult,
 };
 use reqwest::{Client as HttpClient, ClientBuilder, Response};
@@ -148,10 +148,10 @@ impl Client {
         .await
     }
 
-    pub async fn registry_entry(&self, pubkey_or_id: &str) -> Result<RegistryEntryResponse> {
+    pub async fn signer(&self, identifier: &str) -> Result<SignerResponse> {
         Self::handle_response(
             self.client
-                .get(format!("{}/registry/entry/{}", &self.url, pubkey_or_id))
+                .get(format!("{}/signers/{}", &self.url, identifier))
                 .send()
                 .await?,
         )

--- a/core/indexer/src/api/handlers.rs
+++ b/core/indexer/src/api/handlers.rs
@@ -7,7 +7,7 @@ use axum::{
 use bitcoin::consensus::encode;
 use indexer_types::{
     BlockRow, CommitOutputs, ComposeOutputs, ComposeQuery, ContractListRow, ContractResponse, Info,
-    OpWithResult, PaginatedResponse, RegistryEntryResponse, ResultRow, RevealOutputs, RevealQuery,
+    OpWithResult, PaginatedResponse, ResultRow, RevealOutputs, RevealQuery, SignerResponse,
     TransactionHex, TransactionRow, ViewExpr, ViewResult,
 };
 
@@ -15,7 +15,9 @@ use crate::{
     api::compose::reveal_inputs_from_query,
     block::inspect,
     built_info,
-    database::queries::{get_signer_entry, get_signer_entry_by_id},
+    database::queries::{
+        get_signer_entry_by_bls_pubkey, get_signer_entry_by_id, get_signer_entry_by_x_only_pubkey,
+    },
     database::{
         queries::{
             self, get_blocks_paginated, get_checkpoint_latest, get_op_result,
@@ -324,37 +326,48 @@ pub async fn get_result(
         .into())
 }
 
-pub async fn get_registry_entry(
+/// Identifier accepted by `get_signer`. Disambiguated by shape — numeric is a
+/// signer_id, 64-char hex is an x-only pubkey, 192-char hex is a BLS pubkey.
+fn is_hex_of_len(s: &str, len: usize) -> bool {
+    s.len() == len && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+pub async fn get_signer(
     Path(identifier): Path<String>,
     State(env): State<Env>,
-) -> Result<RegistryEntryResponse> {
+) -> Result<SignerResponse> {
     if !*env.available.read().await {
         return Err(HttpError::ServiceUnavailable("Indexer is not available".to_string()).into());
     }
     let runtime = env.runtime_pool.get().await?;
-
     let conn = runtime.get_storage_conn();
+
     let entry = if let Ok(signer_id) = identifier.parse::<u64>() {
-        get_signer_entry_by_id(&conn, signer_id as i64)
-            .await
-            .map_err(|e| HttpError::BadRequest(e.to_string()))?
+        get_signer_entry_by_id(&conn, signer_id as i64).await
+    } else if is_hex_of_len(&identifier, 64) {
+        get_signer_entry_by_x_only_pubkey(&conn, &identifier).await
+    } else if is_hex_of_len(&identifier, 192) {
+        let bytes = hex::decode(&identifier)
+            .map_err(|e| HttpError::BadRequest(format!("invalid bls_pubkey hex: {e}")))?;
+        get_signer_entry_by_bls_pubkey(&conn, &bytes).await
     } else {
-        get_signer_entry(&conn, &identifier)
-            .await
-            .map_err(|e| HttpError::BadRequest(e.to_string()))?
+        return Err(HttpError::BadRequest(
+            "identifier must be signer_id (numeric), x-only pubkey (64 hex), or bls pubkey (192 hex)"
+                .to_string(),
+        )
+        .into());
     };
+    let entry = entry.map_err(|e| HttpError::BadRequest(e.to_string()))?;
 
     match entry {
-        Some(e) => Ok(RegistryEntryResponse {
+        Some(e) => Ok(SignerResponse {
             signer_id: e.signer_id as u64,
             x_only_pubkey: e.x_only_pubkey,
             bls_pubkey: e.bls_pubkey,
-            next_nonce: e.next_nonce as u64,
+            next_nonce: e.next_nonce.map(|n| n as u64),
         }
         .into()),
-        None => {
-            Err(HttpError::NotFound(format!("registry entry not found for: {}", identifier)).into())
-        }
+        None => Err(HttpError::NotFound(format!("signer not found for: {identifier}")).into()),
     }
 }
 
@@ -362,9 +375,9 @@ pub async fn get_registry_entry(
 mod tests {
     use crate::runtime::wit::Signer;
     use crate::{
-        api::{Env, handlers::get_registry_entry},
+        api::{Env, handlers::get_signer},
         bls::RegistrationProof,
-        database::queries::{get_signer_entry, insert_block},
+        database::queries::{get_signer_entry_by_x_only_pubkey, insert_block},
         runtime::{ComponentCache, Runtime, Storage},
         test_utils::new_test_db,
     };
@@ -373,13 +386,13 @@ mod tests {
     use axum_test::{TestResponse, TestServer};
     use bitcoin::key::rand::RngCore;
     use bitcoin::key::{Keypair, Secp256k1, rand};
-    use indexer_types::{BlockRow, RegistryEntryResponse};
+    use indexer_types::{BlockRow, SignerResponse};
     use serde::{Deserialize, Serialize};
     use tempfile::TempDir;
 
     #[derive(Debug, Serialize, Deserialize)]
-    struct RegistryResponse {
-        result: RegistryEntryResponse,
+    struct SignerResponseWrapper {
+        result: SignerResponse,
     }
 
     struct RegisteredUser {
@@ -410,7 +423,7 @@ mod tests {
             .await?;
 
         let conn = runtime.get_storage_conn();
-        let entry = get_signer_entry(&conn, &x_only.to_string())
+        let entry = get_signer_entry_by_x_only_pubkey(&conn, &x_only.to_string())
             .await
             .map_err(|e| anyhow!("{e}"))?
             .expect("signer entry must exist after registration");
@@ -455,80 +468,109 @@ mod tests {
         let env = Env::new_test(reader, db_dir.path(), db_name).await?;
 
         let app = Router::new()
-            .route(
-                "/api/registry/entry/{pubkey_or_id}",
-                get(get_registry_entry),
-            )
+            .route("/api/signers/{identifier}", get(get_signer))
             .with_state(env);
 
         Ok((app, vec![user0, user1], db_dir))
     }
 
     #[tokio::test]
-    async fn test_get_registry_entry_by_pubkey() -> Result<()> {
+    async fn test_get_signer_by_pubkey() -> Result<()> {
         let (app, users, _db) = create_test_app().await?;
         let server = TestServer::new(app);
 
         let response: TestResponse = server
-            .get(&format!("/api/registry/entry/{}", users[0].x_only_pubkey))
+            .get(&format!("/api/signers/{}", users[0].x_only_pubkey))
             .await;
         assert_eq!(response.status_code(), StatusCode::OK);
 
-        let result: RegistryResponse = serde_json::from_slice(response.as_bytes())?;
+        let result: SignerResponseWrapper = serde_json::from_slice(response.as_bytes())?;
         assert_eq!(result.result.signer_id, users[0].signer_id);
-        assert_eq!(result.result.x_only_pubkey, users[0].x_only_pubkey);
+        assert_eq!(
+            result.result.x_only_pubkey.as_deref(),
+            Some(users[0].x_only_pubkey.as_str())
+        );
         assert_eq!(result.result.bls_pubkey, Some(users[0].bls_pubkey.clone()));
-        assert_eq!(result.result.next_nonce, 0);
+        assert_eq!(result.result.next_nonce, Some(0));
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_get_registry_entry_by_signer_id() -> Result<()> {
+    async fn test_get_signer_by_signer_id() -> Result<()> {
         let (app, users, _db) = create_test_app().await?;
         let server = TestServer::new(app);
 
         let response: TestResponse = server
-            .get(&format!("/api/registry/entry/{}", users[0].signer_id))
+            .get(&format!("/api/signers/{}", users[0].signer_id))
             .await;
         assert_eq!(response.status_code(), StatusCode::OK);
 
-        let result: RegistryResponse = serde_json::from_slice(response.as_bytes())?;
+        let result: SignerResponseWrapper = serde_json::from_slice(response.as_bytes())?;
         assert_eq!(result.result.signer_id, users[0].signer_id);
-        assert_eq!(result.result.x_only_pubkey, users[0].x_only_pubkey);
+        assert_eq!(
+            result.result.x_only_pubkey.as_deref(),
+            Some(users[0].x_only_pubkey.as_str())
+        );
         assert_eq!(result.result.bls_pubkey, Some(users[0].bls_pubkey.clone()));
-        assert_eq!(result.result.next_nonce, 0);
+        assert_eq!(result.result.next_nonce, Some(0));
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_get_registry_entry_not_found_by_pubkey() -> Result<()> {
+    async fn test_get_signer_by_bls_pubkey() -> Result<()> {
+        let (app, users, _db) = create_test_app().await?;
+        let server = TestServer::new(app);
+
+        let bls_hex = hex::encode(&users[0].bls_pubkey);
+        let response: TestResponse = server.get(&format!("/api/signers/{bls_hex}")).await;
+        assert_eq!(response.status_code(), StatusCode::OK);
+
+        let result: SignerResponseWrapper = serde_json::from_slice(response.as_bytes())?;
+        assert_eq!(result.result.signer_id, users[0].signer_id);
+        assert_eq!(result.result.bls_pubkey, Some(users[0].bls_pubkey.clone()));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_get_signer_not_found_by_pubkey() -> Result<()> {
         let (app, _, _db) = create_test_app().await?;
         let server = TestServer::new(app);
 
         let fake_xonly = "ab".repeat(32);
-        let response: TestResponse = server
-            .get(&format!("/api/registry/entry/{}", fake_xonly))
-            .await;
+        let response: TestResponse = server.get(&format!("/api/signers/{fake_xonly}")).await;
         assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
 
         let error_body = response.text();
-        assert!(error_body.contains("registry entry not found"));
+        assert!(error_body.contains("signer not found"));
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_get_registry_entry_not_found_by_id() -> Result<()> {
+    async fn test_get_signer_not_found_by_id() -> Result<()> {
         let (app, _, _db) = create_test_app().await?;
         let server = TestServer::new(app);
 
-        let response: TestResponse = server.get("/api/registry/entry/999999").await;
+        let response: TestResponse = server.get("/api/signers/999999").await;
         assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
 
         let error_body = response.text();
-        assert!(error_body.contains("registry entry not found"));
+        assert!(error_body.contains("signer not found"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_get_signer_invalid_identifier() -> Result<()> {
+        let (app, _, _db) = create_test_app().await?;
+        let server = TestServer::new(app);
+
+        // Not numeric, not 64 or 192 hex chars.
+        let response: TestResponse = server.get("/api/signers/notapubkey").await;
+        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
 
         Ok(())
     }
@@ -539,17 +581,17 @@ mod tests {
         let server = TestServer::new(app);
 
         let by_pk: TestResponse = server
-            .get(&format!("/api/registry/entry/{}", users[0].x_only_pubkey))
+            .get(&format!("/api/signers/{}", users[0].x_only_pubkey))
             .await;
         let by_id: TestResponse = server
-            .get(&format!("/api/registry/entry/{}", users[0].signer_id))
+            .get(&format!("/api/signers/{}", users[0].signer_id))
             .await;
 
         assert_eq!(by_pk.status_code(), StatusCode::OK);
         assert_eq!(by_id.status_code(), StatusCode::OK);
 
-        let r_pk: RegistryResponse = serde_json::from_slice(by_pk.as_bytes())?;
-        let r_id: RegistryResponse = serde_json::from_slice(by_id.as_bytes())?;
+        let r_pk: SignerResponseWrapper = serde_json::from_slice(by_pk.as_bytes())?;
+        let r_id: SignerResponseWrapper = serde_json::from_slice(by_id.as_bytes())?;
 
         assert_eq!(r_pk.result.signer_id, r_id.result.signer_id);
         assert_eq!(r_pk.result.x_only_pubkey, r_id.result.x_only_pubkey);
@@ -565,26 +607,32 @@ mod tests {
         let server = TestServer::new(app);
 
         let response: TestResponse = server
-            .get(&format!("/api/registry/entry/{}", users[1].x_only_pubkey))
+            .get(&format!("/api/signers/{}", users[1].x_only_pubkey))
             .await;
         assert_eq!(response.status_code(), StatusCode::OK);
 
-        let result: RegistryResponse = serde_json::from_slice(response.as_bytes())?;
+        let result: SignerResponseWrapper = serde_json::from_slice(response.as_bytes())?;
         assert_eq!(result.result.signer_id, users[1].signer_id);
-        assert_eq!(result.result.x_only_pubkey, users[1].x_only_pubkey);
+        assert_eq!(
+            result.result.x_only_pubkey.as_deref(),
+            Some(users[1].x_only_pubkey.as_str())
+        );
         assert_eq!(result.result.bls_pubkey, Some(users[1].bls_pubkey.clone()));
-        assert_eq!(result.result.next_nonce, 0);
+        assert_eq!(result.result.next_nonce, Some(0));
         assert_eq!(users[1].signer_id, users[0].signer_id + 1);
 
         let by_id: TestResponse = server
-            .get(&format!("/api/registry/entry/{}", users[1].signer_id))
+            .get(&format!("/api/signers/{}", users[1].signer_id))
             .await;
         assert_eq!(by_id.status_code(), StatusCode::OK);
 
-        let by_id_result: RegistryResponse = serde_json::from_slice(by_id.as_bytes())?;
+        let by_id_result: SignerResponseWrapper = serde_json::from_slice(by_id.as_bytes())?;
         assert_eq!(by_id_result.result.signer_id, users[1].signer_id);
-        assert_eq!(by_id_result.result.x_only_pubkey, users[1].x_only_pubkey);
-        assert_eq!(by_id_result.result.next_nonce, 0);
+        assert_eq!(
+            by_id_result.result.x_only_pubkey.as_deref(),
+            Some(users[1].x_only_pubkey.as_str())
+        );
+        assert_eq!(by_id_result.result.next_nonce, Some(0));
 
         Ok(())
     }
@@ -595,24 +643,24 @@ mod tests {
         let server = TestServer::new(app);
 
         let resp0: TestResponse = server
-            .get(&format!("/api/registry/entry/{}", users[0].signer_id))
+            .get(&format!("/api/signers/{}", users[0].signer_id))
             .await;
         let resp1: TestResponse = server
-            .get(&format!("/api/registry/entry/{}", users[1].signer_id))
+            .get(&format!("/api/signers/{}", users[1].signer_id))
             .await;
 
         assert_eq!(resp0.status_code(), StatusCode::OK);
         assert_eq!(resp1.status_code(), StatusCode::OK);
 
-        let r0: RegistryResponse = serde_json::from_slice(resp0.as_bytes())?;
-        let r1: RegistryResponse = serde_json::from_slice(resp1.as_bytes())?;
+        let r0: SignerResponseWrapper = serde_json::from_slice(resp0.as_bytes())?;
+        let r1: SignerResponseWrapper = serde_json::from_slice(resp1.as_bytes())?;
 
         assert_ne!(r0.result.x_only_pubkey, r1.result.x_only_pubkey);
         assert_ne!(r0.result.bls_pubkey, r1.result.bls_pubkey);
         assert_eq!(r0.result.signer_id, users[0].signer_id);
         assert_eq!(r1.result.signer_id, users[1].signer_id);
-        assert_eq!(r0.result.next_nonce, 0);
-        assert_eq!(r1.result.next_nonce, 0);
+        assert_eq!(r0.result.next_nonce, Some(0));
+        assert_eq!(r1.result.next_nonce, Some(0));
 
         Ok(())
     }
@@ -651,7 +699,7 @@ mod tests {
         let entry = get_signer_entry_by_id(&conn, user.signer_id as i64)
             .await?
             .expect("entry must exist");
-        assert_eq!(entry.next_nonce, 0);
+        assert_eq!(entry.next_nonce, Some(0));
 
         insert_block(
             &conn,
@@ -668,7 +716,7 @@ mod tests {
         let entry = get_signer_entry_by_id(&conn, user.signer_id as i64)
             .await?
             .expect("entry must exist after advance");
-        assert_eq!(entry.next_nonce, 1, "nonce must be 1 after advance");
+        assert_eq!(entry.next_nonce, Some(1), "nonce must be 1 after advance");
 
         rollback_to_height(&conn, 1).await?;
 
@@ -676,7 +724,8 @@ mod tests {
             .await?
             .expect("entry must survive rollback (registered at height 1)");
         assert_eq!(
-            entry.next_nonce, 0,
+            entry.next_nonce,
+            Some(0),
             "nonce must revert to 0 after rolling back height 2"
         );
 
@@ -696,7 +745,8 @@ mod tests {
             .await?
             .expect("entry must exist after re-advance");
         assert_eq!(
-            entry.next_nonce, 1,
+            entry.next_nonce,
+            Some(1),
             "nonce must advance again from 0 after reorg"
         );
 

--- a/core/indexer/src/api/router.rs
+++ b/core/indexer/src/api/router.rs
@@ -19,8 +19,8 @@ use tower_http::{
 use tracing::{Level, Span, error, field, info, span};
 
 use crate::api::handlers::{
-    get_block_transactions, get_blocks, get_contract, get_contracts, get_index, get_registry_entry,
-    get_result, get_results, get_transaction, get_transaction_inspect, get_transactions,
+    get_block_transactions, get_blocks, get_contract, get_contracts, get_index, get_result,
+    get_results, get_signer, get_transaction, get_transaction_inspect, get_transactions,
     post_compose, post_contract, post_simulate, post_transaction_hex_inspect, stop,
 };
 
@@ -131,10 +131,7 @@ pub fn new(context: Env) -> Router {
                         .route("/", get(get_results))
                         .route("/{id}", get(get_result)),
                 )
-                .nest(
-                    "/registry",
-                    Router::new().route("/entry/{pubkey_or_id}", get(get_registry_entry)),
-                ),
+                .route("/signers/{identifier}", get(get_signer)),
         )
         .layer(
             ServiceBuilder::new()

--- a/core/indexer/src/block.rs
+++ b/core/indexer/src/block.rs
@@ -135,7 +135,7 @@ pub async fn inspect(
         let signer_ids: Vec<u64> = match &input.insts.aggregate {
             Some(agg) => agg.signer_ids.clone(),
             None => {
-                let id = crate::database::queries::get_signer_entry(
+                let id = crate::database::queries::get_signer_entry_by_x_only_pubkey(
                     conn,
                     &input.x_only_pubkey.to_string(),
                 )

--- a/core/indexer/src/bls.rs
+++ b/core/indexer/src/bls.rs
@@ -172,8 +172,10 @@ impl SignerResolver {
         let entry = get_signer_entry_by_id(&conn, signer_id as i64)
             .await?
             .ok_or_else(|| anyhow!("unknown signer_id {signer_id}"))?;
-        self.signer_map
-            .insert(signer_id, entry.x_only_pubkey.clone());
+        let x_only_pubkey = entry.x_only_pubkey.clone().ok_or_else(|| {
+            anyhow!("signer_id {signer_id} is not a user signer (no x_only_pubkey)")
+        })?;
+        self.signer_map.insert(signer_id, x_only_pubkey);
         let raw_bytes = entry
             .bls_pubkey
             .ok_or_else(|| anyhow!("signer_id {signer_id} has no BLS pubkey registered"))?;

--- a/core/indexer/src/database/queries.rs
+++ b/core/indexer/src/database/queries.rs
@@ -1433,29 +1433,28 @@ pub async fn get_contract_signer_id(
     Ok(rows.next().await?.map(|r| r.get(0)).transpose()?)
 }
 
-pub async fn get_signer_entry(
+/// Shared SELECT + JOIN body for signer entry lookups. Uses LEFT JOINs so
+/// core and contract signers (which lack x_only_pubkeys/nonces rows) are
+/// returned with NULL fields rather than filtered out.
+const SIGNER_ENTRY_SELECT: &str = r#"SELECT
+        s.id AS signer_id,
+        p.x_only_pubkey,
+        b.bls_pubkey,
+        n.next_nonce
+    FROM signers s
+    LEFT JOIN x_only_pubkeys p ON p.signer_id = s.id
+        AND p.height = (SELECT MAX(height) FROM x_only_pubkeys WHERE signer_id = s.id)
+    LEFT JOIN bls_keys b ON b.signer_id = s.id
+        AND b.height = (SELECT MAX(height) FROM bls_keys WHERE signer_id = s.id)
+    LEFT JOIN nonces n ON n.signer_id = s.id
+        AND n.height = (SELECT MAX(height) FROM nonces WHERE signer_id = s.id)"#;
+
+pub async fn get_signer_entry_by_x_only_pubkey(
     conn: &Connection,
     x_only_pubkey: &str,
 ) -> Result<Option<SignerEntry>, Error> {
-    let mut rows = conn
-        .query(
-            r#"SELECT
-                s.id AS signer_id,
-                p.x_only_pubkey,
-                b.bls_pubkey,
-                n.next_nonce
-            FROM signers s
-            JOIN x_only_pubkeys p ON p.signer_id = s.id
-                AND p.height = (SELECT MAX(height) FROM x_only_pubkeys WHERE signer_id = s.id)
-            LEFT JOIN bls_keys b ON b.signer_id = s.id
-                AND b.height = (SELECT MAX(height) FROM bls_keys WHERE signer_id = s.id)
-            JOIN nonces n ON n.signer_id = s.id
-                AND n.height = (SELECT MAX(height) FROM nonces WHERE signer_id = s.id)
-            WHERE p.x_only_pubkey = ?"#,
-            params![x_only_pubkey],
-        )
-        .await?;
-
+    let sql = format!("{SIGNER_ENTRY_SELECT} WHERE p.x_only_pubkey = ?");
+    let mut rows = conn.query(&sql, params![x_only_pubkey]).await?;
     Ok(rows.next().await?.map(|r| from_row(&r)).transpose()?)
 }
 
@@ -1463,26 +1462,29 @@ pub async fn get_signer_entry_by_id(
     conn: &Connection,
     signer_id: i64,
 ) -> Result<Option<SignerEntry>, Error> {
+    let sql = format!("{SIGNER_ENTRY_SELECT} WHERE s.id = ?");
+    let mut rows = conn.query(&sql, params![signer_id]).await?;
+    Ok(rows.next().await?.map(|r| from_row(&r)).transpose()?)
+}
+
+/// Look up a signer by BLS pubkey. Policy allows only one signer per BLS
+/// pubkey (enforced at registration in the runtime), but the schema permits
+/// historical rows if rotation is ever added — so pick the most recent.
+pub async fn get_signer_entry_by_bls_pubkey(
+    conn: &Connection,
+    bls_pubkey: &[u8],
+) -> Result<Option<SignerEntry>, Error> {
     let mut rows = conn
         .query(
-            r#"SELECT
-                s.id AS signer_id,
-                p.x_only_pubkey,
-                b.bls_pubkey,
-                n.next_nonce
-            FROM signers s
-            JOIN x_only_pubkeys p ON p.signer_id = s.id
-                AND p.height = (SELECT MAX(height) FROM x_only_pubkeys WHERE signer_id = s.id)
-            LEFT JOIN bls_keys b ON b.signer_id = s.id
-                AND b.height = (SELECT MAX(height) FROM bls_keys WHERE signer_id = s.id)
-            JOIN nonces n ON n.signer_id = s.id
-                AND n.height = (SELECT MAX(height) FROM nonces WHERE signer_id = s.id)
-            WHERE s.id = ?"#,
-            params![signer_id],
+            "SELECT signer_id FROM bls_keys WHERE bls_pubkey = ? ORDER BY height DESC LIMIT 1",
+            params![bls_pubkey.to_vec()],
         )
         .await?;
-
-    Ok(rows.next().await?.map(|r| from_row(&r)).transpose()?)
+    let signer_id: i64 = match rows.next().await? {
+        Some(row) => row.get(0)?,
+        None => return Ok(None),
+    };
+    get_signer_entry_by_id(conn, signer_id).await
 }
 
 #[cfg(test)]
@@ -3792,14 +3794,16 @@ mod tests {
         let bls_key = vec![1u8; 48];
         row.register_bls_key(&conn, &bls_key, 1).await?;
 
-        let entry = get_signer_entry(&conn, pubkey).await?.unwrap();
+        let entry = get_signer_entry_by_x_only_pubkey(&conn, pubkey)
+            .await?
+            .unwrap();
         assert_eq!(entry.bls_pubkey, Some(bls_key));
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_get_signer_entry() -> Result<()> {
+    async fn test_get_signer_entry_by_x_only_pubkey() -> Result<()> {
         let (_, writer, _temp_dir) = new_test_db().await?;
         let conn = writer.connection();
         setup_block(&conn, 1).await?;
@@ -3807,11 +3811,13 @@ mod tests {
         let pubkey = "aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233";
         let row = get_or_create_identity(&conn, pubkey, 1).await?;
 
-        let entry = get_signer_entry(&conn, pubkey).await?.unwrap();
+        let entry = get_signer_entry_by_x_only_pubkey(&conn, pubkey)
+            .await?
+            .unwrap();
         assert_eq!(entry.signer_id, row.signer_id());
-        assert_eq!(entry.x_only_pubkey, pubkey);
+        assert_eq!(entry.x_only_pubkey.as_deref(), Some(pubkey));
         assert_eq!(entry.bls_pubkey, None);
-        assert_eq!(entry.next_nonce, 0);
+        assert_eq!(entry.next_nonce, Some(0));
 
         Ok(())
     }
@@ -3828,8 +3834,53 @@ mod tests {
         let entry = get_signer_entry_by_id(&conn, row.signer_id())
             .await?
             .unwrap();
-        assert_eq!(entry.x_only_pubkey, pubkey);
-        assert_eq!(entry.next_nonce, 0);
+        assert_eq!(entry.x_only_pubkey.as_deref(), Some(pubkey));
+        assert_eq!(entry.next_nonce, Some(0));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_get_signer_entry_by_bls_pubkey() -> Result<()> {
+        let (_, writer, _temp_dir) = new_test_db().await?;
+        let conn = writer.connection();
+        setup_block(&conn, 1).await?;
+
+        let pubkey = "aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233";
+        let row = get_or_create_identity(&conn, pubkey, 1).await?;
+        let bls_key = vec![7u8; 48];
+        row.register_bls_key(&conn, &bls_key, 1).await?;
+
+        let entry = get_signer_entry_by_bls_pubkey(&conn, &bls_key)
+            .await?
+            .unwrap();
+        assert_eq!(entry.signer_id, row.signer_id());
+        assert_eq!(entry.bls_pubkey, Some(bls_key));
+
+        let missing = get_signer_entry_by_bls_pubkey(&conn, &[0u8; 48]).await?;
+        assert!(missing.is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_get_signer_entry_core_and_contract() -> Result<()> {
+        let (_, writer, _temp_dir) = new_test_db().await?;
+        let conn = writer.connection();
+        setup_block(&conn, 0).await?;
+        setup_block(&conn, 1).await?;
+
+        let core_id = create_core_signer(&conn).await?;
+        let core = get_signer_entry_by_id(&conn, core_id).await?.unwrap();
+        assert_eq!(core.x_only_pubkey, None);
+        assert_eq!(core.bls_pubkey, None);
+        assert_eq!(core.next_nonce, None);
+
+        let contract_id = create_contract_signer(&conn, 1).await?;
+        let contract = get_signer_entry_by_id(&conn, contract_id).await?.unwrap();
+        assert_eq!(contract.x_only_pubkey, None);
+        assert_eq!(contract.bls_pubkey, None);
+        assert_eq!(contract.next_nonce, None);
 
         Ok(())
     }
@@ -3850,13 +3901,15 @@ mod tests {
         // Rollback to height 2 — should remove bls_key (height 3) but keep nonce (height 2)
         rollback_to_height(&conn, 2).await?;
 
-        let entry = get_signer_entry(&conn, pubkey).await?.unwrap();
+        let entry = get_signer_entry_by_x_only_pubkey(&conn, pubkey)
+            .await?
+            .unwrap();
         assert_eq!(entry.bls_pubkey, None);
-        assert_eq!(entry.next_nonce, 1);
+        assert_eq!(entry.next_nonce, Some(1));
 
         // Rollback to height 0 — should remove everything
         rollback_to_height(&conn, 0).await?;
-        let entry = get_signer_entry(&conn, pubkey).await?;
+        let entry = get_signer_entry_by_x_only_pubkey(&conn, pubkey).await?;
         assert!(entry.is_none());
 
         Ok(())

--- a/core/indexer/src/database/types.rs
+++ b/core/indexer/src/database/types.rs
@@ -102,9 +102,9 @@ impl Identity {
 #[derive(Debug, Clone, Deserialize)]
 pub struct SignerEntry {
     pub signer_id: i64,
-    pub x_only_pubkey: String,
+    pub x_only_pubkey: Option<String>,
     pub bls_pubkey: Option<Vec<u8>>,
-    pub next_nonce: i64,
+    pub next_nonce: Option<i64>,
 }
 
 #[derive(Debug, Clone)]

--- a/core/indexer/src/reg_tester.rs
+++ b/core/indexer/src/reg_tester.rs
@@ -587,14 +587,14 @@ impl RegTester {
     }
 
     pub async fn get_signer_id(&self, xonly: &str) -> Result<Option<u64>> {
-        match self.kontor_client().await.registry_entry(xonly).await {
+        match self.kontor_client().await.signer(xonly).await {
             Ok(entry) => Ok(Some(entry.signer_id)),
             Err(_) => Ok(None),
         }
     }
 
     pub async fn get_bls_pubkey(&self, xonly: &str) -> Result<Option<Vec<u8>>> {
-        match self.kontor_client().await.registry_entry(xonly).await {
+        match self.kontor_client().await.signer(xonly).await {
             Ok(entry) => Ok(entry.bls_pubkey),
             Err(_) => Ok(None),
         }
@@ -602,14 +602,9 @@ impl RegTester {
 
     pub async fn get_signer_entry(
         &self,
-        pubkey_or_id: &str,
-    ) -> Result<Option<indexer_types::RegistryEntryResponse>> {
-        match self
-            .kontor_client()
-            .await
-            .registry_entry(pubkey_or_id)
-            .await
-        {
+        identifier: &str,
+    ) -> Result<Option<indexer_types::SignerResponse>> {
+        match self.kontor_client().await.signer(identifier).await {
             Ok(entry) => Ok(Some(entry)),
             Err(_) => Ok(None),
         }

--- a/core/indexer/tests/contracts/bls_bulk_compose.rs
+++ b/core/indexer/tests/contracts/bls_bulk_compose.rs
@@ -158,18 +158,12 @@ async fn bls_bulk_compose_and_execute_regtest() -> Result<()> {
     let decoded1 = arith::wave::eval_parse_return_expr(v1);
     assert_eq!(decoded1.value, 18);
     assert_eq!(
-        client
-            .registry_entry(&signer1_id.to_string())
-            .await?
-            .next_nonce,
-        1
+        client.signer(&signer1_id.to_string()).await?.next_nonce,
+        Some(1)
     );
     assert_eq!(
-        client
-            .registry_entry(&signer2_id.to_string())
-            .await?
-            .next_nonce,
-        1
+        client.signer(&signer2_id.to_string()).await?.next_nonce,
+        Some(1)
     );
 
     // The contract's last_op should reflect the *second* inner call.
@@ -264,7 +258,8 @@ async fn bls_bulk_unknown_signer_id_rejects_bundle_regtest() -> Result<()> {
     let entry = rt.get_signer_entry(&signer_id.to_string()).await?;
     let entry = entry.ok_or_else(|| anyhow!("missing registry entry after rejection"))?;
     assert_eq!(
-        entry.next_nonce, 0,
+        entry.next_nonce,
+        Some(0),
         "unknown signer rejection must not advance nonce"
     );
     Ok(())

--- a/core/indexer/tests/contracts/bls_replay_protection.rs
+++ b/core/indexer/tests/contracts/bls_replay_protection.rs
@@ -116,11 +116,8 @@ async fn bls_bulk_duplicate_nonce_within_bundle_skips_op_regtest() -> Result<()>
     // Op1 (duplicate nonce=0) was skipped; nonce advanced to 1 from op0 only.
     let client = rt.kontor_client().await;
     assert_eq!(
-        client
-            .registry_entry(&signer_id.to_string())
-            .await?
-            .next_nonce,
-        1
+        client.signer(&signer_id.to_string()).await?.next_nonce,
+        Some(1)
     );
 
     // Follow-up op must use nonce=1 (op0 consumed nonce=0).
@@ -234,11 +231,8 @@ async fn bls_bulk_replay_nonce_across_blocks_rejects_regtest() -> Result<()> {
     // Nonce stays at 1 (only the first bundle's op consumed it).
     let client = rt.kontor_client().await;
     assert_eq!(
-        client
-            .registry_entry(&signer_id.to_string())
-            .await?
-            .next_nonce,
-        1
+        client.signer(&signer_id.to_string()).await?.next_nonce,
+        Some(1)
     );
 
     Ok(())
@@ -283,11 +277,8 @@ async fn bls_bulk_failed_execution_still_consumes_nonce_regtest() -> Result<()> 
 
     let client = rt.kontor_client().await;
     assert_eq!(
-        client
-            .registry_entry(&signer_id.to_string())
-            .await?
-            .next_nonce,
-        1
+        client.signer(&signer_id.to_string()).await?.next_nonce,
+        Some(1)
     );
 
     let arith_bytes = runtime
@@ -339,11 +330,8 @@ async fn bls_bulk_failed_execution_still_consumes_nonce_regtest() -> Result<()> 
     let decoded = arith::wave::eval_parse_return_expr(v);
     assert_eq!(decoded.value, 12);
     assert_eq!(
-        client
-            .registry_entry(&signer_id.to_string())
-            .await?
-            .next_nonce,
-        2
+        client.signer(&signer_id.to_string()).await?.next_nonce,
+        Some(2)
     );
 
     Ok(())
@@ -456,18 +444,12 @@ async fn bls_bulk_interleaved_multi_signer_nonces_advance_independently_regtest(
     let decoded3 = arith::wave::eval_parse_return_expr(v3);
     assert_eq!(decoded3.value, 11);
     assert_eq!(
-        client
-            .registry_entry(&signer1_id.to_string())
-            .await?
-            .next_nonce,
-        2
+        client.signer(&signer1_id.to_string()).await?.next_nonce,
+        Some(2)
     );
     assert_eq!(
-        client
-            .registry_entry(&signer2_id.to_string())
-            .await?
-            .next_nonce,
-        2
+        client.signer(&signer2_id.to_string()).await?.next_nonce,
+        Some(2)
     );
 
     Ok(())
@@ -509,11 +491,8 @@ async fn bls_bulk_out_of_order_nonce_skips_op_regtest() -> Result<()> {
 
     let client = rt.kontor_client().await;
     assert_eq!(
-        client
-            .registry_entry(&signer_id.to_string())
-            .await?
-            .next_nonce,
-        0,
+        client.signer(&signer_id.to_string()).await?.next_nonce,
+        Some(0),
         "precondition: nonce starts at 0"
     );
 
@@ -547,11 +526,8 @@ async fn bls_bulk_out_of_order_nonce_skips_op_regtest() -> Result<()> {
     let decoded = arith::wave::eval_parse_return_expr(v);
     assert_eq!(decoded.value, 42);
     assert_eq!(
-        client
-            .registry_entry(&signer_id.to_string())
-            .await?
-            .next_nonce,
-        1,
+        client.signer(&signer_id.to_string()).await?.next_nonce,
+        Some(1),
         "nonce must advance after valid op"
     );
 
@@ -578,11 +554,8 @@ async fn bls_bulk_out_of_order_nonce_skips_op_regtest() -> Result<()> {
 
     // Nonce must remain at 1 — the replayed op was rejected.
     assert_eq!(
-        client
-            .registry_entry(&signer_id.to_string())
-            .await?
-            .next_nonce,
-        1,
+        client.signer(&signer_id.to_string()).await?.next_nonce,
+        Some(1),
         "replayed nonce must not advance"
     );
 
@@ -648,11 +621,8 @@ async fn bls_bulk_exact_bytes_replay_across_blocks_regtest() -> Result<()> {
 
     let client = rt.kontor_client().await;
     assert_eq!(
-        client
-            .registry_entry(&signer_id.to_string())
-            .await?
-            .next_nonce,
-        1
+        client.signer(&signer_id.to_string()).await?.next_nonce,
+        Some(1)
     );
 
     let arith_runtime_contract: indexer::runtime::ContractAddress = arith_contract
@@ -674,11 +644,8 @@ async fn bls_bulk_exact_bytes_replay_across_blocks_regtest() -> Result<()> {
 
     // Nonce unchanged — the replayed op was rejected.
     assert_eq!(
-        client
-            .registry_entry(&signer_id.to_string())
-            .await?
-            .next_nonce,
-        1,
+        client.signer(&signer_id.to_string()).await?.next_nonce,
+        Some(1),
         "byte-for-byte replay must not advance nonce"
     );
 

--- a/kontor-ts/src/bindings.d.ts
+++ b/kontor-ts/src/bindings.d.ts
@@ -164,13 +164,6 @@ export type ParticipantScripts = {
   chained_tap_leaf_script: TapLeafScript | null;
 };
 
-export type RegistryEntryResponse = {
-  signer_id: number;
-  x_only_pubkey: string;
-  bls_pubkey: Array<number> | null;
-  next_nonce: number;
-};
-
 export type ResultResponse<T> = { result: T };
 
 export type ResultRow = {
@@ -226,6 +219,13 @@ export type RevealQuery = {
   participants: Array<RevealParticipantQuery>;
   op_return_data: Array<number> | null;
   envelope: number | null;
+};
+
+export type SignerResponse = {
+  signer_id: number;
+  x_only_pubkey: string | null;
+  bls_pubkey: Array<number> | null;
+  next_nonce: number | null;
 };
 
 export type TapLeafScript = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Renames a public API endpoint and response type, which is a breaking change for any clients still calling `/registry/entry/*` or expecting non-null `x_only_pubkey`/`next_nonce`. Also changes signer lookup SQL to use LEFT JOINs and adds BLS pubkey resolution, which could affect edge-case signer records (core/contract signers) and nonce visibility.
> 
> **Overview**
> Replaces the old registry entry API with a new `GET /api/signers/{identifier}` endpoint and client method, where `identifier` can be a numeric signer id, a 64-char x-only pubkey hex string, or a 192-char BLS pubkey hex string.
> 
> Updates the signer response/model to `SignerResponse`, making `x_only_pubkey` and `next_nonce` optional to support core/contract signers, and adjusts the DB query layer to use LEFT JOIN-based signer entry selection plus a new `get_signer_entry_by_bls_pubkey` lookup. Tests and TypeScript bindings are updated accordingly, and call sites are migrated from `registry_entry` to `signer`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57bdf7a82ea13643e61bebc7412a3725b4f10f8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->