### PR TITLE
indexer: support CONSENSUS_PRIVATE_KEY_FILE for k8s secret mounts

### DIFF
--- a/core/indexer/src/config.rs
+++ b/core/indexer/src/config.rs
@@ -80,6 +80,19 @@ pub struct Config {
     )]
     pub consensus_private_key: Option<String>,
 
+    /// Path to a file containing the hex-encoded Ed25519 private key.
+    /// Standard `_FILE` convention for k8s-mounted secrets — pairs with an
+    /// init container that derives the per-pod key from a master seed and
+    /// writes it to a shared volume. Mutually exclusive with
+    /// `--consensus-private-key`; if both are set, the daemon refuses to
+    /// start so a misconfiguration can't silently pick the wrong source.
+    #[clap(
+        long,
+        env = "CONSENSUS_PRIVATE_KEY_FILE",
+        help = "Path to a file containing the hex-encoded Ed25519 private key (alternative to --consensus-private-key for k8s secret mounts)"
+    )]
+    pub consensus_private_key_file: Option<PathBuf>,
+
     #[clap(
         long,
         env = "CONSENSUS_LISTEN_ADDR",
@@ -125,6 +138,7 @@ impl Config {
             data_dir: "will be set".into(),
             starting_block_height: 1,
             consensus_private_key: None,
+            consensus_private_key_file: None,
             consensus_listen_addr: "/ip4/127.0.0.1/tcp/26656".to_string(),
             consensus_peers: Vec::new(),
             genesis_file: PathBuf::new(),

--- a/core/indexer/src/consensus/signing.rs
+++ b/core/indexer/src/consensus/signing.rs
@@ -1,4 +1,6 @@
-use anyhow::Context;
+use std::path::Path;
+
+use anyhow::{Context, anyhow, bail};
 use async_trait::async_trait;
 use bytes::Bytes;
 
@@ -22,6 +24,41 @@ pub fn private_key_from_hex(hex_str: &str) -> anyhow::Result<PrivateKey> {
         anyhow::anyhow!("Ed25519 private key must be 32 bytes, got {}", v.len())
     })?;
     Ok(PrivateKey::from(key_array))
