### PR TITLE
indexer: treat height-0-only DB as fresh start in create_runtime_executor

### DIFF
--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -505,6 +505,18 @@ pub async fn create_runtime_executor(
         .await
         .context("Failed to query latest block during startup")?
     {
+        // The native block at height 0 is inserted by this function on
+        // first boot (below). On subsequent boots — if no real bitcoin
+        // blocks have been indexed yet — `select_block_latest` returns
+        // it. Treat that case as a fresh start, since `starting_block_height`
+        // is allowed to be (and typically is) much higher than 0.
+        Some(block) if block.height == 0 => {
+            info!(
+                "Only native block found, starting from height {}",
+                starting_block_height
+            );
+            (starting_block_height - 1, None)
+        }
         Some(block) => {
             let block_height = block.height as u64;
             if block_height < starting_block_height - 1 {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts indexer startup height tracking, which can change where block ingestion resumes and could cause missed or duplicated indexing if the height-0 detection is wrong.
> 
> **Overview**
> `create_runtime_executor` now special-cases the situation where `select_block_latest` returns only the synthetic height-0 native block, and treats it as a fresh start by resetting `last_height` to `starting_block_height - 1` and clearing `last_hash`.
> 
> This avoids failing startup when `starting_block_height` is much higher than 0 but the DB has not indexed any real Bitcoin blocks yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d04f596655dc9d3814fa6c24c5e07607b687bc07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->