### PR TITLE
Publisher-paid gas for sponsored ops in BLS aggregate bulks

### DIFF
--- a/BLS_ARCHITECTURE.md
+++ b/BLS_ARCHITECTURE.md
@@ -248,7 +248,51 @@ Source: `../Documentation/specs/whitepaper/main.typ` (Sigil Smart Contracts → 
 
 ---
 
-### 7) Serialization + compression (full stack vs v1)
+### 7) Publisher-paid gas (sponsored ops)
+
+Co-signers in a bundled operation usually pay the KOR gas for their own ops via `token::hold` / `token::release`. There are cases where the bundle publisher (the Bitcoin Taproot signer of the witness) wants to absorb the gas — e.g. a service onboarding users who have no KOR yet, or a relayer batching ops for users who only hold BTC. Kontor supports this **per-op, opt-in**, without breaking the existing signing scheme.
+
+#### A. `AggregateInfo` fields
+
+Two new fields extend `AggregateInfo`:
+
+- `gas_paid_by_publisher: bool` — bundle-level switch (default `false`).
+- `publisher_gas_limit_per_op: u64` — effective `gas_limit` applied to every sponsored op (default `0`).
+
+Both fields use `#[serde(default)]`. This makes JSON paths (kontor-ts bindings, `serde_json::from_str`) accept payloads without the new fields. **Postcard is non-self-describing**, so payloads encoded BEFORE this extension cannot be decoded by the new struct shape — postcard's `SeqAccess` errors with `DeserializeUnexpectedEnd` instead of using the defaults (see [postcard#159](https://github.com/jamesmunns/postcard/issues/159)). This is acceptable today because no BLS-bulk payloads predate this change; if that ever changes, a custom `Deserialize` would be required.
+
+Neither field is part of the BLS `aggregate_signing_message` (`KONTOR-OP-V1 || postcard((signer_id, inst))`). Existing BLS signatures keep verifying byte-for-byte. The consent model is:
+
+- The **co-signer** cryptographically expresses their intent to be sponsored by signing `gas_limit = 0` for that op — `gas_limit` is part of `Inst::Call`, which is part of the signing message, so the co-signer's BLS signature binds it.
+- The **publisher** expresses their consent to fund gas by signing the Bitcoin Taproot spend that publishes the bundle and by setting `gas_paid_by_publisher = true` in the envelope they assemble. The publisher chooses `publisher_gas_limit_per_op` freely — they take on the risk of running out of tokens.
+
+#### B. Per-op selection rule
+
+For every op in an aggregate bundle:
+
+| `op.gas_limit` (signed) | `gas_paid_by_publisher` | Effect                                                                                                                                              |
+| ----------------------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `> 0`                   | `*`                     | **User pays.** Signed `gas_limit` is used verbatim (legacy behavior, unchanged).                                                                    |
+| `= 0`                   | `false` (or absent)     | **Out-of-fuel deterministic.** `fuel_limit = 0`, the op traps on the first `consume_fuel` and rolls back its savepoint (legacy behavior, unchanged). |
+| `= 0`                   | `true`                  | **Publisher pays.** Effective `gas_limit = publisher_gas_limit_per_op`. `token::hold` and `token::release` charge the publisher's auto-created identity, not the co-signer. The co-signer remains the **applicative signer** for contract auth, result attribution, and nonces. |
+
+This makes mixed-payment bulks (some user-paid, some sponsored) possible inside the **same envelope** without any additional plumbing.
+
+#### C. Failure semantics
+
+- **Publisher has insufficient KOR** to cover `publisher_gas_limit_per_op` of one sponsored op → that op fails with a deterministic "Signer ... does not have enough token" error, exactly as a co-signer-paid op would on the legacy path. Other ops in the same bulk are unaffected — each op has its own savepoint. This matches the existing "not all-or-nothing" behavior of bulk execution.
+- **`gas_paid_by_publisher = true` but `publisher_gas_limit_per_op = 0`** is a shape error — `validate_aggregate_shape` rejects the entire bulk. The publisher gets an explicit failure rather than every sponsored op silently trapping out-of-fuel.
+- **Direct (non-aggregate) publication is unchanged.** The publisher-paid-gas path is aggregate-only.
+
+#### D. Implementation pointers
+
+- Per-op resolution lives in `process_aggregate_input` (`core/indexer/src/reactor/executor.rs`): when the bulk opts in, the publisher's identity is resolved exactly once via `get_or_create_identity(&x_only_pubkey)` and then routed into `execute_op` as a `gas_payer: Option<Signer>`.
+- The actual override happens inside `Runtime::prepare_call` and `Runtime::handle_procedure` (`core/indexer/src/runtime/call.rs`): when `runtime.gas_payer` is `Some`, it is the payer passed to `token::api::hold` and `token::api::release` (wrapped in `Signer::Core(...)`). The applicative signer is unchanged.
+- The executor sets `runtime.set_gas_payer(...)` immediately before each `execute_op` and resets it to `None` after, so the override never leaks across ops.
+
+---
+
+### 8) Serialization + compression (full stack vs v1)
 
 The full scalability stack includes Postcard serialization and Zstd compression; v1 `Inst::BlsBulk` uses Postcard and intentionally defers compression to a later, uniform layer.
 

--- a/core/indexer-types/src/lib.rs
+++ b/core/indexer-types/src/lib.rs
@@ -277,6 +277,38 @@ pub struct OpMetadata {
 pub struct AggregateInfo {
     pub signer_ids: Vec<u64>,
     pub signature: Vec<u8>,
+    /// Opt-in flag: when true, ops whose user-signed `gas_limit == 0`
+    /// are paid for by the Bitcoin publisher (the x_only_pubkey that
+    /// signs the Taproot witness) using `publisher_gas_limit_per_op`
+    /// as effective fuel cap.
+    ///
+    /// `#[serde(default)]` populates JSON paths (kontor-ts bindings,
+    /// `serde_json::from_str`) when the field is absent. Postcard is
+    /// non-self-describing and DOES NOT use this default — old
+    /// postcard payloads encoded before this field existed cannot be
+    /// decoded by the new shape (they error with
+    /// `DeserializeUnexpectedEnd`). This is acceptable today because
+    /// no BLS bulk payloads predate this change; if that ever changes,
+    /// a custom `Deserialize` would be required.
+    ///
+    /// NOT included in `aggregate_signing_message` — co-signers
+    /// express their consent to be sponsored cryptographically by
+    /// signing `gas_limit = 0` (which IS part of `Inst::Call` and so
+    /// IS in the signed message). The publisher's consent is
+    /// expressed by signing the Taproot spend.
+    #[serde(default)]
+    pub gas_paid_by_publisher: bool,
+    /// Effective gas_limit applied to every op in the bulk that
+    /// signs `gas_limit = 0` and is sponsored by the publisher.
+    /// Chosen by the publisher (not signed by co-signers).
+    ///
+    /// `#[serde(default)]` applies on JSON paths (see
+    /// `gas_paid_by_publisher` above for the postcard caveat).
+    /// Validated by `validate_aggregate_shape`: must be > 0 when
+    /// `gas_paid_by_publisher == true`.
+    #[ts(type = "number")]
+    #[serde(default)]
+    pub publisher_gas_limit_per_op: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]

--- a/core/indexer/src/block.rs
+++ b/core/indexer/src/block.rs
@@ -239,6 +239,8 @@ mod tests {
             aggregate: Some(AggregateInfo {
                 signer_ids: vec![7],
                 signature: vec![9u8; 48],
+                gas_paid_by_publisher: false,
+                publisher_gas_limit_per_op: 0,
             }),
         };
         let payload = serialize(&insts).expect("serialize Insts");

--- a/core/indexer/src/bls/aggregate.rs
+++ b/core/indexer/src/bls/aggregate.rs
@@ -104,6 +104,15 @@ pub fn validate_aggregate_shape(insts: &Insts) -> Result<&indexer_types::Aggrega
             }
         }
     }