+}
+
+/// Resolve the consensus private key from config: prefer the inline hex
+/// value, fall back to reading from a file path (`_FILE` convention for
+/// k8s-mounted secrets), refuse to start if both are set, otherwise
+/// generate a random key and run as a sync-only follower.
+///
+/// Returns `(key, consensus_enabled)` — `consensus_enabled` is false
+/// only when neither source was provided (the random-key follower path).
+pub fn resolve_consensus_private_key(
+    inline_hex: Option<&str>,
+    file_path: Option<&Path>,
+) -> anyhow::Result<(PrivateKey, bool)> {
+    if inline_hex.is_some() && file_path.is_some() {
+        bail!(
+            "both --consensus-private-key and --consensus-private-key-file are set; \
+             pick one (typically the file form for k8s)"
+        );
+    }
+    if let Some(hex) = inline_hex {
+        return Ok((private_key_from_hex(hex)?, true));
+    }
+    if let Some(path) = file_path {
+        let raw = std::fs::read_to_string(path)
+            .with_context(|| format!("reading consensus private key from {}", path.display()))?;
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Err(anyhow!(
+                "consensus private key file {} is empty",
+                path.display()
+            ));
+        }
+        return Ok((private_key_from_hex(trimmed)?, true));
+    }
+    Ok((generate_random_private_key(), false))
 }
 
 pub trait Hashable {
@@ -132,5 +169,63 @@ impl SigningProvider<Ctx> for Ed25519Provider {
         Ok(VerificationResult::from_bool(
             public_key.verify(extension.as_ref(), signature).is_ok(),
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    const KEY_HEX: &str = "8a9314fb7c22dc4ab1cb39fe1041be2923b4c78ce99ba0e04497e5e006a1cd35";
+
+    #[test]
+    fn resolve_inline_hex() {
+        let (_pk, enabled) = resolve_consensus_private_key(Some(KEY_HEX), None).unwrap();
+        assert!(enabled);
+    }
+
+    #[test]
+    fn resolve_from_file() {
+        let mut f = NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut f, KEY_HEX.as_bytes()).unwrap();
+        let (_pk, enabled) = resolve_consensus_private_key(None, Some(f.path())).unwrap();
+        assert!(enabled);
+    }
+
+    #[test]
+    fn resolve_from_file_trims_whitespace_and_newline() {
+        // K8s-mounted secrets usually end with a trailing newline; make sure we strip.
+        let mut f = NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut f, format!("  {KEY_HEX}\n").as_bytes()).unwrap();
+        let (_pk, enabled) = resolve_consensus_private_key(None, Some(f.path())).unwrap();
+        assert!(enabled);
+    }
+
+    #[test]
+    fn resolve_inline_and_file_set_is_rejected() {
+        let f = NamedTempFile::new().unwrap();
+        let err = resolve_consensus_private_key(Some(KEY_HEX), Some(f.path())).unwrap_err();
+        assert!(err.to_string().contains("both"));
+    }
+
+    #[test]
+    fn resolve_empty_file_is_rejected() {
+        let f = NamedTempFile::new().unwrap();
+        let err = resolve_consensus_private_key(None, Some(f.path())).unwrap_err();
+        assert!(err.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn resolve_neither_falls_back_to_follower() {
+        let (_pk, enabled) = resolve_consensus_private_key(None, None).unwrap();
+        assert!(!enabled);
+    }
+
+    #[test]
+    fn resolve_missing_file_is_rejected() {
+        let err = resolve_consensus_private_key(None, Some(Path::new("/nonexistent/path")))
+            .unwrap_err();
+        assert!(err.to_string().to_lowercase().contains("reading"));
     }
 }

--- a/core/indexer/src/consensus/signing.rs
+++ b/core/indexer/src/consensus/signing.rs
@@ -224,8 +224,8 @@ mod tests {
 
     #[test]
     fn resolve_missing_file_is_rejected() {
-        let err = resolve_consensus_private_key(None, Some(Path::new("/nonexistent/path")))
-            .unwrap_err();
+        let err =
+            resolve_consensus_private_key(None, Some(Path::new("/nonexistent/path"))).unwrap_err();
         assert!(err.to_string().to_lowercase().contains("reading"));
     }
 }

--- a/core/indexer/src/main.rs
+++ b/core/indexer/src/main.rs
@@ -136,10 +136,11 @@ async fn run_daemon(config: Config) -> Result<()> {
     .await;
     handles.push(follower_handle);
 
-    let (private_key, consensus_enabled) = indexer::consensus::signing::resolve_consensus_private_key(
-        config.consensus_private_key.as_deref(),
-        config.consensus_private_key_file.as_deref(),
-    )?;
+    let (private_key, consensus_enabled) =
+        indexer::consensus::signing::resolve_consensus_private_key(
+            config.consensus_private_key.as_deref(),
+            config.consensus_private_key_file.as_deref(),
+        )?;
     if !consensus_enabled {
         info!("No consensus private key provided, running as sync-only follower");
     }

--- a/core/indexer/src/main.rs
+++ b/core/indexer/src/main.rs
@@ -29,7 +29,7 @@ struct Cli {
 #[derive(Subcommand)]
 enum Command {
     /// Run the indexer daemon.
-    Run(Config),
+    Run(Box<Config>),
     /// Generate validator keys deterministically from a master seed.
     Keygen(KeygenArgs),
 }
@@ -38,7 +38,7 @@ enum Command {
 async fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
-        Command::Run(config) => run_daemon(config).await,
+        Command::Run(config) => run_daemon(*config).await,
         Command::Keygen(args) => keygen::run(args),
     }
 }
@@ -136,18 +136,13 @@ async fn run_daemon(config: Config) -> Result<()> {
     .await;
     handles.push(follower_handle);
 
-    let (private_key, consensus_enabled) = if let Some(key_hex) = &config.consensus_private_key {
-        (
-            indexer::consensus::signing::private_key_from_hex(key_hex)?,
-            true,
-        )
-    } else {
+    let (private_key, consensus_enabled) = indexer::consensus::signing::resolve_consensus_private_key(
+        config.consensus_private_key.as_deref(),
+        config.consensus_private_key_file.as_deref(),
+    )?;
+    if !consensus_enabled {
         info!("No consensus private key provided, running as sync-only follower");
-        (
-            indexer::consensus::signing::generate_random_private_key(),
-            false,
-        )
-    };
+    }
     let engine_config = reactor::engine::EngineConfig {
         private_key,
         listen_addr: config.consensus_listen_addr.clone(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how the daemon resolves the consensus signing key at startup (including new failure modes when misconfigured), which can affect node participation/availability in consensus.
> 
> **Overview**
> Adds support for supplying the consensus Ed25519 private key via `--consensus-private-key-file`/`CONSENSUS_PRIVATE_KEY_FILE` (for k8s secret mounts), including trimming, explicit errors for empty/missing files, and **refusing to start** if both inline and file sources are set.
> 
> Refactors daemon startup to use a new `resolve_consensus_private_key` helper (with unit tests) while preserving the existing fallback behavior of generating a random key and running as sync-only follower when no key is provided; `Command::Run` now parses `Config` behind a `Box`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcb4aa7eb3063a73740dc175e2ccdcecb0b41a09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->