### PR TITLE
indexer: default consensus_propose_timeout_ms to 10000ms

### DIFF
--- a/core/indexer/src/config.rs
+++ b/core/indexer/src/config.rs
@@ -125,12 +125,18 @@ pub struct Config {
     )]
     pub genesis_file: PathBuf,
 
+    /// Hard deadline for kontor's empty-batch fallback is 80% of this value
+    /// (see `consensus_state::PendingProposal::hard_deadline`). Tuned to match
+    /// the reactor's 500ms debounce; lower values fire empty batches too
+    /// aggressively for kontor's Bitcoin-anchored mempool turnover. Override
+    /// only if you know the debounce model and have a reason.
     #[clap(
         long,
         env = "CONSENSUS_PROPOSE_TIMEOUT_MS",
-        help = "Consensus propose timeout in milliseconds (default: 3000)"
+        default_value = "10000",
+        help = "Consensus propose timeout in milliseconds"
     )]
-    pub consensus_propose_timeout_ms: Option<u64>,
+    pub consensus_propose_timeout_ms: u64,
 }
 
 impl Config {
@@ -152,7 +158,7 @@ impl Config {
             consensus_listen_addr: "/ip4/127.0.0.1/tcp/26656".to_string(),
             consensus_peers: Vec::new(),
             genesis_file: PathBuf::new(),
-            consensus_propose_timeout_ms: None,
+            consensus_propose_timeout_ms: 10000,
         }
     }
 }

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -627,7 +627,7 @@ pub fn run(
     replay_tx: Option<mpsc::Sender<u64>>,
     genesis_validators: Vec<crate::runtime::GenesisValidator>,
     observation_channels: Option<consensus_state::ObservationChannels>,
-    consensus_propose_timeout_ms: Option<u64>,
+    consensus_propose_timeout_ms: u64,
     fee_tx: Option<tokio::sync::watch::Sender<Fees>>,
 ) -> JoinHandle<()> {
     tokio::spawn({
@@ -644,8 +644,8 @@ pub fn run(
                 .await
                 .context("create_runtime_executor failed")?;
 
-                let timeouts = consensus_propose_timeout_ms.map(|ms| LinearTimeouts {
-                    propose: std::time::Duration::from_millis(ms),
+                let timeouts = Some(LinearTimeouts {
+                    propose: std::time::Duration::from_millis(consensus_propose_timeout_ms),
                     ..LinearTimeouts::default()
                 });
 

--- a/core/indexer/src/reactor/reactor_cluster_tests.rs
+++ b/core/indexer/src/reactor/reactor_cluster_tests.rs
@@ -23,7 +23,6 @@ use bitcoin::hashes::Hash;
 use indexer_types::Event;
 use indexer_types::OpWithResult;
 use malachitebft_app_channel::app::types::core::VotingPower;
-use malachitebft_core_types::LinearTimeouts;
 
 fn allocate_port() -> u16 {
     static NEXT_PORT: std::sync::atomic::AtomicU16 = std::sync::atomic::AtomicU16::new(19000);
@@ -324,10 +323,6 @@ impl ReactorCluster {
                 crate::reactor::mempool_fee_index::MempoolFeeIndex::new(None),
             )
             .await;
-            state.timeouts = LinearTimeouts {
-                propose: Duration::from_secs(10),
-                ..Default::default()
-            };
             state.observation = Some(ObservationChannels {
                 decided_tx: dtx,
                 finality_tx: ftx,

--- a/core/indexer/src/reg_tester.rs
+++ b/core/indexer/src/reg_tester.rs
@@ -164,9 +164,7 @@ async fn run_kontor(
             .arg("--consensus-listen-addr")
             .arg(&c.listen_addr)
             .arg("--genesis-file")
-            .arg(&c.genesis_file)
-            .arg("--consensus-propose-timeout-ms")
-            .arg("10000");
+            .arg(&c.genesis_file);
         for peer in &c.peers {
             cmd.arg("--consensus-peers").arg(peer);
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes consensus timing defaults and removes optional configuration, which can affect proposal/empty-batch behavior and liveness/throughput under load if the new timeout is mismatched for some deployments.
> 
> **Overview**
> Sets `CONSENSUS_PROPOSE_TIMEOUT_MS` to a **non-optional** config value with a new default of **10,000ms**, and documents how it interacts with the reactor debounce and empty-batch fallback.
> 
> Updates the reactor startup to always apply the propose timeout (no `Option`), and simplifies tests/regtest helpers by removing ad-hoc timeout overrides/CLI flags now covered by the default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c1bb7ad734c222d966106551486647dc77625b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->