+    // Publisher-paid gas opt-in: when activated, the publisher MUST declare
+    // a non-zero per-op gas cap. Otherwise every sponsored op would trap
+    // out-of-fuel on the first consume_fuel — that is almost certainly a
+    // publisher misconfiguration so we reject the whole bulk.
+    if agg.gas_paid_by_publisher && agg.publisher_gas_limit_per_op == 0 {
+        return Err(anyhow!(
+            "gas_paid_by_publisher = true requires publisher_gas_limit_per_op > 0"
+        ));
+    }
     Ok(agg)
 }
 

--- a/core/indexer/src/bls/tests.rs
+++ b/core/indexer/src/bls/tests.rs
@@ -132,6 +132,8 @@ async fn verify_aggregate_rejects_empty_bundle() {
         aggregate: Some(AggregateInfo {
             signer_ids: vec![],
             signature: vec![],
+            gas_paid_by_publisher: false,
+            publisher_gas_limit_per_op: 0,
         }),
     };
     let err = verify_aggregate(&mut runtime, &insts)
@@ -157,6 +159,8 @@ async fn verify_aggregate_rejects_wrong_signature_length() {
         aggregate: Some(AggregateInfo {
             signer_ids: vec![0],
             signature: vec![0u8; BLS_SIGNATURE_BYTES - 1],
+            gas_paid_by_publisher: false,
+            publisher_gas_limit_per_op: 0,
         }),
     };
     let err = verify_aggregate(&mut runtime, &insts)
@@ -190,6 +194,8 @@ async fn verify_aggregate_rejects_invalid_signature_bytes() {
         aggregate: Some(AggregateInfo {
             signer_ids: vec![0],
             signature: bad_sig.to_vec(),
+            gas_paid_by_publisher: false,
+            publisher_gas_limit_per_op: 0,
         }),
     };
     let err = verify_aggregate(&mut runtime, &insts)
@@ -221,6 +227,8 @@ async fn verify_aggregate_enforces_op_count_cap() {
         aggregate: Some(AggregateInfo {
             signer_ids: vec![0; MAX_BLS_BULK_OPS + 1],
             signature: vec![],
+            gas_paid_by_publisher: false,
+            publisher_gas_limit_per_op: 0,
         }),
     };
     let err = verify_aggregate(&mut runtime, &insts)
@@ -251,12 +259,74 @@ async fn verify_aggregate_enforces_total_message_bytes_cap() {
                 .sign(b"cap-test", KONTOR_BLS_DST, &[])
                 .to_bytes()
                 .to_vec(),
+            gas_paid_by_publisher: false,
+            publisher_gas_limit_per_op: 0,
         }),
     };
     let err = verify_aggregate(&mut runtime, &insts)
         .await
         .expect_err("message bytes cap must be enforced");
     assert!(err.to_string().contains("signed message bytes exceed max"));
+}
+
+/// `gas_paid_by_publisher = true` AND `publisher_gas_limit_per_op = 0`
+/// is a publisher misconfiguration: every sponsored op would trap out
+/// of fuel on the first consume_fuel. The shape validator MUST reject
+/// the whole bulk so the publisher gets a clear error instead of seeing
+/// every op fail silently.
+#[tokio::test]
+async fn validate_aggregate_shape_rejects_publisher_gas_zero() {
+    let insts = Insts {
+        ops: vec![Inst::Call {
+            gas_limit: 0,
+            contract: ContractAddress {
+                name: "c".into(),
+                height: 1,
+                tx_index: 0,
+            },
+            nonce: Some(0),
+            expr: "noop()".into(),
+        }],
+        aggregate: Some(AggregateInfo {
+            signer_ids: vec![0],
+            signature: vec![0u8; BLS_SIGNATURE_BYTES],
+            gas_paid_by_publisher: true,
+            publisher_gas_limit_per_op: 0,
+        }),
+    };
+    let err = super::aggregate::validate_aggregate_shape(&insts)
+        .expect_err("flag = true with cap = 0 must be rejected");
+    assert!(
+        err.to_string()
+            .contains("gas_paid_by_publisher = true requires publisher_gas_limit_per_op > 0"),
+        "unexpected error: {err}"
+    );
+}
+
+/// `gas_paid_by_publisher = true` with a positive `publisher_gas_limit_per_op`
+/// is a valid configuration — the shape validator must accept it.
+#[tokio::test]
+async fn validate_aggregate_shape_accepts_publisher_gas_set() {
+    let insts = Insts {
+        ops: vec![Inst::Call {
+            gas_limit: 0,
+            contract: ContractAddress {
+                name: "c".into(),
+                height: 1,
+                tx_index: 0,
+            },
+            nonce: Some(0),
+            expr: "noop()".into(),
+        }],
+        aggregate: Some(AggregateInfo {
+            signer_ids: vec![0],
+            signature: vec![0u8; BLS_SIGNATURE_BYTES],
+            gas_paid_by_publisher: true,
+            publisher_gas_limit_per_op: 50_000,
+        }),
+    };
+    super::aggregate::validate_aggregate_shape(&insts)
+        .expect("valid sponsor configuration must pass shape validation");
 }
 
 /*
@@ -497,6 +567,8 @@ fn bls_attack_eve_registers_own_key_under_alice_identity_aggregate_rejected() {
         aggregate: Some(AggregateInfo {
             signer_ids: vec![0],
             signature: vec![0u8; 48],
+            gas_paid_by_publisher: false,
+            publisher_gas_limit_per_op: 0,
         }),
     };
     let err =

--- a/core/indexer/src/reactor/executor.rs
+++ b/core/indexer/src/reactor/executor.rs
@@ -342,7 +342,14 @@ async fn process_direct_input(
             )
             .await;
 
-        execute_op(runtime, &op).await?;
+        // Direct path keeps the legacy behavior: no publisher-paid gas
+        // sponsoring, the op's gas_limit is used as-is.
+        let effective_gas_limit = match &op {
+            indexer_types::Op::Publish { gas_limit, .. }
+            | indexer_types::Op::Call { gas_limit, .. } => *gas_limit,
+            _ => 0,
+        };
+        execute_op(runtime, &op, effective_gas_limit, None).await?;
     }
     Ok(())
 }
@@ -369,6 +376,22 @@ async fn process_aggregate_input(
         .aggregate
         .as_ref()
         .expect("aggregate must be present after successful verification");
+    let gas_paid_by_publisher = agg.gas_paid_by_publisher;
+    let publisher_gas_limit_per_op = agg.publisher_gas_limit_per_op;
+
+    // Resolve the Bitcoin publisher's identity exactly once if this bulk
+    // opts into sponsored gas. Same pattern as `process_direct_input` —
+    // an x_only_pubkey that never paid for an op before is auto-registered
+    // here on first sponsorship. Reused for every sponsored op in the bulk.
+    let publisher_identity = if gas_paid_by_publisher {
+        Some(
+            runtime
+                .get_or_create_identity(&input.x_only_pubkey.to_string())
+                .await?,
+        )
+    } else {
+        None
+    };
 
     for (op_index, (inst, &signer_id)) in input
         .insts
@@ -422,66 +445,91 @@ async fn process_aggregate_input(
             }
         }
 
+        // Sponsored-gas selection per op:
+        // - flag = true AND op.gas_limit == 0  → publisher pays,
+        //   effective gas_limit = publisher_gas_limit_per_op.
+        // - otherwise → current behavior, user-signed gas_limit is used
+        //   verbatim. Validate_aggregate_shape requires every aggregate
+        //   op to be `Inst::Call` so this read is safe.
+        let signed_gas_limit = match inst {
+            Inst::Call { gas_limit, .. } => *gas_limit,
+            _ => {
+                warn!("aggregate path encountered non-Call op (shape check should have rejected)");
+                continue;
+            }
+        };
+        let (effective_gas_limit, gas_payer) = if gas_paid_by_publisher && signed_gas_limit == 0 {
+            let payer = publisher_identity
+                .clone()
+                .expect("publisher_identity must be set when gas_paid_by_publisher is true");
+            (publisher_gas_limit_per_op, Some(Signer::Id(payer)))
+        } else {
+            (signed_gas_limit, None)
+        };
+
         let metadata = OpMetadata {
             previous_output: input.previous_output,
             input_index: input.input_index,
             signer_id,
         };
         let op = op_from_inst(inst.clone(), metadata);
-        execute_op(runtime, &op).await?;
+        execute_op(runtime, &op, effective_gas_limit, gas_payer).await?;
     }
     Ok(())
 }
 
-async fn execute_op(runtime: &mut Runtime, op: &indexer_types::Op) -> Result<()> {
+async fn execute_op(
+    runtime: &mut Runtime,
+    op: &indexer_types::Op,
+    effective_gas_limit: u64,
+    gas_payer: Option<Signer>,
+) -> Result<()> {
     let identity = database::types::Identity::new(op.metadata().signer_id as i64);
     let signer = Signer::Id(identity);
 
-    match op {
-        indexer_types::Op::Publish {
-            gas_limit,
-            name,
-            bytes,
-            ..
-        } => {
-            runtime.set_gas_limit(*gas_limit);
+    // Sponsored-gas override (`Some(...)`) is set ONLY for the duration of
+    // this op so it never leaks into the next iteration. Reset to `None`
+    // before returning, regardless of which branch executed.
+    runtime.set_gas_payer(gas_payer);
+
+    let result = match op {
+        indexer_types::Op::Publish { name, bytes, .. } => {
+            runtime.set_gas_limit(effective_gas_limit);
             match runtime.publish(&signer, name, bytes).await {
-                Ok(_) => {}
+                Ok(_) => Ok(()),
                 Err(ExecutionError::Deterministic(e)) => {
                     warn!("Publish operation failed: {e:#}");
+                    Ok(())
                 }
                 Err(ExecutionError::NonDeterministic(e)) => {
-                    return Err(e.context("Publish operation infrastructure failure"));
+                    Err(e.context("Publish operation infrastructure failure"))
                 }
             }
         }
-        indexer_types::Op::Call {
-            gas_limit,
-            contract,
-            expr,
-            ..
-        } => {
-            runtime.set_gas_limit(*gas_limit);
+        indexer_types::Op::Call { contract, expr, .. } => {
+            runtime.set_gas_limit(effective_gas_limit);
             match runtime
                 .execute(Some(&signer), &(contract.into()), expr)
                 .await
             {
-                Ok(_) => {}
+                Ok(_) => Ok(()),
                 Err(ExecutionError::Deterministic(e)) => {
                     warn!("Call operation failed: {e:#}");
+                    Ok(())
                 }
                 Err(ExecutionError::NonDeterministic(e)) => {
-                    return Err(e.context("Call operation infrastructure failure"));
+                    Err(e.context("Call operation infrastructure failure"))
                 }
             }
         }
         indexer_types::Op::Issuance { .. } => match runtime.issuance(&signer).await {
-            Ok(_) => {}
+            Ok(_) => Ok(()),
             Err(ExecutionError::Deterministic(e)) => {
                 warn!("Issuance operation failed: {e:#}");
+                Ok(())
             }
             Err(ExecutionError::NonDeterministic(e)) => {
-                return Err(e.context("Issuance infrastructure failure"));
+                Err(e.context("Issuance infrastructure failure"))
             }
         },
         indexer_types::Op::RegisterBlsKey {
@@ -500,18 +548,22 @@ async fn execute_op(runtime: &mut Runtime, op: &indexer_types::Op) -> Result<()>
                 .await
             {
                 Ok(_) => {
-                    registry::api::registered(runtime, &Signer::Core(Box::new(signer.clone())))
-                        .await
-                        .map_err(|e| anyhow::anyhow!("registry.registered failed: {e}"))?;
+                    let reg_result =
+                        registry::api::registered(runtime, &Signer::Core(Box::new(signer.clone())))
+                            .await
+                            .map_err(|e| anyhow::anyhow!("registry.registered failed: {e}"));
+                    reg_result.map(|_| ())
                 }
                 Err(ExecutionError::Deterministic(e)) => {
                     warn!("RegisterBlsKey failed: {e:#}");
+                    Ok(())
                 }
                 Err(ExecutionError::NonDeterministic(e)) => {
-                    return Err(e.context("RegisterBlsKey infrastructure failure"));
+                    Err(e.context("RegisterBlsKey infrastructure failure"))
                 }
             }
         }
-    }
-    Ok(())
+    };
+    runtime.set_gas_payer(None);
+    result
 }

--- a/core/indexer/src/runtime/call.rs
+++ b/core/indexer/src/runtime/call.rs
@@ -232,21 +232,24 @@ impl Runtime {
                 .expect("Failed to convert fuel limit into gas limit")
                 .mul(self.gas_to_token_multiplier)
                 .expect("Failed to convert gas limit into token limit");
+            // BLS aggregate sponsored-gas path: when the runtime has been
+            // configured with a `gas_payer`, charge that signer instead
+            // of the op's applicative signer. Everything else (contract
+            // auth, nonces, result attribution) keeps using `signer`.
+            let payer = self.gas_payer.as_ref().unwrap_or(signer);
             tracing::info!(
                 node = %self.node_label,
                 %hold_amount,
                 signer = ?signer,
+                gas_payer = ?self.gas_payer,
                 "Gas hold"
             );
             Box::pin({
                 let mut runtime = self.clone();
+                let payer = payer.clone();
                 async move {
-                    token::api::hold(
-                        &mut runtime,
-                        &Signer::Core(Box::new(signer.clone())),
-                        hold_amount,
-                    )
-                    .await
+                    token::api::hold(&mut runtime, &Signer::Core(Box::new(payer)), hold_amount)
+                        .await
                 }
             })
             .await
@@ -254,7 +257,7 @@ impl Runtime {
             .map_err(|e| {
                 ExecutionError::Deterministic(anyhow!(
                     "Signer {:?} does not have enough token to cover gas limit: {}",
-                    signer,
+                    payer,
                     e
                 ))
             })?;
@@ -435,6 +438,10 @@ impl Runtime {
                 .expect("u64 to decimal")
                 .mul(self.gas_to_token_multiplier)
                 .expect("Failed to convert gas consumed to token amount");
+            // Symmetric to `prepare_call`: the publisher (when sponsoring)
+            // is the one that gets the unused-fuel refund / final gas debit,
+            // because we earlier `hold`-ed against that same payer.
+            let payer = self.gas_payer.as_ref().unwrap_or(signer);
             tracing::info!(
                 node = %self.node_label,
                 gas,
@@ -445,18 +452,16 @@ impl Runtime {
                 contract = %contract_address,
                 func = func_name,
                 signer = ?signer,
+                gas_payer = ?self.gas_payer,
                 "Gas release"
             );
             Box::pin({
                 let mut runtime = self.clone();
                 runtime.stack = Stack::new();
+                let payer = payer.clone();
                 async move {
-                    token::api::release(
-                        &mut runtime,
-                        &Signer::Core(Box::new(signer.clone())),
-                        burn_amount,
-                    )
-                    .await
+                    token::api::release(&mut runtime, &Signer::Core(Box::new(payer)), burn_amount)
+                        .await
                 }
             })
             .await

--- a/core/indexer/src/runtime/mod.rs
+++ b/core/indexer/src/runtime/mod.rs
@@ -168,6 +168,14 @@ pub struct Runtime {
     pub op_return_data: Option<OpReturnData>,
     pub node_label: String,
     core_signer_id: Option<i64>,
+    /// Override for the signer that funds gas (token::hold/release).
+    /// When `Some`, only the hold/release calls use this payer; the
+    /// "applicative signer" passed to `execute` for contract auth,
+    /// result attribution and nonces is unaffected. Used by the BLS
+    /// aggregate sponsored-gas path to charge the Bitcoin publisher
+    /// instead of the per-op co-signer. The executor MUST reset this
+    /// back to `None` after each op so the override never leaks.
+    pub gas_payer: Option<Signer>,
 }
 
 impl Runtime {
@@ -220,6 +228,7 @@ impl Runtime {
             op_return_data: None,
             node_label: String::new(),
             core_signer_id: None,
+            gas_payer: None,
         })
     }
 
@@ -284,6 +293,14 @@ impl Runtime {
 
     pub fn set_gas_limit(&mut self, gas_limit: u64) {
         self.gas_limit = Some(gas_limit);
+    }
+
+    /// Override the signer that funds gas (`token::hold`/`token::release`).
+    /// Pass `None` to restore the default behavior (the op's applicative
+    /// signer pays). The executor MUST reset this to `None` after each op
+    /// so the override never leaks across operations.
+    pub fn set_gas_payer(&mut self, payer: Option<Signer>) {
+        self.gas_payer = payer;
     }
 
     pub fn gas_consumed(&self, starting_fuel: u64, ending_fuel: u64) -> u64 {

--- a/core/indexer/tests/contracts/bls_bulk_compose.rs
+++ b/core/indexer/tests/contracts/bls_bulk_compose.rs
@@ -29,6 +29,8 @@ fn aggregate_insts(ops: Vec<Inst>, signer_ids: Vec<u64>, signature: Vec<u8>) -> 
         aggregate: Some(AggregateInfo {
             signer_ids,
             signature,
+            gas_paid_by_publisher: false,
+            publisher_gas_limit_per_op: 0,
         }),
     }
 }

--- a/core/indexer/tests/contracts/bls_bulk_publisher_pays.rs
+++ b/core/indexer/tests/contracts/bls_bulk_publisher_pays.rs
@@ -1,0 +1,523 @@
+//! End-to-end coverage of the publisher-paid (sponsored) BLS-bulk path.
+//!
+//! Every scenario shares the same scaffolding (publish `arith`, mint signers,
+//! sign + aggregate, submit). To keep the file readable we extract the common
+//! setup into a few helpers and group all scenarios as separate
+//! `#[testlib::test]` entry points:
+//!
+//! - `two_ops` — happy path: 2 co-signers, `gas_limit = 0`, publisher pays.
+//! - `mixed_payment` — same envelope mixing user-paid and publisher-paid ops.
+//! - `gas_zero_without_flag` — legacy guard: `gas_limit = 0` without the
+//!   sponsor flag MUST trap with `fuel_limit = 0` (no implicit sponsorship).
+//! - `insufficient_funds` — broke publisher: sponsored op fails in isolation,
+//!   the rest of the bulk keeps executing.
+//! - `invalid_shape` — `flag = true` + `publisher_gas_limit_per_op = 0` is
+//!   rejected by `validate_aggregate_shape`, the whole bulk is dropped.
+//!
+//! The pure serde / postcard backward-compat checks live in the sibling
+//! `bls_bulk_publisher_pays_backward_compat.rs` because they don't need the
+//! regtest cluster.
+
+use anyhow::{Result, anyhow};
+use blst::min_sig::AggregateSignature;
+use indexer::bls::KONTOR_BLS_DST;
+use indexer::database::types::OpResultId;
+use indexer::reg_tester::{Identity, RegTester};
+use indexer_types::{AggregateInfo, ContractAddress as IndexerContractAddress, Inst, Insts};
+use testlib::Runtime;
+use testlib::*;
+
+interface!(name = "arith", path = "../../test-contracts/arith/wit",);
+import!(
+    name = "token",
+    height = 0,
+    tx_index = 0,
+    path = "../../native-contracts/token/wit",
+);
+
+fn aggregate_call(
+    nonce: u64,
+    gas_limit: u64,
+    contract: IndexerContractAddress,
+    expr: String,
+) -> Inst {
+    Inst::Call {
+        gas_limit,
+        contract,
+        nonce: Some(nonce),
+        expr,
+    }
+}
+
+/// Publish the `arith` contract on-chain and return its address. We take an
+/// explicit `&Runtime` because the `runtime` symbol injected by
+/// `#[testlib::test]` only exists in test-function scope.
+async fn publish_arith(
+    runtime: &Runtime,
+    rt: &mut RegTester,
+    publisher_ident: &mut Identity,
+) -> Result<IndexerContractAddress> {
+    let arith_bytes = runtime
+        .contract_reader
+        .read("arith")
+        .await?
+        .ok_or_else(|| anyhow!("arith contract bytes not found"))?;
+    let publish = rt
+        .instruction(
+            publisher_ident,
+            Inst::Publish {
+                gas_limit: 50_000,
+                name: "arith".to_string(),
+                bytes: arith_bytes,
+            },
+        )
+        .await?;
+    publish.result.contract.parse().map_err(|e| {
+        anyhow!(
+            "invalid contract address {}: {}",
+            publish.result.contract,
+            e
+        )
+    })
+}
+
+/// Sign one op message with a co-signer's BLS secret key.
+fn sign_op(op: &Inst, signer_id: u64, sk_bytes: &[u8]) -> Result<blst::min_sig::Signature> {
+    let msg = op.aggregate_signing_message(signer_id)?;
+    let sk = blst::min_sig::SecretKey::from_bytes(sk_bytes)
+        .map_err(|e| anyhow!("invalid BLS secret key: {e:?}"))?;
+    Ok(sk.sign(&msg, KONTOR_BLS_DST, &[]))
+}
+
+fn aggregate_signatures(sigs: &[&blst::min_sig::Signature]) -> Result<Vec<u8>> {
+    let agg = AggregateSignature::aggregate(sigs, true)
+        .map_err(|e| anyhow!("aggregate signature failed: {e:?}"))?;
+    Ok(agg.to_signature().to_bytes().to_vec())
+}
+
+fn sponsored_insts(
+    ops: Vec<Inst>,
+    signer_ids: Vec<u64>,
+    signature: Vec<u8>,
+    gas_paid_by_publisher: bool,
+    publisher_gas_limit_per_op: u64,
+) -> Insts {
+    Insts {
+        ops,
+        aggregate: Some(AggregateInfo {
+            signer_ids,
+            signature,
+            gas_paid_by_publisher,
+            publisher_gas_limit_per_op,
+        }),
+    }
+}
+
+async fn signer_id_of(rt: &mut RegTester, ident: &Identity) -> Result<u64> {
+    rt.get_signer_id(&ident.x_only_public_key().to_string())
+        .await?
+        .ok_or_else(|| anyhow!("missing signer_id"))
+}
+
+/// Happy path: two co-signers sign ops with `gas_limit = 0`, publisher pays.
+/// Co-signer balances stay at the genesis amount, publisher balance decreases.
+#[testlib::test(contracts_dir = "../../test-contracts", regtest_only)]
+async fn bls_bulk_publisher_pays_two_ops_regtest() -> Result<()> {
+    let mut rt = runtime.reg_tester().unwrap();
+
+    let signer1 = rt.identity().await?;
+    let signer2 = rt.identity().await?;
+    let mut publisher_ident = rt.identity().await?;
+
+    let arith_contract = publish_arith(runtime, &mut rt, &mut publisher_ident).await?;
+    let signer1_id = signer_id_of(&mut rt, &signer1).await?;
+    let signer2_id = signer_id_of(&mut rt, &signer2).await?;
+    let publisher_id = signer_id_of(&mut rt, &publisher_ident).await?;
+
+    // Each identity got `10` from genesis issuance via `rt.identity()`. Snapshot
+    // every relevant balance before submitting the sponsored bulk so we can
+    // assert exact accounting after execution.
+    let bal_signer1_before = token::balance(runtime, HolderRef::SignerId(signer1_id)).await?;
+    let bal_signer2_before = token::balance(runtime, HolderRef::SignerId(signer2_id)).await?;
+    let bal_publisher_before = token::balance(runtime, HolderRef::SignerId(publisher_id)).await?;
+
+    let op0 = aggregate_call(
+        0,
+        0,
+        arith_contract.clone(),
+        arith::wave::eval_call_expr(10, arith::Op::Id),
+    );
+    let op1 = aggregate_call(
+        0,
+        0,
+        arith_contract.clone(),
+        arith::wave::eval_call_expr(10, arith::Op::Sum(arith::Operand { y: 8 })),
+    );
+
+    let sig0 = sign_op(&op0, signer1_id, &signer1.bls_secret_key)?;
+    let sig1 = sign_op(&op1, signer2_id, &signer2.bls_secret_key)?;
+    let aggregate = aggregate_signatures(&[&sig0, &sig1])?;
+
+    let res = rt
+        .instruction_insts(
+            &mut publisher_ident,
+            sponsored_insts(
+                vec![op0, op1],
+                vec![signer1_id, signer2_id],
+                aggregate,
+                true,
+                50_000,
+            ),
+        )
+        .await?;
+    let v0 = res
+        .result
+        .value
+        .as_deref()
+        .ok_or_else(|| anyhow!("expected a return value for inner op 0"))?;
+    let decoded0 = arith::wave::eval_parse_return_expr(v0);
+    assert_eq!(decoded0.value, 10);
+
+    let bal_signer1_after = token::balance(runtime, HolderRef::SignerId(signer1_id)).await?;
+    let bal_signer2_after = token::balance(runtime, HolderRef::SignerId(signer2_id)).await?;
+    assert_eq!(
+        bal_signer1_after, bal_signer1_before,
+        "co-signer1 should not be debited when publisher sponsors"
+    );
+    assert_eq!(
+        bal_signer2_after, bal_signer2_before,
+        "co-signer2 should not be debited when publisher sponsors"
+    );
+
+    // We use a strict `<` rather than an exact equality because the runtime
+    // applies a `gas_to_token_multiplier` and per-op gas consumption depends
+    // on the contract function — both are brittle to pin. The important
+    // invariant is "publisher decreased and co-signers did not".
+    let bal_publisher_after = token::balance(runtime, HolderRef::SignerId(publisher_id)).await?;
+    match (bal_publisher_before, bal_publisher_after) {
+        (Some(before), Some(after)) => assert!(
+            after < before,
+            "publisher balance should decrease after sponsoring two ops (before: {before}, after: {after})"
+        ),
+        other => panic!("unexpected balance state for publisher: {other:?}"),
+    }
+
+    Ok(())
+}
+
+/// Mixed-payment bulk: same envelope contains user-paid ops (`gas_limit > 0`)
+/// and a publisher-paid op (`gas_limit = 0`). Validates the per-op selection
+/// rule when the sponsor flag is set.
+#[testlib::test(contracts_dir = "../../test-contracts", regtest_only)]
+async fn bls_bulk_mixed_payment_regtest() -> Result<()> {
+    let mut rt = runtime.reg_tester().unwrap();
+
+    let signer1 = rt.identity().await?;
+    let signer2 = rt.identity().await?;
+    let signer3 = rt.identity().await?;
+    let mut publisher_ident = rt.identity().await?;
+
+    let arith_contract = publish_arith(runtime, &mut rt, &mut publisher_ident).await?;
+    let signer1_id = signer_id_of(&mut rt, &signer1).await?;
+    let signer2_id = signer_id_of(&mut rt, &signer2).await?;
+    let signer3_id = signer_id_of(&mut rt, &signer3).await?;
+    let publisher_id = signer_id_of(&mut rt, &publisher_ident).await?;
+
+    let bal_signer1_before = token::balance(runtime, HolderRef::SignerId(signer1_id)).await?;
+    let bal_signer2_before = token::balance(runtime, HolderRef::SignerId(signer2_id)).await?;
+    let bal_signer3_before = token::balance(runtime, HolderRef::SignerId(signer3_id)).await?;
+    let bal_publisher_before = token::balance(runtime, HolderRef::SignerId(publisher_id)).await?;
+
+    // op0: signer1 pays (gas_limit > 0). op1: publisher pays (gas_limit = 0).
+    // op2: signer3 pays (gas_limit > 0). Same envelope, same publisher.
+    let op0 = aggregate_call(
+        0,
+        50_000,
+        arith_contract.clone(),
+        arith::wave::eval_call_expr(10, arith::Op::Id),
+    );
+    let op1 = aggregate_call(
+        0,
+        0,
+        arith_contract.clone(),
+        arith::wave::eval_call_expr(20, arith::Op::Id),
+    );
+    let op2 = aggregate_call(
+        0,
+        50_000,
+        arith_contract.clone(),
+        arith::wave::eval_call_expr(30, arith::Op::Id),
+    );
+
+    let sig0 = sign_op(&op0, signer1_id, &signer1.bls_secret_key)?;
+    let sig1 = sign_op(&op1, signer2_id, &signer2.bls_secret_key)?;
+    let sig2 = sign_op(&op2, signer3_id, &signer3.bls_secret_key)?;
+    let aggregate = aggregate_signatures(&[&sig0, &sig1, &sig2])?;
+
+    let res = rt
+        .instruction_insts(
+            &mut publisher_ident,
+            sponsored_insts(
+                vec![op0, op1, op2],
+                vec![signer1_id, signer2_id, signer3_id],
+                aggregate,
+                true,
+                50_000,
+            ),
+        )
+        .await?;
+    assert!(res.result.value.is_some(), "op0 should have a result");
+
+    let bal_signer1_after = token::balance(runtime, HolderRef::SignerId(signer1_id)).await?;
+    let bal_signer2_after = token::balance(runtime, HolderRef::SignerId(signer2_id)).await?;
+    let bal_signer3_after = token::balance(runtime, HolderRef::SignerId(signer3_id)).await?;
+    let bal_publisher_after = token::balance(runtime, HolderRef::SignerId(publisher_id)).await?;
+
+    fn unwrap_dec(d: Option<Decimal>, label: &str) -> Decimal {
+        d.unwrap_or_else(|| panic!("{label} has no balance"))
+    }
+    let s1_before = unwrap_dec(bal_signer1_before, "signer1 before");
+    let s1_after = unwrap_dec(bal_signer1_after, "signer1 after");
+    let s2_before = unwrap_dec(bal_signer2_before, "signer2 before");
+    let s2_after = unwrap_dec(bal_signer2_after, "signer2 after");
+    let s3_before = unwrap_dec(bal_signer3_before, "signer3 before");
+    let s3_after = unwrap_dec(bal_signer3_after, "signer3 after");
+    let p_before = unwrap_dec(bal_publisher_before, "publisher before");
+    let p_after = unwrap_dec(bal_publisher_after, "publisher after");
+
+    assert!(
+        s1_after < s1_before,
+        "signer1 (user-paid) should decrease: {s1_before} -> {s1_after}"
+    );
+    assert_eq!(
+        s2_after, s2_before,
+        "signer2 (publisher-sponsored) should NOT change"
+    );
+    assert!(
+        s3_after < s3_before,
+        "signer3 (user-paid) should decrease: {s3_before} -> {s3_after}"
+    );
+    assert!(
+        p_after < p_before,
+        "publisher should decrease after sponsoring op1: {p_before} -> {p_after}"
+    );
+
+    Ok(())
+}
+
+/// Backward-compat regression: an op signs `gas_limit = 0` but the bulk
+/// envelope does NOT opt into publisher-paid gas. The runtime keeps the legacy
+/// behavior — the op gets `fuel_limit = 0` and traps on the first
+/// `consume_fuel`, so it deterministically fails. Guards us against
+/// accidentally extending sponsored behavior to bulks that did not opt in.
+#[testlib::test(contracts_dir = "../../test-contracts", regtest_only)]
+async fn bls_bulk_gas_zero_without_flag_regtest() -> Result<()> {
+    let mut rt = runtime.reg_tester().unwrap();
+
+    let signer1 = rt.identity().await?;
+    let signer2 = rt.identity().await?;
+    let mut publisher_ident = rt.identity().await?;
+
+    let arith_contract = publish_arith(runtime, &mut rt, &mut publisher_ident).await?;
+    let signer1_id = signer_id_of(&mut rt, &signer1).await?;
+    let signer2_id = signer_id_of(&mut rt, &signer2).await?;
+
+    let op0 = aggregate_call(
+        0,
+        50_000,
+        arith_contract.clone(),
+        arith::wave::eval_call_expr(7, arith::Op::Id),
+    );
+    let op1 = aggregate_call(
+        0,
+        0,
+        arith_contract.clone(),
+        arith::wave::eval_call_expr(13, arith::Op::Id),
+    );
+
+    let sig0 = sign_op(&op0, signer1_id, &signer1.bls_secret_key)?;
+    let sig1 = sign_op(&op1, signer2_id, &signer2.bls_secret_key)?;
+    let aggregate = aggregate_signatures(&[&sig0, &sig1])?;
+
+    let res = rt
+        .instruction_insts(
+            &mut publisher_ident,
+            sponsored_insts(
+                vec![op0, op1],
+                vec![signer1_id, signer2_id],
+                aggregate,
+                // Flag is explicitly false — this is the legacy path.
+                false,
+                0,
+            ),
+        )
+        .await?;
+    let v0 = res
+        .result
+        .value
+        .as_deref()
+        .ok_or_else(|| anyhow!("op0 should have a result"))?;
+    let decoded0 = arith::wave::eval_parse_return_expr(v0);
+    assert_eq!(decoded0.value, 7, "op0 should have executed normally");
+
+    // op1 must NOT have a successful value — fuel_limit = 0 traps the call
+    // deterministically as in the legacy behavior. Two acceptable shapes:
+    // either the row exists with `value = None` (the op failed and was rolled
+    // back) OR the row is missing entirely.
+    let txid =
+        bitcoin::consensus::encode::deserialize_hex::<bitcoin::Transaction>(&res.reveal_tx_hex)?
+            .compute_txid()
+            .to_string();
+    let client = rt.kontor_client().await;
+    let op1_result = client
+        .result(&OpResultId::builder().txid(txid).op_index(1).build())
+        .await?;
+    if let Some(r) = op1_result {
+        assert!(
+            r.value.is_none(),
+            "op with gas_limit=0 and no sponsor flag must fail (got value: {:?})",
+            r.value
+        );
+    }
+
+    Ok(())
+}
+
+/// Insufficient-funds path: publisher is broke (unregistered_identity has 0
+/// KOR) but signs the sponsor flag anyway. The sponsored op must fail
+/// deterministically; ops that pay their own gas in the same bulk must still
+/// succeed (each op has its own savepoint).
+#[testlib::test(contracts_dir = "../../test-contracts", regtest_only)]
+async fn bls_bulk_publisher_pays_insufficient_funds_regtest() -> Result<()> {
+    let mut rt = runtime.reg_tester().unwrap();
+
+    let signer1 = rt.identity().await?;
+    let signer2 = rt.identity().await?;
+    // Publisher is a fresh Bitcoin-funded identity that did NOT do a KOR
+    // Issuance — KOR balance is 0, no sponsorship can succeed. Using
+    // `unregistered_identity()` is the cleanest way to put them in this state:
+    // the publisher signs the Taproot spend, not the BLS aggregate, so no BLS
+    // key is needed.
+    let mut publisher_ident = rt.unregistered_identity().await?;
+
+    // Publish via a separate funded identity — the broke publisher must stay
+    // broke for the assertion below.
+    let mut publish_ident = rt.identity().await?;
+    let arith_contract = publish_arith(runtime, &mut rt, &mut publish_ident).await?;
+
+    let signer1_id = signer_id_of(&mut rt, &signer1).await?;
+    let signer2_id = signer_id_of(&mut rt, &signer2).await?;
+
+    // op0 pays its own gas — should succeed.
+    // op1 expects to be sponsored — should fail (publisher has 0 KOR).
+    let op0 = aggregate_call(
+        0,
+        50_000,
+        arith_contract.clone(),
+        arith::wave::eval_call_expr(11, arith::Op::Id),
+    );
+    let op1 = aggregate_call(
+        0,
+        0,
+        arith_contract.clone(),
+        arith::wave::eval_call_expr(22, arith::Op::Id),
+    );
+
+    let sig0 = sign_op(&op0, signer1_id, &signer1.bls_secret_key)?;
+    let sig1 = sign_op(&op1, signer2_id, &signer2.bls_secret_key)?;
+    let aggregate = aggregate_signatures(&[&sig0, &sig1])?;
+
+    // `instruction_insts` errors out if op_index = 0 has no value, but op0
+    // should succeed — so this is OK. We still want to inspect op1
+    // independently to assert it failed deterministically.
+    let res = rt
+        .instruction_insts(
+            &mut publisher_ident,
+            sponsored_insts(
+                vec![op0, op1],
+                vec![signer1_id, signer2_id],
+                aggregate,
+                true,
+                50_000,
+            ),
+        )
+        .await?;
+    let v0 = res
+        .result
+        .value
+        .as_deref()
+        .ok_or_else(|| anyhow!("op0 (user-paid) should have a result"))?;
+    let decoded0 = arith::wave::eval_parse_return_expr(v0);
+    assert_eq!(decoded0.value, 11, "op0 should have executed normally");
+
+    let txid =
+        bitcoin::consensus::encode::deserialize_hex::<bitcoin::Transaction>(&res.reveal_tx_hex)?
+            .compute_txid()
+            .to_string();
+    let client = rt.kontor_client().await;
+    let op1_result = client
+        .result(&OpResultId::builder().txid(txid).op_index(1).build())
+        .await?;
+    // Two acceptable shapes: row exists with `value = None` (failed & rolled
+    // back) OR the row is missing entirely. Anything else is a regression.
+    if let Some(r) = op1_result {
+        assert!(
+            r.value.is_none(),
+            "sponsored op should fail when publisher is broke (got value: {:?})",
+            r.value
+        );
+    }
+
+    // Co-signer2 must NOT have been debited — the sponsored path means they
+    // never enter the token hold; failure attribution is on the publisher.
+    let bal_signer2_after = token::balance(runtime, HolderRef::SignerId(signer2_id)).await?;
+    assert!(
+        bal_signer2_after.is_some(),
+        "co-signer2 should still exist as a balance entry after sponsored failure"
+    );
+
+    Ok(())
+}
+
+/// Shape validation: `gas_paid_by_publisher = true` with
+/// `publisher_gas_limit_per_op = 0` is configuration-invalid.
+/// `validate_aggregate_shape` rejects the bulk; executor logs and continues,
+/// no op result is produced and `instruction_insts` errors out.
+#[testlib::test(contracts_dir = "../../test-contracts", regtest_only)]
+async fn bls_bulk_publisher_pays_invalid_shape_regtest() -> Result<()> {
+    let mut rt = runtime.reg_tester().unwrap();
+
+    let signer1 = rt.identity().await?;
+    let mut publisher_ident = rt.identity().await?;
+
+    let arith_contract = publish_arith(runtime, &mut rt, &mut publisher_ident).await?;
+    let signer1_id = signer_id_of(&mut rt, &signer1).await?;
+
+    let op = aggregate_call(
+        0,
+        0,
+        arith_contract.clone(),
+        arith::wave::eval_call_expr(99, arith::Op::Id),
+    );
+
+    let sig = sign_op(&op, signer1_id, &signer1.bls_secret_key)?;
+    let aggregate = aggregate_signatures(&[&sig])?;
+
+    // Inconsistent shape: flag = true REQUIRES publisher_gas_limit_per_op > 0.
+    let insts = sponsored_insts(vec![op], vec![signer1_id], aggregate, true, 0);
+
+    let res = rt.instruction_insts(&mut publisher_ident, insts).await;
+    assert!(res.is_err(), "invalid-shape bulk must produce no op result");
+
+    // Sanity: the co-signer's nonce must NOT have advanced (the bulk did not
+    // execute at all).
+    let client = rt.kontor_client().await;
+    let entry = client.signer(&signer1_id.to_string()).await?;
+    assert_eq!(
+        entry.next_nonce,
+        Some(0),
+        "rejected bulk must not consume the co-signer's nonce"
+    );
+
+    Ok(())
+}

--- a/core/indexer/tests/contracts/bls_bulk_publisher_pays_backward_compat.rs
+++ b/core/indexer/tests/contracts/bls_bulk_publisher_pays_backward_compat.rs
@@ -1,0 +1,107 @@
+//! Backward-compat: when a publisher constructs an `AggregateInfo` without
+//! explicitly setting `gas_paid_by_publisher` / `publisher_gas_limit_per_op`,
+//! e.g. via a JSON / struct-literal path that omits the new fields, the
+//! defaults (`false` and `0`) must take effect. This keeps every existing
+//! aggregate-construction code path (with two-field `AggregateInfo` literals)
+//! working — they now silently fall back to the legacy user-pays behavior.
+//!
+//! IMPORTANT LIMITATION (postcard ≤ 1.x):
+//! `#[serde(default)]` does NOT automatically deserialize OLD postcard
+//! payloads (encoded with only the original two fields) into the NEW struct
+//! shape. Postcard is non-self-describing and fails with `DeserializeUnexpectedEnd`
+//! when the buffer is exhausted before all struct fields are read. See
+//! <https://github.com/jamesmunns/postcard/issues/159>. The `#[serde(default)]`
+//! attributes still serve two purposes in this codebase:
+//! 1. JSON deserialization paths (kontor-ts bindings, ts-rs exports,
+//!    `serde_json::from_str`) populate the defaults correctly when fields
+//!    are missing.
+//! 2. Struct construction in Rust code can use `..` shorthand if the type
+//!    ever derives `Default` (it doesn't today).
+//!
+//! Practical impact: if there are NO existing on-chain payloads using the
+//! old 2-field `AggregateInfo` (BLS bulk is a recent feature), then strict
+//! wire-level backward-compat is moot. If older payloads exist and need to
+//! be replayed from history, a custom `Deserialize` impl would be required.
+
+use anyhow::Result;
+use indexer_types::AggregateInfo;
+use serde::Serialize;
+use testlib::*;
+
+#[testlib::test(contracts_dir = "../../test-contracts")]
+async fn bls_bulk_publisher_pays_backward_compat() -> Result<()> {
+    // JSON path: `#[serde(default)]` MUST kick in when the new fields are
+    // absent from the input. This is the path most third-party clients
+    // (kontor-ts, tooling) go through.
+    let json_legacy = r#"{
+        "signer_ids": [1, 2, 3],
+        "signature": []
+    }"#;
+    let decoded: AggregateInfo = serde_json::from_str(json_legacy)?;
+    assert_eq!(decoded.signer_ids, vec![1, 2, 3]);
+    assert!(decoded.signature.is_empty());
+    assert!(
+        !decoded.gas_paid_by_publisher,
+        "gas_paid_by_publisher must default to false when absent from JSON"
+    );
+    assert_eq!(
+        decoded.publisher_gas_limit_per_op, 0,
+        "publisher_gas_limit_per_op must default to 0 when absent from JSON"
+    );
+
+    // JSON path with all fields explicit: round-tripping a current-shape
+    // payload preserves both new fields.
+    let json_full = r#"{
+        "signer_ids": [7],
+        "signature": [1, 2],
+        "gas_paid_by_publisher": true,
+        "publisher_gas_limit_per_op": 50000
+    }"#;
+    let decoded: AggregateInfo = serde_json::from_str(json_full)?;
+    assert!(decoded.gas_paid_by_publisher);
+    assert_eq!(decoded.publisher_gas_limit_per_op, 50_000);
+
+    // Postcard round-trip with the new fields: serialize and deserialize
+    // a current-shape AggregateInfo to confirm wire-format stability. This
+    // also pins the wire layout against accidental field-order changes.
+    let current = AggregateInfo {
+        signer_ids: vec![42, 43],
+        signature: vec![1, 2, 3, 4],
+        gas_paid_by_publisher: true,
+        publisher_gas_limit_per_op: 7_500,
+    };
+    let bytes = indexer_types::serialize(&current)?;
+    let decoded: AggregateInfo = indexer_types::deserialize(&bytes)?;
+    assert_eq!(decoded.signer_ids, current.signer_ids);
+    assert_eq!(decoded.signature, current.signature);
+    assert!(decoded.gas_paid_by_publisher);
+    assert_eq!(decoded.publisher_gas_limit_per_op, 7_500);
+
+    // Postcard regression — document the known limitation explicitly. A
+    // payload encoded with only the two original fields CANNOT decode into
+    // the new struct shape; postcard's `SeqAccess` errors with
+    // `DeserializeUnexpectedEnd` before `#[serde(default)]` can take effect.
+    // If a future maintainer adds a custom Deserialize impl that tolerates
+    // truncated input, this test will need to flip to `is_ok()` and verify
+    // the defaults — until then, we pin the limitation so the regression is
+    // intentional rather than accidental.
+    #[derive(Serialize)]
+    struct LegacyAggregateInfo {
+        signer_ids: Vec<u64>,
+        signature: Vec<u8>,
+    }
+    let legacy = LegacyAggregateInfo {
+        signer_ids: vec![1, 2],
+        signature: vec![9; 4],
+    };
+    let legacy_bytes = indexer_types::serialize(&legacy)?;
+    let decoded: Result<AggregateInfo, _> = indexer_types::deserialize(&legacy_bytes);
+    assert!(
+        decoded.is_err(),
+        "postcard payloads predating the new fields are NOT expected to \
+         decode today — see comment above and \
+         https://github.com/jamesmunns/postcard/issues/159"
+    );
+
+    Ok(())
+}

--- a/core/indexer/tests/contracts/bls_replay_protection.rs
+++ b/core/indexer/tests/contracts/bls_replay_protection.rs
@@ -33,6 +33,8 @@ fn aggregate_insts(ops: Vec<Inst>, signer_ids: Vec<u64>, signature: Vec<u8>) -> 
         aggregate: Some(AggregateInfo {
             signer_ids,
             signature,
+            gas_paid_by_publisher: false,
+            publisher_gas_limit_per_op: 0,
         }),
     }
 }

--- a/core/indexer/tests/contracts/bls_user_registry.rs
+++ b/core/indexer/tests/contracts/bls_user_registry.rs
@@ -55,6 +55,8 @@ async fn bls_user_registry_register_in_aggregate_rejected_regtest() -> Result<()
         aggregate: Some(AggregateInfo {
             signer_ids: vec![0, 1],
             signature: vec![9u8; 48],
+            gas_paid_by_publisher: false,
+            publisher_gas_limit_per_op: 0,
         }),
     })
     .expect_err("aggregate RegisterBlsKey must be rejected");
@@ -184,6 +186,8 @@ async fn bls_user_registry_duplicate_same_key_in_aggregate_rejected_regtest() ->
         aggregate: Some(AggregateInfo {
             signer_ids: vec![0, 0],
             signature: vec![9u8; 48],
+            gas_paid_by_publisher: false,
+            publisher_gas_limit_per_op: 0,
         }),
     })
     .expect_err("aggregate RegisterBlsKey must be rejected");
@@ -251,6 +255,8 @@ async fn bls_user_registry_different_keys_same_xonly_in_aggregate_rejected_regte
         aggregate: Some(AggregateInfo {
             signer_ids: vec![0, 0],
             signature: vec![9u8; 48],
+            gas_paid_by_publisher: false,
+            publisher_gas_limit_per_op: 0,
         }),
     })
     .expect_err("aggregate RegisterBlsKey must be rejected");
@@ -313,6 +319,8 @@ async fn bls_user_registry_malformed_sig_lengths_in_aggregate_rejected_regtest()
             aggregate: Some(AggregateInfo {
                 signer_ids: vec![0],
                 signature: vec![9u8; 48],
+                gas_paid_by_publisher: false,
+                publisher_gas_limit_per_op: 0,
             }),
         })
         .expect_err("aggregate RegisterBlsKey must be rejected");

--- a/core/indexer/tests/contracts/mod.rs
+++ b/core/indexer/tests/contracts/mod.rs
@@ -1,6 +1,8 @@
 mod amm_contract;
 mod bls_attack_vectors;
 mod bls_bulk_compose;
+mod bls_bulk_publisher_pays;
+mod bls_bulk_publisher_pays_backward_compat;
 mod bls_key_derivation_and_registration;
 mod bls_replay_protection;
 mod bls_user_registry;
@@ -46,6 +48,8 @@ testlib::regtest_tests! {
     amm_contract,
     bls_attack_vectors,
     bls_bulk_compose,
+    bls_bulk_publisher_pays,
+    bls_bulk_publisher_pays_backward_compat,
     bls_key_derivation_and_registration,
     bls_replay_protection,
     bls_user_registry,

--- a/core/testlib/src/lib.rs
+++ b/core/testlib/src/lib.rs
@@ -422,6 +422,22 @@ impl RuntimeRegtest {
         &self,
         calls: &[(&Signer, &ContractAddress, &str)],
     ) -> Result<Insts> {
+        self.compose_bls_bulk(calls, 10_000, false, 0).await
+    }
+
+    /// Build BLS aggregate Insts with full control over per-op gas and
+    /// publisher-paid sponsorship. Used both by the default
+    /// `build_aggregate_insts` (gas_limit_per_call = 10_000, no sponsor)
+    /// and by tests that exercise the sponsored-gas path. `gas_limit = 0`
+    /// is allowed and intentional when paired with
+    /// `gas_paid_by_publisher = true`.
+    pub async fn compose_bls_bulk(
+        &self,
+        calls: &[(&Signer, &ContractAddress, &str)],
+        gas_limit_per_call: u64,
+        gas_paid_by_publisher: bool,
+        publisher_gas_limit_per_op: u64,
+    ) -> Result<Insts> {
         use blst::min_sig::{AggregateSignature, SecretKey as BlsSecretKey};
 
         let mut ops = Vec::with_capacity(calls.len());
@@ -441,7 +457,7 @@ impl RuntimeRegtest {
             *nonce += 1;
 
             ops.push(Inst::Call {
-                gas_limit: 10_000,
+                gas_limit: gas_limit_per_call,
                 contract: (*contract).clone().into(),
                 nonce: Some(current_nonce),
                 expr: expr.to_string(),
@@ -471,6 +487,8 @@ impl RuntimeRegtest {
             aggregate: Some(indexer_types::AggregateInfo {
                 signer_ids,
                 signature: aggregate.to_signature().to_bytes().to_vec(),
+                gas_paid_by_publisher,
+                publisher_gas_limit_per_op,
             }),
         })
     }

--- a/kontor-ts/src/bindings.d.ts
+++ b/kontor-ts/src/bindings.d.ts
@@ -3,6 +3,39 @@
 export type AggregateInfo = {
   signer_ids: Array<bigint>;
   signature: Array<number>;
+  /**
+   * Opt-in flag: when true, ops whose user-signed `gas_limit == 0`
+   * are paid for by the Bitcoin publisher (the x_only_pubkey that
+   * signs the Taproot witness) using `publisher_gas_limit_per_op`
+   * as effective fuel cap.
+   *
+   * `#[serde(default)]` populates JSON paths (kontor-ts bindings,
+   * `serde_json::from_str`) when the field is absent. Postcard is
+   * non-self-describing and DOES NOT use this default — old
+   * postcard payloads encoded before this field existed cannot be
+   * decoded by the new shape (they error with
+   * `DeserializeUnexpectedEnd`). This is acceptable today because
+   * no BLS bulk payloads predate this change; if that ever changes,
+   * a custom `Deserialize` would be required.
+   *
+   * NOT included in `aggregate_signing_message` — co-signers
+   * express their consent to be sponsored cryptographically by
+   * signing `gas_limit = 0` (which IS part of `Inst::Call` and so
+   * IS in the signed message). The publisher's consent is
+   * expressed by signing the Taproot spend.
+   */
+  gas_paid_by_publisher: boolean;
+  /**
+   * Effective gas_limit applied to every op in the bulk that
+   * signs `gas_limit = 0` and is sponsored by the publisher.
+   * Chosen by the publisher (not signed by co-signers).
+   *
+   * `#[serde(default)]` applies on JSON paths (see
+   * `gas_paid_by_publisher` above for the postcard caveat).
+   * Validated by `validate_aggregate_shape`: must be > 0 when
+   * `gas_paid_by_publisher == true`.
+   */
+  publisher_gas_limit_per_op: number;
 };
 
 export type Block = {


### PR DESCRIPTION
Add per-op opt-in sponsorship: when AggregateInfo.gas_paid_by_publisher is true and an op signs gas_limit = 0, the Bitcoin publisher's identity funds the token::hold/release instead of the co-signer. Applicative signer (contract auth, result attribution, nonces) is unchanged.

- Two new AggregateInfo fields (gas_paid_by_publisher, publisher_gas_limit_per_op) with #[serde(default)] for JSON backward-compat; postcard limitation documented and pinned.
- validate_aggregate_shape rejects flag=true with cap=0 to prevent silent out-of-fuel traps.
- Runtime.gas_payer override applied only in prepare_call/ handle_procedure; executor resets it after each op so it never leaks across operations.
- Direct (non-aggregate) path strictly unchanged.

Covered by 5 regtest scenarios (happy path, mixed payment, gas_zero without flag, insufficient funds, invalid shape) plus a local serde backward-compat test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes BLS aggregate execution to optionally charge gas to the Bitcoin publisher via a new runtime payer override, which affects token accounting and per-op execution semantics; direct/non-aggregate flow is intended to remain unchanged but needs careful review for leakage across ops.
> 
> **Overview**
> Adds **publisher-paid (sponsored) gas** for BLS aggregate bundles: bundles can opt in via new `AggregateInfo.gas_paid_by_publisher` and `publisher_gas_limit_per_op`, and any op whose *signed* `gas_limit == 0` will run with an effective gas limit provided by the publisher and have `token::hold`/`token::release` charged to the publisher’s identity.
> 
> Enforces a new aggregate shape rule rejecting `gas_paid_by_publisher=true` with a zero per-op cap, threads a per-op `gas_payer` through the executor into the runtime (set/reset per op), and updates TS bindings plus adds extensive unit/regtest coverage for happy path, mixed payment, legacy `gas_limit=0` behavior, insufficient publisher funds, invalid shape, and JSON/postcard (non-)compat behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6881fcd0855d0c1e8acc016c31cb4c90921b7f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->