### PR TITLE
SDK: contract calls end-to-end — `transfer().submit().wait()` against a live regtest chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,29 +54,12 @@ jobs:
         working-directory: ./native-contracts
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@v1.17.8
-      - name: Install wasm-opt
-        run: cargo binstall wasm-opt --no-confirm
       - name: Run clippy (core)
         run: cargo clippy --workspace --tests -- -D warnings
         working-directory: ./core
       - name: Check wit-validator compiles to wasm32-unknown-unknown
         run: cargo check -p wit-validator --target wasm32-unknown-unknown
         working-directory: ./core
-      - name: Install wasm-tools
-        run: cargo binstall wasm-tools --no-confirm
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-      - name: Install sdk dependencies
-        run: npm ci
-        working-directory: ./sdk
-      - name: Build sdk (Rust + TS)
-        run: npm run build:rs && npm run build
-        working-directory: ./sdk
-      - name: Test sdk
-        run: npm test
-        working-directory: ./sdk
       - name: Install cargo-audit
         run: cargo binstall cargo-audit --no-confirm
       - name: Audit (test-contracts)
@@ -139,6 +122,59 @@ jobs:
       - name: Run tests
         working-directory: ./core
         run: REGTEST=1 cargo test --release --workspace
+
+  sdk:
+    name: SDK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: cargo-registry-${{ github.job }}-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-registry-${{ github.job }}-${{ runner.os }}-
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Install dependencies (Linux)
+        run: sudo apt-get update && sudo apt-get install -y libzmq3-dev libboost-all-dev
+      - name: Download Bitcoin Core v30.2
+        run: |
+          curl -L -o bitcoin.zip "https://github.com/KontorProtocol/Kontor/releases/download/bitcoin-v30.2/bitcoin-${{ runner.os }}-${{ runner.arch }}.zip"
+          unzip bitcoin.zip -d bitcoin-bin
+          chmod +x bitcoin-bin/*
+          echo "${{ github.workspace }}/bitcoin-bin" >> $GITHUB_PATH
+      - name: Test bitcoind
+        run: bitcoind --version
+      # `kontor regtest` (spawned by the SDK's `startRegtest`) is the
+      # release binary; native contracts are committed `.wasm.br`, so this
+      # needs no wasm toolchain.
+      - name: Build kontor binary
+        run: cargo build --release --bin kontor
+        working-directory: ./core
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install SDK dependencies
+        run: npm ci
+        working-directory: ./sdk
+      - name: Build SDK
+        run: npm run build
+        working-directory: ./sdk
+      - name: Unit tests
+        run: npm test
+        working-directory: ./sdk
+      - name: Live regtest test
+        run: npm run test:regtest
+        working-directory: ./sdk
 
   docker-cache-deps:
     name: Docker - Cache Dependencies (${{ matrix.arch }})

--- a/core/indexer-types/src/lib.rs
+++ b/core/indexer-types/src/lib.rs
@@ -148,6 +148,24 @@ pub struct RevealOutputs {
     pub participants: Vec<ParticipantScripts>,
 }
 
+/// Request body for `POST /api/transactions/broadcast`: raw Bitcoin tx
+/// hex in dependency order (e.g. `[commit, reveal]`), relayed to bitcoind
+/// as a single `submitpackage`.
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "../../../sdk/src/bindings.d.ts")]
+pub struct BroadcastQuery {
+    pub transactions: Vec<String>,
+}
+
+/// Response from `POST /api/transactions/broadcast`: the txid of the last
+/// transaction in the package — the reveal, which carries the Kontor op
+/// and is what callers wait on for results.
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "../../../sdk/src/bindings.d.ts")]
+pub struct BroadcastResult {
+    pub txid: String,
+}
+
 #[derive(Debug, Serialize, Deserialize, TS)]
 #[ts(export, export_to = "../../../sdk/src/bindings.d.ts")]
 pub struct ErrorResponse {

--- a/core/indexer/src/api/handlers/transactions.rs
+++ b/core/indexer/src/api/handlers/transactions.rs
@@ -5,7 +5,10 @@ use axum::{
     extract::{Path, Query, State},
 };
 use bitcoin::consensus::encode;
-use indexer_types::{OpWithResult, PaginatedResponse, TransactionHex, TransactionRow};
+use indexer_types::{
+    BroadcastQuery, BroadcastResult, OpWithResult, PaginatedResponse, TransactionHex,
+    TransactionRow,
+};
 
 use super::validate_query;
 use crate::api::{Env, error::HttpError, result::Result};
@@ -60,6 +63,45 @@ pub async fn get_transaction_inspect(
         .ok_or_else(|| HttpError::BadRequest("Not a valid Kontor transaction".to_string()))?;
     let conn = env.reader.connection().await?;
     Ok(inspect(&conn, &tx).await?.into())
+}
+
+/// Relay a package of raw Bitcoin transactions (dependency order — e.g.
+/// `[commit, reveal]`) to bitcoind via `submitpackage`. Lets SDK clients
+/// — browser ones especially — broadcast without their own bitcoind RPC
+/// access. Returns the last tx's txid; a rejected package is a 400 with
+/// the reason.
+pub async fn post_transaction_broadcast(
+    State(env): State<Env>,
+    Json(BroadcastQuery { transactions }): Json<BroadcastQuery>,
+) -> Result<BroadcastResult> {
+    let last = transactions
+        .last()
+        .ok_or_else(|| HttpError::BadRequest("no transactions provided".to_string()))?;
+    // Deserialize the last tx up front: validates the hex and gives the
+    // txid to return (submitpackage keys its results by wtxid).
+    let last_txid = encode::deserialize_hex::<bitcoin::Transaction>(last)
+        .map_err(|e| HttpError::BadRequest(format!("invalid transaction hex: {e}")))?
+        .compute_txid();
+
+    let result = env
+        .bitcoin
+        .submit_package(&transactions)
+        .await
+        .map_err(|e| HttpError::BadRequest(format!("broadcast failed: {e}")))?;
+
+    if result.package_msg != "success" {
+        let detail = result
+            .tx_results
+            .values()
+            .find_map(|r| r.error.clone())
+            .unwrap_or(result.package_msg);
+        return Err(HttpError::BadRequest(format!("package rejected: {detail}")).into());
+    }
+
+    Ok(BroadcastResult {
+        txid: last_txid.to_string(),
+    }
+    .into())
 }
 
 pub async fn post_simulate(

--- a/core/indexer/src/api/router.rs
+++ b/core/indexer/src/api/router.rs
@@ -22,8 +22,8 @@ use tracing::{Level, Span, error, field, info, span};
 use crate::api::handlers::{
     get_block_transactions, get_blocks, get_contract, get_contracts, get_fees, get_index,
     get_metrics, get_result, get_results, get_signer, get_transaction, get_transaction_inspect,
-    get_transactions, post_compose, post_contract, post_simulate, post_transaction_hex_inspect,
-    stop,
+    get_transactions, post_compose, post_contract, post_simulate, post_transaction_broadcast,
+    post_transaction_hex_inspect, stop,
 };
 
 use super::{
@@ -121,6 +121,7 @@ pub fn new(context: Env, prom_handle: PrometheusHandle) -> Router {
                         .route("/{txid}/inspect", get(get_transaction_inspect))
                         .route("/inspect", post(post_transaction_hex_inspect))
                         .route("/simulate", post(post_simulate))
+                        .route("/broadcast", post(post_transaction_broadcast))
                         .nest(
                             "/compose",
                             Router::new()

--- a/core/indexer/src/bitcoin_client/client.rs
+++ b/core/indexer/src/bitcoin_client/client.rs
@@ -308,10 +308,7 @@ impl Client {
     /// mempool atomically — validation + broadcast in one RPC. Used to
     /// relay a Kontor commit+reveal pair so the reveal can't land without
     /// its parent.
-    pub async fn submit_package(
-        &self,
-        raw_txs: &[String],
-    ) -> Result<SubmitPackageResult, Error> {
+    pub async fn submit_package(&self, raw_txs: &[String]) -> Result<SubmitPackageResult, Error> {
         self.call("submitpackage", vec![raw_txs.into()]).await
     }
 

--- a/core/indexer/src/bitcoin_client/client.rs
+++ b/core/indexer/src/bitcoin_client/client.rs
@@ -9,7 +9,8 @@ use serde_json::Value;
 
 use crate::bitcoin_client::types::{
     Acceptance, CreateWalletResult, GetMempoolInfoResult, GetNetworkInfoResult,
-    GetRawMempoolResult, MempoolEntry, TestMempoolAcceptResult, fee_rate_sat_per_vb,
+    GetRawMempoolResult, MempoolEntry, SubmitPackageResult, TestMempoolAcceptResult,
+    fee_rate_sat_per_vb,
 };
 use crate::config::{Config, RegtestConfig};
 
@@ -301,6 +302,17 @@ impl Client {
         raw_txs: &[String],
     ) -> Result<Vec<TestMempoolAcceptResult>, Error> {
         self.call("testmempoolaccept", vec![raw_txs.into()]).await
+    }
+
+    /// Submit a package of raw transactions (in dependency order) to the
+    /// mempool atomically — validation + broadcast in one RPC. Used to
+    /// relay a Kontor commit+reveal pair so the reveal can't land without
+    /// its parent.
+    pub async fn submit_package(
+        &self,
+        raw_txs: &[String],
+    ) -> Result<SubmitPackageResult, Error> {
+        self.call("submitpackage", vec![raw_txs.into()]).await
     }
 
     pub async fn stop(&self) -> Result<String, Error> {

--- a/core/indexer/src/bitcoin_client/types.rs
+++ b/core/indexer/src/bitcoin_client/types.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt;
 
 use bitcoin::{Amount, Network, Txid};
@@ -120,6 +121,24 @@ pub struct TestMempoolAcceptResult {
     pub reject_reason: Option<String>,
     pub vsize: Option<u64>,
     pub fees: Option<TestMempoolAcceptResultFees>,
+}
+
+/// Result of bitcoind's `submitpackage`. `package_msg` is `"success"`
+/// when the whole package was accepted into the mempool; otherwise it
+/// describes the failure. `tx_results` is keyed by wtxid; extra fields
+/// bitcoind returns (vsize, fees, replaced-transactions) are ignored.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SubmitPackageResult {
+    pub package_msg: String,
+    #[serde(rename = "tx-results")]
+    pub tx_results: HashMap<String, SubmitPackageTxResult>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SubmitPackageTxResult {
+    pub txid: Txid,
+    /// Per-transaction rejection reason, when this tx specifically failed.
+    pub error: Option<String>,
 }
 
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]

--- a/core/indexer/src/main.rs
+++ b/core/indexer/src/main.rs
@@ -90,6 +90,10 @@ async fn run_regtest() -> Result<()> {
 
     let api_port = cluster.node_configs[0].api_port;
     let dev = &cluster.identity;
+    // The dev account's current spendable Bitcoin UTXO (the change output
+    // of the Issuance above) — the SDK passes it to `submit` as funding,
+    // since the SDK never sources UTXOs itself.
+    let funding = &dev.next_funding_utxo;
     // One JSON line, consumed by `@kontor/sdk/regtest`'s `startRegtest()`.
     // A single line is parsed atomically — it can't be matched while still
     // half-streamed the way five independent marker lines could.
@@ -99,6 +103,12 @@ async fn run_regtest() -> Result<()> {
         "devPrivateKey": hex::encode(dev.keypair.secret_bytes()),
         "devPublicKey": dev.x_only_public_key().to_string(),
         "devAddress": dev.address.to_string(),
+        "devFundingUtxo": {
+            "txid": funding.0.txid.to_string(),
+            "vout": funding.0.vout,
+            "value": funding.1.value.to_sat(),
+            "scriptPubKey": hex::encode(funding.1.script_pubkey.as_bytes()),
+        },
     });
     println!("KONTOR_REGTEST_INFO {info}");
     println!("kontor regtest devnet running — Ctrl-C to stop");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Kontor",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "Kontor",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -7,6 +7,11 @@
     "": {
       "name": "@kontor/sdk",
       "version": "0.3.0",
+      "dependencies": {
+        "@scure/bip32": "^2.2.0",
+        "@scure/bip39": "^2.2.0",
+        "@scure/btc-signer": "^2.2.0"
+      },
       "bin": {
         "kontor-codegen": "dist/cli.js"
       },
@@ -237,29 +242,6 @@
       ],
       "bin": {
         "wizer-win32-x64": "wizer"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -673,6 +655,33 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@oxc-parser/binding-android-arm64": {
@@ -1254,6 +1263,57 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.2.0.tgz",
+      "integrity": "sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.2.0.tgz",
+      "integrity": "sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/btc-signer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/btc-signer/-/btc-signer-2.2.0.tgz",
+      "integrity": "sha512-ZXZ08sZqSZKEcOuEQnxTF66ouHtl6+UA6U/QfQM06K9WiOlEkXF4LviZCaSgkdiFh9cyMt9+xdup7JtEv3p0fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~2.2.0",
+        "@noble/hashes": "~2.2.0",
+        "@scure/base": "~2.2.0",
+        "micro-packed": "~0.9.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1303,6 +1363,7 @@
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -1336,6 +1397,7 @@
       "integrity": "sha512-OlTlJej7YN6VwV7zJJoNeaCsctF+JXpzpZ4oBHUbrQFfIq+0KW2f07rprCLh9N/zRIZ0v4Mchn1QDDmWMUhPKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.1.7",
         "@vitest/mocker": "4.1.7",
@@ -2125,7 +2187,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -2747,6 +2808,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/micro-packed": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/micro-packed/-/micro-packed-0.9.0.tgz",
+      "integrity": "sha512-gFdaWTxEXOwtSOcpxulO4AuXVtp3HWIRmB8eq8+3m1Zku0ubgva0UGpi03YhcvsTJasHngG9gTIUK5kHNKdesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@scure/base": "~2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -3060,7 +3136,6 @@
       "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -3187,6 +3262,7 @@
       "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.132.0",
         "@rolldown/pluginutils": "^1.0.0"
@@ -3596,6 +3672,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3712,6 +3789,7 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3831,6 +3909,7 @@
       "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.7",
         "@vitest/mocker": "4.1.7",

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@kontor/sdk",
       "version": "0.3.0",
       "dependencies": {
+        "@scure/base": "^2.2.0",
         "@scure/bip32": "^2.2.0",
         "@scure/bip39": "^2.2.0",
         "@scure/btc-signer": "^2.2.0"

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -245,6 +245,31 @@
         "wizer-win32-x64": "wizer"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -3536,9 +3561,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.47.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
-      "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -47,7 +47,9 @@
     "build": "npm run build:ts",
     "prepare": "npm run build",
     "test": "vitest",
-    "test:browser": "vitest --browser"
+    "test:browser": "vitest --browser",
+    "test:regtest": "npm run build && vitest --config vitest.regtest.config.ts",
+    "test:regtest:browser": "npm run build && vitest --config vitest.regtest.config.ts --browser"
   },
   "devDependencies": {
     "@bytecodealliance/jco": "^1.19.0",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -59,6 +59,7 @@
     "vitest": "^4.1.6"
   },
   "dependencies": {
+    "@scure/base": "^2.2.0",
     "@scure/bip32": "^2.2.0",
     "@scure/bip39": "^2.2.0",
     "@scure/btc-signer": "^2.2.0"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -57,5 +57,10 @@
     "vite": "^8.0.13",
     "vite-plugin-dts": "^5.0.0",
     "vitest": "^4.1.6"
+  },
+  "dependencies": {
+    "@scure/bip32": "^2.2.0",
+    "@scure/bip39": "^2.2.0",
+    "@scure/btc-signer": "^2.2.0"
   }
 }

--- a/sdk/src/account/local.ts
+++ b/sdk/src/account/local.ts
@@ -19,6 +19,7 @@
  * For browser / wallet-mediated signing, use `WalletAccount` instead.
  */
 
+import { hex } from "@scure/base";
 import { HDKey } from "@scure/bip32";
 import { mnemonicToSeedSync, validateMnemonic } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english.js";
@@ -80,7 +81,7 @@ export class LocalAccount implements Account {
     if (payment.address == null) {
       throw new SignerError("LocalAccount: could not derive a P2TR address");
     }
-    this.xOnlyPubKey = bytesToHex(xOnly);
+    this.xOnlyPubKey = hex.encode(xOnly);
     this.address = payment.address;
     this.holderRef = HolderRef.xOnlyPubkey(this.xOnlyPubKey);
   }
@@ -195,24 +196,13 @@ function bip86Path(chain: Chain, idx: Bip86Indices): string {
   return `m/${BIP86_PURPOSE}'/${coinType(chain)}'/${account}'/${change}/${address}`;
 }
 
+/** Decode a hex private key (optionally `0x`-prefixed) to bytes. */
 function hexToBytes(s: string): Uint8Array {
-  const clean = s.startsWith("0x") ? s.slice(2) : s;
-  if (clean.length % 2 !== 0) {
-    throw new SignerError("private key hex has an odd length");
+  try {
+    return hex.decode(s.startsWith("0x") ? s.slice(2) : s);
+  } catch (cause) {
+    throw new SignerError("private key is not valid hex", {
+      cause: cause instanceof Error ? cause : undefined,
+    });
   }
-  const out = new Uint8Array(clean.length / 2);
-  for (let i = 0; i < out.length; i++) {
-    const byte = Number.parseInt(clean.slice(2 * i, 2 * i + 2), 16);
-    if (Number.isNaN(byte)) {
-      throw new SignerError("private key hex contains invalid characters");
-    }
-    out[i] = byte;
-  }
-  return out;
-}
-
-function bytesToHex(b: Uint8Array): string {
-  let s = "";
-  for (const byte of b) s += byte.toString(16).padStart(2, "0");
-  return s;
 }

--- a/sdk/src/account/local.ts
+++ b/sdk/src/account/local.ts
@@ -1,43 +1,68 @@
 /**
- * In-process signer. Holds a private key directly, signs without
- * leaving the SDK. Use this for backend services, CLIs, and tests.
+ * In-process signer. Holds a secp256k1 private key directly and signs
+ * without it leaving the SDK — use it for backend services, CLIs,
+ * tests, and the regtest devnet's pre-funded dev key.
  *
- * Three construction paths:
+ * Three constructors, all converging on the same shape: a 32-byte
+ * secret, the BIP-340 x-only taproot pubkey, and the bech32m P2TR
+ * address for the bound chain.
+ *
  *   - `LocalAccount.fromPrivateKey({ privateKey, chain })`
- *   - `LocalAccount.fromHdKey({ hdKey, chain, path? })`
- *   - `LocalAccount.fromMnemonic({ mnemonic, chain, passphrase?, ... })`
+ *   - `LocalAccount.fromHdKey({ hdKey, chain, ... })`
+ *   - `LocalAccount.fromMnemonic({ mnemonic, chain, ... })`
  *
- * All three converge on the same shape: a 32-byte secp256k1 secret,
- * the x-only taproot pubkey, and the bech32m address. Signing uses
- * `@scure/btc-signer` (BIP-340 schnorr) — same code Bitcoin Core
- * verifies against, no custom crypto.
+ * HD derivation is BIP-86 — `m/86'/coin'/account'/change/address` —
+ * with coin type 0 for mainnet and 1 for every test network. Address
+ * encoding and PSBT signing run through `@scure/btc-signer`, the same
+ * primitives Bitcoin Core verifies against; no custom crypto here.
  *
  * For browser / wallet-mediated signing, use `WalletAccount` instead.
  */
 
+import { HDKey } from "@scure/bip32";
+import { mnemonicToSeedSync, validateMnemonic } from "@scure/bip39";
+import { wordlist } from "@scure/bip39/wordlists/english.js";
+import { Transaction, p2tr, utils as btcUtils } from "@scure/btc-signer";
+
 import { HolderRef } from "../canonical/HolderRef.js";
 import { SignerError } from "../errors.js";
 import type { Account } from "./index.js";
-import type { Chain } from "../chains.js";
+import type { BitcoinNetwork, Chain } from "../chains.js";
+
+/** BIP-86 path components beyond purpose and coin type. */
+export interface Bip86Indices {
+  /** Account index — the `account'` component. Default 0. */
+  accountIndex?: number;
+  /** External (0) vs change (1) chain. Default 0. */
+  changeIndex?: 0 | 1;
+  /** Address index — the final component. Default 0. */
+  addressIndex?: number;
+}
 
 export interface FromPrivateKeyOptions {
-  /** 32-byte secp256k1 secret, hex string or Uint8Array. */
+  /** 32-byte secp256k1 secret, hex string or `Uint8Array`. */
   privateKey: string | Uint8Array;
   chain: Chain;
 }
 
-export interface FromMnemonicOptions {
+export interface FromHdKeyOptions extends Bip86Indices {
+  /** A `@scure/bip32` HD node — must carry a private key. */
+  hdKey: HDKey;
+  chain: Chain;
+  /**
+   * Full derivation path override. When set, the `*Index` options are
+   * ignored; when omitted, the BIP-86 path is built from them plus the
+   * chain's coin type.
+   */
+  path?: string;
+}
+
+export interface FromMnemonicOptions extends Bip86Indices {
   /** BIP-39 mnemonic phrase. */
   mnemonic: string;
   chain: Chain;
-  /** Optional BIP-39 passphrase. */
+  /** Optional BIP-39 passphrase ("25th word"). */
   passphrase?: string;
-  /** BIP-86 account index (default 0). */
-  accountIndex?: number;
-  /** BIP-86 address index (default 0). */
-  addressIndex?: number;
-  /** External (0) vs change (1) chain (default 0). */
-  changeIndex?: 0 | 1;
 }
 
 export class LocalAccount implements Account {
@@ -46,42 +71,148 @@ export class LocalAccount implements Account {
   readonly holderRef: HolderRef;
 
   private constructor(
+    /** Raw 32-byte secp256k1 secret. Held for the instance's lifetime. */
     readonly privateKey: Uint8Array,
-    xOnlyPubKey: string,
-    address: string,
+    network: BitcoinNetwork,
   ) {
-    this.xOnlyPubKey = xOnlyPubKey;
-    this.address = address;
-    this.holderRef = HolderRef.xOnlyPubkey(xOnlyPubKey);
+    const xOnly = btcUtils.pubSchnorr(privateKey);
+    const payment = p2tr(xOnly, undefined, network);
+    if (payment.address == null) {
+      throw new SignerError("LocalAccount: could not derive a P2TR address");
+    }
+    this.xOnlyPubKey = bytesToHex(xOnly);
+    this.address = payment.address;
+    this.holderRef = HolderRef.xOnlyPubkey(this.xOnlyPubKey);
   }
 
   /**
-   * Build an account from a raw private key. The key is held in
+   * Build an account from a raw 32-byte private key. The key is held in
    * memory for the lifetime of the instance.
    */
-  static fromPrivateKey(_opts: FromPrivateKeyOptions): LocalAccount {
-    throw new SignerError("LocalAccount.fromPrivateKey: not implemented", {
-      docsPath: "/sdk/account",
-    });
+  static fromPrivateKey(opts: FromPrivateKeyOptions): LocalAccount {
+    const key =
+      typeof opts.privateKey === "string"
+        ? hexToBytes(opts.privateKey)
+        : opts.privateKey;
+    if (key.length !== 32) {
+      throw new SignerError(
+        `private key must be 32 bytes, got ${key.length}`,
+        { docsPath: "/sdk/account" },
+      );
+    }
+    return new LocalAccount(key, opts.chain.network);
+  }
+
+  /**
+   * Build an account from a `@scure/bip32` HD node, deriving the BIP-86
+   * (P2TR) child key. The node must be private (a master seed node or
+   * an xprv) — an xpub-only node has no private key to sign with.
+   */
+  static fromHdKey(opts: FromHdKeyOptions): LocalAccount {
+    const path = opts.path ?? bip86Path(opts.chain, opts);
+    const node = opts.hdKey.derive(path);
+    if (node.privateKey == null) {
+      throw new SignerError(
+        "fromHdKey: the derived node has no private key — derive from a " +
+          "master seed or an xprv, not an xpub",
+        { docsPath: "/sdk/account" },
+      );
+    }
+    return new LocalAccount(node.privateKey, opts.chain.network);
   }
 
   /**
    * Build an account from a BIP-39 mnemonic, deriving the key via the
-   * BIP-86 (P2TR) path `m/86'/coinType'/account'/change/address`.
-   * `coinType` is taken from the chain (0 for mainnet, 1 for everything
-   * else).
+   * BIP-86 path `m/86'/coin'/account'/change/address`. `coin` is taken
+   * from the chain — 0 for mainnet, 1 for every test network.
    */
-  static fromMnemonic(_opts: FromMnemonicOptions): LocalAccount {
-    throw new SignerError("LocalAccount.fromMnemonic: not implemented", {
-      docsPath: "/sdk/account",
+  static fromMnemonic(opts: FromMnemonicOptions): LocalAccount {
+    if (!validateMnemonic(opts.mnemonic, wordlist)) {
+      throw new SignerError("fromMnemonic: invalid BIP-39 mnemonic", {
+        docsPath: "/sdk/account",
+      });
+    }
+    const seed = mnemonicToSeedSync(opts.mnemonic, opts.passphrase);
+    return LocalAccount.fromHdKey({
+      hdKey: HDKey.fromMasterSeed(seed),
+      chain: opts.chain,
+      accountIndex: opts.accountIndex,
+      changeIndex: opts.changeIndex,
+      addressIndex: opts.addressIndex,
     });
   }
 
   signMessage(_message: string | Uint8Array): Promise<string> {
-    throw new SignerError("LocalAccount.signMessage: not implemented");
+    return Promise.reject(
+      new SignerError(
+        "LocalAccount.signMessage: not yet implemented — BIP-322 message " +
+          "signing lands with the wallet/auth work, not the contract-call path",
+        { docsPath: "/sdk/account" },
+      ),
+    );
   }
 
-  signPsbt(_psbt: Uint8Array, _signInputs?: number[]): Promise<Uint8Array> {
-    throw new SignerError("LocalAccount.signPsbt: not implemented");
+  signPsbt(psbt: Uint8Array, signInputs?: number[]): Promise<Uint8Array> {
+    let tx: Transaction;
+    try {
+      tx = Transaction.fromPSBT(psbt);
+    } catch (cause) {
+      return Promise.reject(
+        new SignerError("signPsbt: input is not a valid PSBT", {
+          cause: cause instanceof Error ? cause : undefined,
+        }),
+      );
+    }
+    try {
+      if (signInputs == null) {
+        tx.sign(this.privateKey);
+      } else {
+        for (const index of signInputs) tx.signIdx(this.privateKey, index);
+      }
+    } catch (cause) {
+      return Promise.reject(
+        new SignerError("signPsbt: signing failed", {
+          cause: cause instanceof Error ? cause : undefined,
+        }),
+      );
+    }
+    return Promise.resolve(tx.toPSBT());
   }
+}
+
+const BIP86_PURPOSE = 86;
+
+/** BIP-44 coin type: 0 for Bitcoin mainnet, 1 for every test network. */
+function coinType(chain: Chain): 0 | 1 {
+  return chain.network.bech32 === "bc" ? 0 : 1;
+}
+
+/** Build the BIP-86 P2TR derivation path for `chain` and `idx`. */
+function bip86Path(chain: Chain, idx: Bip86Indices): string {
+  const account = idx.accountIndex ?? 0;
+  const change = idx.changeIndex ?? 0;
+  const address = idx.addressIndex ?? 0;
+  return `m/${BIP86_PURPOSE}'/${coinType(chain)}'/${account}'/${change}/${address}`;
+}
+
+function hexToBytes(s: string): Uint8Array {
+  const clean = s.startsWith("0x") ? s.slice(2) : s;
+  if (clean.length % 2 !== 0) {
+    throw new SignerError("private key hex has an odd length");
+  }
+  const out = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    const byte = Number.parseInt(clean.slice(2 * i, 2 * i + 2), 16);
+    if (Number.isNaN(byte)) {
+      throw new SignerError("private key hex contains invalid characters");
+    }
+    out[i] = byte;
+  }
+  return out;
+}
+
+function bytesToHex(b: Uint8Array): string {
+  let s = "";
+  for (const byte of b) s += byte.toString(16).padStart(2, "0");
+  return s;
 }

--- a/sdk/src/canonical/ContractAddress.ts
+++ b/sdk/src/canonical/ContractAddress.ts
@@ -36,4 +36,14 @@ export class ContractAddress {
   toString(): string {
     return `${this.name}@${this.height}.${this.txIndex}`;
   }
+
+  /**
+   * The indexer's wire form — `name_height_txIndex` (Kontor's
+   * `ContractAddress` `Display`/`FromStr`). Used in API URL paths and as
+   * the `contract` field of a wire `Call`. Distinct from `toString()`,
+   * which is the human-facing `name@height.txIndex`.
+   */
+  toWire(): string {
+    return `${this.name}_${this.height}_${this.txIndex}`;
+  }
 }

--- a/sdk/src/chains.ts
+++ b/sdk/src/chains.ts
@@ -83,3 +83,25 @@ export function nativeTokenAddress(chain: Chain): ContractAddress {
   }
   return new ContractAddress(nt.name, nt.height, nt.txIndex);
 }
+
+/**
+ * Build a `Chain` for a `kontor regtest` devnet at the given endpoints.
+ * Unlike `signet`, a regtest config is per-process — the ports are
+ * allocated at runtime — so it's a builder rather than a static const.
+ * `@kontor/sdk/regtest`'s `startRegtest()` calls this with the endpoints
+ * it parses from the binary; callers running their own devnet can too.
+ */
+export function regtestChain(endpoints: {
+  apiUrl: string;
+  bitcoinRpc: string;
+}): Chain {
+  return {
+    name: "regtest",
+    nativeCurrency: { name: "Kontor", symbol: "KOR", decimals: 18 },
+    // `kontor regtest` auto-mines roughly every 10s.
+    blockTime: 10_000,
+    urls: { http: endpoints.apiUrl, bitcoinRpc: endpoints.bitcoinRpc },
+    contracts: { nativeToken: { name: "token", height: 0n, txIndex: 0n } },
+    network: { bech32: "bcrt", pubKeyHash: 0x6f, scriptHash: 0xc4, wif: 0xef },
+  };
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -32,6 +32,13 @@ export type { Inst } from "./inst";
 export { signet } from "./chains";
 export type { Chain } from "./chains";
 export type { Account } from "./account/index";
+export { LocalAccount } from "./account/local";
+export type {
+  Bip86Indices,
+  FromHdKeyOptions,
+  FromMnemonicOptions,
+  FromPrivateKeyOptions,
+} from "./account/local";
 export { Decimal } from "./canonical/Decimal";
 export { Integer } from "./canonical/Integer";
 export { HolderRef } from "./canonical/HolderRef";

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -29,6 +29,8 @@ export type { KontorTransport } from "./json-codec";
 // aggregate — lands with the runtime implementation (work item #13).
 export { KontorSession } from "./session";
 export type { Inst } from "./inst";
+export { HttpTransport, http } from "./transport/http";
+export type { HttpTransportOptions, Utxo } from "./transport/http";
 export { signet } from "./chains";
 export type { Chain } from "./chains";
 export type { Account } from "./account/index";

--- a/sdk/src/inst.ts
+++ b/sdk/src/inst.ts
@@ -190,7 +190,10 @@ export class Inst<T> implements PromiseLike<T> {
       txid,
       async wait(opts?: WaitOptions): Promise<OpResult<T>> {
         try {
-          return await waitForTx(events, txid, decode, opts);
+          // A single Inst is always op (0, 0) of its own tx. Multi-Inst
+          // (`bulk`) and aggregate bundles go through `Insts`, which
+          // maps every op of the tx itself.
+          return await waitForTx(events, txid, decode, 0, 0, opts);
         } finally {
           await events.return?.();
         }
@@ -250,21 +253,28 @@ function unwrapOrThrow<T>(r: OpResult<T>): T {
 
 /**
  * Drain the poller's event stream until the `tx` event for `txid`
- * arrives, then decode its (single) op outcome into an `OpResult<T>`.
- * Honors `timeoutMs` / `signal` from `WaitOptions`.
+ * arrives, then decode the op at `(inputIndex, opIndex)` into an
+ * `OpResult<T>`. Honors `timeoutMs` / `signal` from `WaitOptions`.
  */
 async function waitForTx<T>(
   events: AsyncIterableIterator<ChainEvent>,
   txid: string,
   decode: InstDecoder<T>,
+  inputIndex: number,
+  opIndex: number,
   opts?: WaitOptions,
 ): Promise<OpResult<T>> {
   const scan = async (): Promise<OpResult<T>> => {
     for await (const ev of events) {
       if (ev.kind !== "tx" || ev.txid !== txid) continue;
-      const raw = ev.outcomes[0];
+      // The poller has collapsed each op to its canonical result.
+      const raw = ev.outcomes.find(
+        (o) => o.inputIndex === inputIndex && o.opIndex === opIndex,
+      );
       if (raw === undefined) {
-        throw new TransportError(`wait: tx ${txid} landed with no op results`);
+        throw new TransportError(
+          `wait: tx ${txid} carried no result for op (${inputIndex}, ${opIndex})`,
+        );
       }
       return {
         status: raw.status,

--- a/sdk/src/inst.ts
+++ b/sdk/src/inst.ts
@@ -294,17 +294,26 @@ async function waitForTx<T>(
   // unblocks when the caller's `finally` closes the event iterator.
   return new Promise<OpResult<T>>((resolve, reject) => {
     let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const onAbort = (): void =>
+      settle(() => reject(new TransportError(`wait: aborted for tx ${txid}`)));
+
+    // First settler wins; on the way out, release the timer and abort
+    // listener so neither keeps the event loop (or the signal) alive.
     const settle = (fn: () => void): void => {
       if (settled) return;
       settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      opts.signal?.removeEventListener("abort", onAbort);
       fn();
     };
+
     scan().then(
       (r) => settle(() => resolve(r)),
       (e) => settle(() => reject(e)),
     );
     if (opts.timeoutMs != null) {
-      setTimeout(
+      timer = setTimeout(
         () =>
           settle(() =>
             reject(
@@ -317,12 +326,8 @@ async function waitForTx<T>(
       );
     }
     if (opts.signal != null) {
-      const onAbort = (): void =>
-        settle(() =>
-          reject(new TransportError(`wait: aborted for tx ${txid}`)),
-        );
       if (opts.signal.aborted) onAbort();
-      else opts.signal.addEventListener("abort", onAbort, { once: true });
+      else opts.signal.addEventListener("abort", onAbort);
     }
   });
 }

--- a/sdk/src/inst.ts
+++ b/sdk/src/inst.ts
@@ -32,9 +32,16 @@
 
 import type { AggregateFragment } from "./aggregate.js";
 import type { Account } from "./account/index.js";
+import type {
+  Inst as WireInst,
+  InstKind as WireInstKind,
+  Insts as WireInsts,
+  PaymentIntent as WirePaymentIntent,
+} from "./bindings.js";
 import type { ContractAddress } from "./canonical/ContractAddress.js";
-import { ContractError, SignerError } from "./errors.js";
-import type { OpResult } from "./json-codec.js";
+import { ContractError, SignerError, TransportError } from "./errors.js";
+import type { ChainEvent } from "./events.js";
+import type { BroadcastResult, OpResult } from "./json-codec.js";
 import type { KontorSession } from "./session.js";
 
 /**
@@ -166,7 +173,29 @@ export class Inst<T> implements PromiseLike<T> {
    * once the indexer surfaces the outcome.
    */
   async submit(): Promise<SubmittedTx<OpResult<T>>> {
-    throw new Error("Inst.submit: not implemented");
+    const wire: WireInsts = { ops: [instToWire(this)], aggregate: null };
+    // Attach to the poller's event stream *before* broadcasting, so the
+    // tx's result event can't slip past between broadcast and wait().
+    const events = this.session.events();
+    let broadcast: BroadcastResult;
+    try {
+      broadcast = await this.session.transport.submit(wire);
+    } catch (e) {
+      await events.return?.();
+      throw e;
+    }
+    const { txid } = broadcast;
+    const decode = this.decode;
+    return {
+      txid,
+      async wait(opts?: WaitOptions): Promise<OpResult<T>> {
+        try {
+          return await waitForTx(events, txid, decode, opts);
+        } finally {
+          await events.return?.();
+        }
+      },
+    };
   }
 
   /**
@@ -217,4 +246,112 @@ function unwrapOrThrow<T>(r: OpResult<T>): T {
   throw new ContractError(`contract call failed with status: ${r.status}`, {
     details: r.error,
   });
+}
+
+/**
+ * Drain the poller's event stream until the `tx` event for `txid`
+ * arrives, then decode its (single) op outcome into an `OpResult<T>`.
+ * Honors `timeoutMs` / `signal` from `WaitOptions`.
+ */
+async function waitForTx<T>(
+  events: AsyncIterableIterator<ChainEvent>,
+  txid: string,
+  decode: InstDecoder<T>,
+  opts?: WaitOptions,
+): Promise<OpResult<T>> {
+  const scan = async (): Promise<OpResult<T>> => {
+    for await (const ev of events) {
+      if (ev.kind !== "tx" || ev.txid !== txid) continue;
+      const raw = ev.outcomes[0];
+      if (raw === undefined) {
+        throw new TransportError(`wait: tx ${txid} landed with no op results`);
+      }
+      return {
+        status: raw.status,
+        gas: raw.gas,
+        error: raw.error,
+        value: raw.value !== undefined ? decode(raw.value) : undefined,
+      };
+    }
+    throw new TransportError(
+      `wait: event stream ended before tx ${txid} landed`,
+    );
+  };
+
+  if (opts?.timeoutMs == null && opts?.signal == null) return scan();
+
+  // Race the scan against the timeout / abort signal. The losing `scan`
+  // unblocks when the caller's `finally` closes the event iterator.
+  return new Promise<OpResult<T>>((resolve, reject) => {
+    let settled = false;
+    const settle = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      fn();
+    };
+    scan().then(
+      (r) => settle(() => resolve(r)),
+      (e) => settle(() => reject(e)),
+    );
+    if (opts.timeoutMs != null) {
+      setTimeout(
+        () =>
+          settle(() =>
+            reject(
+              new TransportError(
+                `wait: tx ${txid} not seen within ${opts.timeoutMs}ms`,
+              ),
+            ),
+          ),
+        opts.timeoutMs,
+      );
+    }
+    if (opts.signal != null) {
+      const onAbort = (): void =>
+        settle(() =>
+          reject(new TransportError(`wait: aborted for tx ${txid}`)),
+        );
+      if (opts.signal.aborted) onAbort();
+      else opts.signal.addEventListener("abort", onAbort, { once: true });
+    }
+  });
+}
+
+/**
+ * Convert an SDK `Inst` to its wire shape — the JSON `Inst` the
+ * indexer's compose endpoint consumes. Exported for `session.bulk`,
+ * which assembles several into one `Insts` bundle.
+ *
+ * @internal
+ */
+export function instToWire(inst: Inst<unknown>): WireInst {
+  return {
+    payment: paymentToWire(inst.payment),
+    kind: instKindToWire(inst.kind),
+  };
+}
+
+function paymentToWire(p: PaymentIntent): WirePaymentIntent {
+  return p.kind === "SelfPay"
+    ? { SelfPay: { limit: Number(p.limit) } }
+    : "Sponsored";
+}
+
+function instKindToWire(k: InstKind): WireInstKind {
+  switch (k.kind) {
+    case "Call":
+      return { Call: { contract: k.contract.toWire(), expr: k.expr } };
+    case "Issuance":
+      return "Issuance";
+    case "Publish":
+      return { Publish: { name: k.name, bytes: [...k.bytes] } };
+    case "RegisterBlsKey":
+      return {
+        RegisterBlsKey: {
+          bls_pubkey: [...k.blsPubkey],
+          schnorr_sig: [...k.schnorrSig],
+          bls_sig: [...k.blsSig],
+        },
+      };
+  }
 }

--- a/sdk/src/json-codec.ts
+++ b/sdk/src/json-codec.ts
@@ -56,6 +56,17 @@ export interface OpResultRaw {
   error?: string;
   /** WAVE-encoded result. Absent on non-Ok status / void-return Insts. */
   value?: string;
+  /** The function this op invoked (e.g. `transfer`). */
+  func: string;
+  /** Contract the op ran on, wire form (`name_height_txIndex`). */
+  contract: string;
+  /**
+   * The op's position in the broadcast tx — Bitcoin input index and
+   * op index within that input. For a single-Inst `submit` the user's
+   * op is `(0, 0)`; `wait()` selects on these.
+   */
+  inputIndex: number | null;
+  opIndex: number | null;
 }
 
 /**

--- a/sdk/src/poller.ts
+++ b/sdk/src/poller.ts
@@ -366,11 +366,34 @@ export class ResultsPoller {
     // Results with no txid (shouldn't occur for contract calls) carry
     // no transaction to surface — skip the group.
     if (last.txid == null) return;
-    const outcomes: OpResultRaw[] = rows.map((r) => ({
-      status: r.status,
-      gas: BigInt(r.gas),
-      value: r.value ?? undefined,
-    }));
+    // Collapse each (input_index, op_index) to its highest-`result_index`
+    // row — the op's canonical result, mirroring the indexer's
+    // `get_op_result`. Drops intermediate sub-results and the implicit
+    // gas op (which shares the user op's indices at a lower
+    // `result_index`).
+    const canonical = new Map<string, ResultRow>();
+    for (const r of rows) {
+      const key = `${r.input_index}:${r.op_index}`;
+      const prev = canonical.get(key);
+      if (prev === undefined || r.result_index > prev.result_index) {
+        canonical.set(key, r);
+      }
+    }
+    const outcomes: OpResultRaw[] = [...canonical.values()]
+      .sort(
+        (a, b) =>
+          (a.input_index ?? 0) - (b.input_index ?? 0) ||
+          (a.op_index ?? 0) - (b.op_index ?? 0),
+      )
+      .map((r) => ({
+        status: r.status,
+        gas: BigInt(r.gas),
+        value: r.value ?? undefined,
+        func: r.func,
+        contract: r.contract,
+        inputIndex: r.input_index,
+        opIndex: r.op_index,
+      }));
     this.emit({
       kind: "tx",
       id: last.id,

--- a/sdk/src/poller.ts
+++ b/sdk/src/poller.ts
@@ -5,7 +5,7 @@
  * The indexer is followed entirely over its REST surface — no
  * websocket, no server-side event log:
  *
- *   - `GET /api/?wait=&since=` — long-poll heartbeat. The request hangs
+ *   - `GET /api?wait=&since=` — long-poll heartbeat. The request hangs
  *     until `Info.signature` moves (a block / batch / rollback) or the
  *     timeout elapses.
  *   - `GET /api/results?cursor=` — forward, id-cursored drain of
@@ -424,12 +424,14 @@ export class ResultsPoller {
   }
 
   private getInfo(): Promise<Info> {
-    return this.fetchResult<Info>("/");
+    // The indexer serves the info endpoint at the API base exactly
+    // (`/api`); `/api/` 404s. So this path is empty, not "/".
+    return this.fetchResult<Info>("");
   }
 
   private longPoll(): Promise<Info> {
     const sig = encodeURIComponent(this.signature);
-    return this.fetchResult<Info>(`/?wait=${LONG_POLL_MS}&since=${sig}`);
+    return this.fetchResult<Info>(`?wait=${LONG_POLL_MS}&since=${sig}`);
   }
 
   private getBlock(height: number): Promise<BlockRow> {

--- a/sdk/src/regtest.ts
+++ b/sdk/src/regtest.ts
@@ -20,8 +20,13 @@
  * logic lives in the Rust binary — this is pure process management.
  */
 
-import { spawn, type ChildProcess } from "node:child_process";
-import type { Chain } from "./chains.js";
+import type { ChildProcess } from "node:child_process";
+import { regtestChain, type Chain } from "./chains.js";
+
+// `regtestChain` is a pure, browser-safe chain builder — it lives in
+// `chains.ts` next to `signet`. Re-exported here so `@kontor/sdk/regtest`
+// consumers still find it alongside `startRegtest`.
+export { regtestChain };
 
 export interface StartRegtestOptions {
   /**
@@ -134,23 +139,6 @@ function parseInfoPayload(json: string): RegtestInfo {
   };
 }
 
-/**
- * Build a `Chain` for a `kontor regtest` devnet. Exposed for callers who
- * run `kontor regtest` themselves (e.g. a shared devnet) rather than via
- * `startRegtest`.
- */
-export function regtestChain(info: Pick<RegtestInfo, "apiUrl" | "bitcoinRpc">): Chain {
-  return {
-    name: "regtest",
-    nativeCurrency: { name: "Kontor", symbol: "KOR", decimals: 18 },
-    // `kontor regtest` auto-mines roughly every 10s.
-    blockTime: 10_000,
-    urls: { http: info.apiUrl, bitcoinRpc: info.bitcoinRpc },
-    contracts: { nativeToken: { name: "token", height: 0n, txIndex: 0n } },
-    network: { bech32: "bcrt", pubKeyHash: 0x6f, scriptHash: 0xc4, wif: 0xef },
-  };
-}
-
 /** Resolve the `kontor` binary path: explicit option → `$KONTOR_BIN` → PATH. */
 function resolveKontorBin(opt?: string): string {
   return opt ?? process.env.KONTOR_BIN ?? "kontor";
@@ -176,8 +164,16 @@ function stopChild(child: ChildProcess): Promise<void> {
  * Spawn `kontor regtest` and resolve once the devnet is up. Rejects if the
  * process exits before reporting ready, or if `timeoutMs` elapses first —
  * in both cases the child is killed so nothing is left running.
+ *
+ * `node:child_process` is imported dynamically, not at the top of the
+ * module: that keeps `regtest.ts` loadable in a browser (its pure helpers
+ * — `parseRegtestInfo`, `regtestChain` — stay importable anywhere).
+ * Calling `startRegtest` itself is Node-only, by nature.
  */
-export function startRegtest(opts: StartRegtestOptions = {}): Promise<Regtest> {
+export async function startRegtest(
+  opts: StartRegtestOptions = {},
+): Promise<Regtest> {
+  const { spawn } = await import("node:child_process");
   const bin = resolveKontorBin(opts.kontorBin);
   const timeoutMs = opts.timeoutMs ?? 240_000;
 

--- a/sdk/src/regtest.ts
+++ b/sdk/src/regtest.ts
@@ -22,6 +22,7 @@
 
 import type { ChildProcess } from "node:child_process";
 import { regtestChain, type Chain } from "./chains.js";
+import type { Utxo } from "./transport/http.js";
 
 // `regtestChain` is a pure, browser-safe chain builder — it lives in
 // `chains.ts` next to `signet`. Re-exported here so `@kontor/sdk/regtest`
@@ -60,6 +61,12 @@ export interface RegtestInfo {
   devPublicKey: string;
   /** The dev account's bech32m (p2tr) address. */
   devAddress: string;
+  /**
+   * A spendable Bitcoin UTXO owned by the dev account — pass it to
+   * `submit` as funding (the SDK never sources UTXOs itself). One UTXO;
+   * a multi-tx test must chain its own change.
+   */
+  devFundingUtxo: Utxo;
 }
 
 /** A running `kontor regtest` devnet. */
@@ -73,14 +80,14 @@ export interface Regtest extends RegtestInfo {
 /** The single stdout line `kontor regtest` prints once the devnet is up. */
 const INFO_MARKER = "KONTOR_REGTEST_INFO ";
 
-/** Required string fields of the `KONTOR_REGTEST_INFO` JSON payload. */
-const INFO_FIELDS: readonly (keyof RegtestInfo)[] = [
+/** The string-valued fields of the `KONTOR_REGTEST_INFO` JSON payload. */
+const INFO_STRING_FIELDS = [
   "apiUrl",
   "bitcoinRpc",
   "devPrivateKey",
   "devPublicKey",
   "devAddress",
-];
+] as const;
 
 /**
  * Scan accumulated `kontor regtest` stdout for the readiness line.
@@ -123,7 +130,7 @@ function parseInfoPayload(json: string): RegtestInfo {
     throw new Error("KONTOR_REGTEST_INFO payload is not a JSON object");
   }
   const obj = parsed as Record<string, unknown>;
-  for (const field of INFO_FIELDS) {
+  for (const field of INFO_STRING_FIELDS) {
     if (typeof obj[field] !== "string") {
       throw new Error(
         `KONTOR_REGTEST_INFO payload is missing string field '${field}'`,
@@ -136,7 +143,26 @@ function parseInfoPayload(json: string): RegtestInfo {
     devPrivateKey: obj.devPrivateKey as string,
     devPublicKey: obj.devPublicKey as string,
     devAddress: obj.devAddress as string,
+    devFundingUtxo: parseFundingUtxo(obj.devFundingUtxo),
   };
+}
+
+/** Parse + validate the `devFundingUtxo` object into a `Utxo`. */
+function parseFundingUtxo(raw: unknown): Utxo {
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error("KONTOR_REGTEST_INFO: devFundingUtxo missing or not an object");
+  }
+  const u = raw as Record<string, unknown>;
+  if (
+    typeof u.txid !== "string" ||
+    typeof u.vout !== "number" ||
+    typeof u.value !== "number" ||
+    typeof u.scriptPubKey !== "string"
+  ) {
+    throw new Error("KONTOR_REGTEST_INFO: devFundingUtxo has missing or mistyped fields");
+  }
+  // `value` arrives as a JSON number of satoshis; `Utxo.value` is bigint.
+  return { txid: u.txid, vout: u.vout, value: BigInt(u.value), scriptPubKey: u.scriptPubKey };
 }
 
 /** Resolve the `kontor` binary path: explicit option → `$KONTOR_BIN` → PATH. */

--- a/sdk/src/transport/http.ts
+++ b/sdk/src/transport/http.ts
@@ -108,7 +108,7 @@ export class HttpTransport implements KontorTransport {
   async view(contract: ContractAddress, wave: string): Promise<string> {
     const body: ViewExpr = { expr: wave };
     const result = await this.postJson<ViewResult>(
-      `/contracts/${contractPath(contract)}`,
+      `/contracts/${contract.toWire()}`,
       body,
     );
     if (result.type === "Ok") return result.value;
@@ -301,15 +301,6 @@ export class HttpTransport implements KontorTransport {
     });
     return hex.encode(tx.extract());
   }
-}
-
-/**
- * The indexer's URL form for a contract address: `name_height_txIndex`
- * — Kontor's `ContractAddress` `Display`. Distinct from the SDK's
- * `toString()` (`name@height.txIndex`), which is the human/parse form.
- */
-function contractPath(c: ContractAddress): string {
-  return `${c.name}_${c.height}_${c.txIndex}`;
 }
 
 /**

--- a/sdk/src/transport/http.ts
+++ b/sdk/src/transport/http.ts
@@ -10,10 +10,10 @@
  *   - `simulate(insts)`        — same composition, POST to
  *                                `/transactions/simulate`. Sandboxed
  *                                live execution.
- *   - `submit(insts)`          — compose, sign via the session's
- *                                account, broadcast via Bitcoin RPC,
- *                                poll the indexer until the tx lands
- *                                and per-Inst results are available.
+ *   - `submit(insts)`          — compose the commit/reveal pair, sign
+ *                                both with the account, and broadcast
+ *                                them through the indexer's
+ *                                `/transactions/broadcast` relay.
  *
  * Each tx-composition step is overridable through `HttpTransportOptions`
  * — power users can swap UTXO selection, fee estimation, or wait
@@ -24,10 +24,13 @@
  * `WireInsts` payload.
  */
 
+import { hex } from "@scure/base";
+import { TaprootControlBlock, Transaction, utils as btcUtils } from "@scure/btc-signer";
+
 import type { Account } from "../account/index.js";
 import type { Chain } from "../chains.js";
 import type { ContractAddress } from "../canonical/ContractAddress.js";
-import { ContractError, TransportError } from "../errors.js";
+import { ChainError, ContractError, SignerError, TransportError } from "../errors.js";
 import type {
   BroadcastResult,
   KontorTransport,
@@ -35,7 +38,10 @@ import type {
   WireInsts,
 } from "../json-codec.js";
 import type {
+  ComposeOutputs,
+  ComposeQuery,
   ErrorResponse,
+  ParticipantScripts,
   ResultResponse,
   ViewExpr,
   ViewResult,
@@ -173,10 +179,127 @@ export class HttpTransport implements KontorTransport {
     });
   }
 
-  submit(_insts: WireInsts): Promise<BroadcastResult> {
-    throw new TransportError("HttpTransport.submit: not implemented", {
-      docsPath: "/sdk/transport",
+  /**
+   * Compose a Kontor transaction for `insts`, sign the commit + reveal,
+   * and broadcast them through the indexer. Returns the reveal txid; the
+   * per-Inst results are resolved later by the session's poller.
+   *
+   * Funding UTXOs and fee rate are caller-supplied (the `utxos` /
+   * `feeRate` options) — the SDK does not source UTXOs itself.
+   */
+  async submit(insts: WireInsts): Promise<BroadcastResult> {
+    const { account } = this.opts;
+    const utxos = await this.resolveUtxos();
+    const query: ComposeQuery = {
+      instructions: [
+        {
+          address: account.address,
+          x_only_public_key: account.xOnlyPubKey,
+          funding_utxo_ids: utxos.map((u) => `${u.txid}:${u.vout}`).join(","),
+          insts,
+          chained_insts: null,
+        },
+      ],
+      sat_per_vbyte: await this.resolveFeeRate(),
+      envelope: null,
+    };
+
+    const composed = await this.postJson<ComposeOutputs>(
+      "/transactions/compose",
+      query,
+    );
+    const commitHex = await this.signCommit(composed.commit_psbt_hex);
+    const revealHex = await this.signReveal(
+      composed.reveal_psbt_hex,
+      composed.per_participant,
+    );
+    return this.postJson<BroadcastResult>("/transactions/broadcast", {
+      transactions: [commitHex, revealHex],
     });
+  }
+
+  /** Caller-supplied funding UTXOs; the SDK never sources them itself. */
+  private async resolveUtxos(): Promise<Utxo[]> {
+    if (this.opts.utxos == null) {
+      throw new ChainError(
+        "submit: no funding UTXOs — set a `utxos` provider on the transport",
+        { docsPath: "/sdk/transport" },
+      );
+    }
+    const utxos = await this.opts.utxos();
+    if (utxos.length === 0) {
+      throw new ChainError("submit: the `utxos` provider returned none", {
+        docsPath: "/sdk/transport",
+      });
+    }
+    return utxos;
+  }
+
+  /** Fee rate in sat/vB, or `null` to let the indexer pick `fastest_fee`. */
+  private async resolveFeeRate(): Promise<number | null> {
+    const f = this.opts.feeRate;
+    if (f == null) return null;
+    return typeof f === "number" ? f : await f();
+  }
+
+  /**
+   * Sign the commit PSBT — a taproot key-path spend — and return the
+   * finalized raw transaction hex.
+   */
+  private async signCommit(psbtHex: string): Promise<string> {
+    const signed = await this.opts.account.signPsbt(hex.decode(psbtHex));
+    const tx = Transaction.fromPSBT(signed);
+    tx.finalize();
+    return hex.encode(tx.extract());
+  }
+
+  /**
+   * Sign the reveal PSBT — a taproot script-path spend. The compose
+   * response carries each input's tap-leaf script separately; it must be
+   * injected into the PSBT before signing, and the witness assembled by
+   * hand afterwards (the Kontor reveal leaf is non-standard, so
+   * `@scure/btc-signer`'s `finalize()` can't build it).
+   */
+  private async signReveal(
+    psbtHex: string,
+    participants: ParticipantScripts[],
+  ): Promise<string> {
+    // Prepare: inject each input's leaf script + control block.
+    const prep = Transaction.fromPSBT(hex.decode(psbtHex));
+    participants.forEach((p, i) => {
+      const leaf = p.commit_tap_leaf_script;
+      const scriptWithVersion = btcUtils.concatBytes(
+        hex.decode(leaf.script),
+        new Uint8Array([leaf.leafVersion]),
+      );
+      const controlBlock = TaprootControlBlock.decode(
+        hex.decode(leaf.controlBlock),
+      );
+      prep.updateInput(i, { tapLeafScript: [[controlBlock, scriptWithVersion]] }, true);
+    });
+
+    const signed = await this.opts.account.signPsbt(prep.toPSBT());
+
+    // Finalize by hand: witness = [schnorr sig, leaf script, control block].
+    const tx = Transaction.fromPSBT(signed);
+    participants.forEach((p, i) => {
+      const sig = tx.getInput(i).tapScriptSig?.[0]?.[1];
+      if (sig == null) {
+        throw new SignerError(
+          `submit: reveal input ${i} was not signed by the account`,
+          { docsPath: "/sdk/transport" },
+        );
+      }
+      const leaf = p.commit_tap_leaf_script;
+      tx.updateInput(i, {
+        finalScriptWitness: [
+          sig,
+          hex.decode(leaf.script),
+          hex.decode(leaf.controlBlock),
+        ],
+      });
+    });
+    return hex.encode(tx.extract());
   }
 }
 

--- a/sdk/src/transport/http.ts
+++ b/sdk/src/transport/http.ts
@@ -27,13 +27,19 @@
 import type { Account } from "../account/index.js";
 import type { Chain } from "../chains.js";
 import type { ContractAddress } from "../canonical/ContractAddress.js";
-import { TransportError } from "../errors.js";
+import { ContractError, TransportError } from "../errors.js";
 import type {
   BroadcastResult,
   KontorTransport,
   OpResultRaw,
   WireInsts,
 } from "../json-codec.js";
+import type {
+  ErrorResponse,
+  ResultResponse,
+  ViewExpr,
+  ViewResult,
+} from "../bindings.js";
 
 export interface Utxo {
   txid: string;
@@ -84,12 +90,75 @@ export interface HttpTransportOptions {
 }
 
 export class HttpTransport implements KontorTransport {
-  constructor(private readonly opts: HttpTransportOptions) {}
+  /** Indexer API base, trailing slash trimmed (so `${base}/contracts/…`). */
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
 
-  view(_contract: ContractAddress, _wave: string): Promise<string> {
-    throw new TransportError("HttpTransport.view: not implemented", {
+  constructor(private readonly opts: HttpTransportOptions) {
+    this.baseUrl = (opts.url ?? opts.chain.urls.http).replace(/\/+$/, "");
+    this.fetchImpl = opts.fetch ?? globalThis.fetch.bind(globalThis);
+  }
+
+  async view(contract: ContractAddress, wave: string): Promise<string> {
+    const body: ViewExpr = { expr: wave };
+    const result = await this.postJson<ViewResult>(
+      `/contracts/${contractPath(contract)}`,
+      body,
+    );
+    if (result.type === "Ok") return result.value;
+    // The view function itself returned an error (revert, bad expr,
+    // unknown contract) — a contract-level failure, not a transport one.
+    throw new ContractError(`view call on '${contract}' failed`, {
+      details: result.message,
       docsPath: "/sdk/transport",
     });
+  }
+
+  /**
+   * POST `body` as JSON to `path` under the indexer API base, unwrap the
+   * `{ result }` envelope, and return the inner value. HTTP-level
+   * failures — unreachable node, non-2xx status, malformed body — all
+   * surface as `TransportError`.
+   */
+  private async postJson<T>(path: string, body: unknown): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    let res: Response;
+    try {
+      res = await this.fetchImpl(url, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...this.opts.headers },
+        body: JSON.stringify(body),
+      });
+    } catch (cause) {
+      throw new TransportError(`POST ${url} failed`, {
+        cause: cause instanceof Error ? cause : undefined,
+        docsPath: "/sdk/transport",
+      });
+    }
+    const text = await res.text();
+    if (!res.ok) {
+      // The indexer returns `{ error }` on 4xx/5xx; fall back to the raw
+      // body if it isn't that shape.
+      let detail = text;
+      try {
+        detail = (JSON.parse(text) as ErrorResponse).error ?? text;
+      } catch {
+        /* not JSON — keep the raw text */
+      }
+      throw new TransportError(`POST ${url} returned HTTP ${res.status}`, {
+        details: detail,
+        docsPath: "/sdk/transport",
+      });
+    }
+    try {
+      return (JSON.parse(text) as ResultResponse<T>).result;
+    } catch (cause) {
+      throw new TransportError(`POST ${url} returned a non-JSON body`, {
+        cause: cause instanceof Error ? cause : undefined,
+        details: text.slice(0, 200),
+        docsPath: "/sdk/transport",
+      });
+    }
   }
 
   inspect(_insts: WireInsts): Promise<OpResultRaw[]> {
@@ -109,6 +178,15 @@ export class HttpTransport implements KontorTransport {
       docsPath: "/sdk/transport",
     });
   }
+}
+
+/**
+ * The indexer's URL form for a contract address: `name_height_txIndex`
+ * — Kontor's `ContractAddress` `Display`. Distinct from the SDK's
+ * `toString()` (`name@height.txIndex`), which is the human/parse form.
+ */
+function contractPath(c: ContractAddress): string {
+  return `${c.name}_${c.height}_${c.txIndex}`;
 }
 
 /**

--- a/sdk/test/local-account.test.ts
+++ b/sdk/test/local-account.test.ts
@@ -8,8 +8,7 @@ import { test, expect } from "vitest";
 import { Transaction, p2tr } from "@scure/btc-signer";
 import { LocalAccount } from "../src/account/local.js";
 import { SignerError } from "../src/errors.js";
-import { signet } from "../src/chains.js";
-import { regtestChain } from "../src/regtest.js";
+import { regtestChain, signet } from "../src/chains.js";
 
 // BIP-39 test vector mnemonic (the "test … junk" phrase). Deriving it at
 // BIP-86 `m/86'/1'/0'/0/0` on a testnet chain is a fixed, known answer.

--- a/sdk/test/local-account.test.ts
+++ b/sdk/test/local-account.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for `LocalAccount` — the in-process signer. Key-derivation
+ * tests are known-answer (a fixed mnemonic → a fixed P2TR address);
+ * `signPsbt` is exercised against a real taproot key-path PSBT built
+ * with `@scure/btc-signer`.
+ */
+import { test, expect } from "vitest";
+import { Transaction, p2tr } from "@scure/btc-signer";
+import { LocalAccount } from "../src/account/local.js";
+import { SignerError } from "../src/errors.js";
+import { signet } from "../src/chains.js";
+import { regtestChain } from "../src/regtest.js";
+
+// BIP-39 test vector mnemonic (the "test … junk" phrase). Deriving it at
+// BIP-86 `m/86'/1'/0'/0/0` on a testnet chain is a fixed, known answer.
+const MNEMONIC =
+  "test test test test test test test test test test test junk";
+const SIGNET_ADDRESS =
+  "tb1pfewlxm8meyyvgjydfu7v8j4ej64symj6ut8sf66h9germp94qgzsgnnjhk";
+const SIGNET_XONLY =
+  "8c7fc6552af4384a13791e63bac79ff2bcfeedf143a88d6dc4b6080a8829cdc1";
+
+function xOnlyBytes(hex: string): Uint8Array {
+  return Uint8Array.from(hex.match(/.{2}/g)!.map((h) => parseInt(h, 16)));
+}
+
+test("fromMnemonic: known mnemonic derives the expected P2TR account", () => {
+  const acct = LocalAccount.fromMnemonic({ mnemonic: MNEMONIC, chain: signet });
+  expect(acct.address).toBe(SIGNET_ADDRESS);
+  expect(acct.xOnlyPubKey).toBe(SIGNET_XONLY);
+  expect(acct.holderRef.kind).toBe("x-only-pubkey");
+});
+
+test("fromPrivateKey: round-trips the key fromMnemonic derived", () => {
+  const fromSeed = LocalAccount.fromMnemonic({ mnemonic: MNEMONIC, chain: signet });
+  const fromKey = LocalAccount.fromPrivateKey({
+    privateKey: fromSeed.privateKey,
+    chain: signet,
+  });
+  expect(fromKey.address).toBe(SIGNET_ADDRESS);
+  expect(fromKey.xOnlyPubKey).toBe(SIGNET_XONLY);
+});
+
+test("fromPrivateKey: hex string and Uint8Array forms are equivalent", () => {
+  const bytes = LocalAccount.fromMnemonic({
+    mnemonic: MNEMONIC,
+    chain: signet,
+  }).privateKey;
+  const hex = [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+  const a = LocalAccount.fromPrivateKey({ privateKey: bytes, chain: signet });
+  const b = LocalAccount.fromPrivateKey({ privateKey: hex, chain: signet });
+  const c = LocalAccount.fromPrivateKey({ privateKey: `0x${hex}`, chain: signet });
+  expect(a.address).toBe(b.address);
+  expect(b.address).toBe(c.address);
+});
+
+test("fromPrivateKey: rejects a key that isn't 32 bytes", () => {
+  expect(() =>
+    LocalAccount.fromPrivateKey({ privateKey: "aabbcc", chain: signet }),
+  ).toThrow(SignerError);
+});
+
+test("fromMnemonic: rejects an invalid BIP-39 mnemonic", () => {
+  expect(() =>
+    LocalAccount.fromMnemonic({ mnemonic: "not a real mnemonic", chain: signet }),
+  ).toThrow(/invalid BIP-39 mnemonic/);
+});
+
+test("derivation: coin type follows the chain (regtest → bcrt address)", () => {
+  const regtest = regtestChain({
+    apiUrl: "http://localhost:1/api",
+    bitcoinRpc: "http://localhost:2",
+  });
+  const acct = LocalAccount.fromMnemonic({ mnemonic: MNEMONIC, chain: regtest });
+  expect(acct.address.startsWith("bcrt1p")).toBe(true);
+  // Different coin type (1 vs 1 but distinct purpose path is identical for
+  // testnets) — regtest and signet share coin type 1, so the key matches;
+  // only the address HRP differs.
+  expect(acct.xOnlyPubKey).toBe(SIGNET_XONLY);
+});
+
+test("signMessage: rejects — BIP-322 not yet implemented", async () => {
+  const acct = LocalAccount.fromMnemonic({ mnemonic: MNEMONIC, chain: signet });
+  await expect(acct.signMessage("hello")).rejects.toBeInstanceOf(SignerError);
+});
+
+test("signPsbt: signs a taproot key-path input", async () => {
+  const acct = LocalAccount.fromMnemonic({ mnemonic: MNEMONIC, chain: signet });
+  const payment = p2tr(xOnlyBytes(acct.xOnlyPubKey), undefined, signet.network);
+
+  const tx = new Transaction();
+  tx.addInput({
+    txid: "00".repeat(32),
+    index: 0,
+    witnessUtxo: { script: payment.script, amount: 100_000n },
+    tapInternalKey: payment.tapInternalKey,
+  });
+  tx.addOutputAddress(acct.address, 90_000n, signet.network);
+  const psbt = tx.toPSBT();
+
+  const signed = await acct.signPsbt(psbt);
+  expect(signed).not.toEqual(psbt);
+
+  // The signed PSBT must finalize — proof input 0 carries a valid sig.
+  const reparsed = Transaction.fromPSBT(signed);
+  reparsed.finalize();
+  expect(reparsed.isFinal).toBe(true);
+});
+
+test("signPsbt: rejects bytes that aren't a PSBT", async () => {
+  const acct = LocalAccount.fromMnemonic({ mnemonic: MNEMONIC, chain: signet });
+  await expect(
+    acct.signPsbt(new Uint8Array([1, 2, 3])),
+  ).rejects.toBeInstanceOf(SignerError);
+});

--- a/sdk/test/poller.test.ts
+++ b/sdk/test/poller.test.ts
@@ -69,9 +69,9 @@ function mockFetch(opts: {
   return (async (url: string) => {
     const path = url.replace(/^.*\/api/, "");
     let result: unknown;
-    if (path === "/") {
+    if (path === "") {
       result = opts.infos[0]; // bootstrap
-    } else if (path.startsWith("/?wait=")) {
+    } else if (path.startsWith("?wait=")) {
       await sleep(5); // mimic a long-poll, avoid a busy loop
       pollCount += 1;
       result = opts.infos[Math.min(pollCount, opts.infos.length - 1)];

--- a/sdk/test/poller.test.ts
+++ b/sdk/test/poller.test.ts
@@ -87,17 +87,23 @@ function mockFetch(opts: {
   }) as typeof fetch;
 }
 
-function row(id: number, txid: string, height: number, status = "Ok") {
+function row(
+  id: number,
+  txid: string,
+  height: number,
+  opIndex = 0,
+  resultIndex = 0,
+) {
   return {
     id,
     height,
     tx_index: 0,
     input_index: 0,
-    op_index: 0,
-    result_index: 0,
+    op_index: opIndex,
+    result_index: resultIndex,
     func: "transfer",
     gas: 10,
-    status,
+    status: "Ok",
     value: null,
     contract: "token_0_0",
     txid,
@@ -111,8 +117,9 @@ test("ResultsPoller: drains results into a per-tx event", async () => {
       { height: 1, last_result_id: 0, recent_blocks: [{ height: 1, hash: "a" }], signature: "s0" },
       { height: 1, last_result_id: 2, recent_blocks: [{ height: 1, hash: "a" }], signature: "s1" },
     ],
-    // two op-results sharing one txid → one `tx` event, two outcomes
-    results: [row(1, "txAA", 1), row(2, "txAA", 1)],
+    // two distinct ops (op_index 0 and 1) of one txid → one `tx` event,
+    // two outcomes.
+    results: [row(1, "txAA", 1, 0), row(2, "txAA", 1, 1)],
   });
   const poller = new ResultsPoller({ baseUrl: "http://test/api", fetch });
   const iter = poller.events();
@@ -129,6 +136,33 @@ test("ResultsPoller: drains results into a per-tx event", async () => {
   expect(ev.id).toBe(2); // cursor = last row id in the group
   expect(ev.height).toBe(1n);
   expect(ev.outcomes).toHaveLength(2);
+  expect(ev.outcomes[0]!.gas).toBe(10n);
+});
+
+test("ResultsPoller: collapses one op's rows to its max-result_index result", async () => {
+  // The user op and the implicit gas op share (input 0, op 0); the gas
+  // op sits at a lower result_index. The poller keeps only the highest
+  // — one canonical outcome, mirroring the indexer's `get_op_result`.
+  const fetch = mockFetch({
+    infos: [
+      { height: 1, last_result_id: 0, recent_blocks: [{ height: 1, hash: "a" }], signature: "s0" },
+      { height: 1, last_result_id: 2, recent_blocks: [{ height: 1, hash: "a" }], signature: "s1" },
+    ],
+    results: [
+      { ...row(1, "txGG", 1, 0, 0), func: "release", gas: 5 },
+      { ...row(2, "txGG", 1, 0, 1), func: "transfer", gas: 10 },
+    ],
+  });
+  const poller = new ResultsPoller({ baseUrl: "http://test/api", fetch });
+  const iter = poller.events();
+  poller.start();
+
+  const ev = (await iter.next()).value!;
+  poller.stop();
+
+  if (ev.kind !== "tx") throw new Error("expected tx");
+  expect(ev.outcomes).toHaveLength(1);
+  expect(ev.outcomes[0]!.func).toBe("transfer");
   expect(ev.outcomes[0]!.gas).toBe(10n);
 });
 

--- a/sdk/test/regtest.test.ts
+++ b/sdk/test/regtest.test.ts
@@ -6,6 +6,8 @@
 import { test, expect } from "vitest";
 import { parseRegtestInfo, regtestChain } from "../src/regtest.js";
 
+/** The `KONTOR_REGTEST_INFO` JSON payload as the binary prints it —
+ *  `devFundingUtxo.value` is a plain number of satoshis on the wire. */
 const INFO = {
   apiUrl: "http://localhost:32889/api",
   bitcoinRpc: "http://rpc:rpc@127.0.0.1:44745",
@@ -14,6 +16,13 @@ const INFO = {
   devPublicKey:
     "3285de1e9b50e8eec053b840fb5c6b886cefcfdb729c37bba2a7e27a066f86fe",
   devAddress: "bcrt1pfj2vd8zrgmrt2tu75t7kx29ju673v3mc8peqnp676524aayl0tvq0jq7mh",
+  devFundingUtxo: {
+    txid: "a1b2c3d4e5f6071829303142535465768798a0b1c2d3e4f50617283940516273",
+    vout: 1,
+    value: 4999990000,
+    scriptPubKey:
+      "51204c953681c8d18d6a5f3d45f5b194597b5e8b23783875099d76aa2abdef27ded8",
+  },
 };
 
 /** A realistic `kontor regtest` stdout slice — the info line in log noise. */
@@ -30,27 +39,40 @@ test("parseRegtestInfo: returns null until the info line has appeared", () => {
   ).toBeNull();
 });
 
-test("parseRegtestInfo: extracts every field from the JSON payload", () => {
-  expect(parseRegtestInfo(READY_OUTPUT)).toEqual(INFO);
+test("parseRegtestInfo: extracts every field, value as a bigint", () => {
+  const info = parseRegtestInfo(READY_OUTPUT)!;
+  expect(info.apiUrl).toBe(INFO.apiUrl);
+  expect(info.bitcoinRpc).toBe(INFO.bitcoinRpc);
+  expect(info.devPrivateKey).toBe(INFO.devPrivateKey);
+  expect(info.devPublicKey).toBe(INFO.devPublicKey);
+  expect(info.devAddress).toBe(INFO.devAddress);
+  expect(info.devFundingUtxo).toEqual({
+    txid: INFO.devFundingUtxo.txid,
+    vout: 1,
+    value: 4999990000n,
+    scriptPubKey: INFO.devFundingUtxo.scriptPubKey,
+  });
 });
 
 test("parseRegtestInfo: an info line still streaming in is not matched", () => {
   // The line is present but has no terminating newline yet — a chunk
-  // boundary fell mid-line, so its JSON is truncated. Matching it would
-  // resolve `startRegtest` with garbage.
+  // boundary fell mid-line, so its JSON is truncated.
   const partial = `KONTOR_REGTEST_INFO ${JSON.stringify(INFO).slice(0, 40)}`;
   expect(parseRegtestInfo(partial)).toBeNull();
-  // Once the full line + newline arrive, it parses.
-  expect(parseRegtestInfo(`${READY_OUTPUT}\n`)).toEqual(INFO);
+  expect(parseRegtestInfo(`${READY_OUTPUT}\n`)).not.toBeNull();
 });
 
 test("parseRegtestInfo: throws on a complete-but-malformed info line", () => {
   expect(() => parseRegtestInfo("KONTOR_REGTEST_INFO {not json}\n")).toThrow(
     /not valid JSON/,
   );
-  const missing = JSON.stringify({ apiUrl: INFO.apiUrl });
-  expect(() => parseRegtestInfo(`KONTOR_REGTEST_INFO ${missing}\n`)).toThrow(
+  const noBitcoinRpc = JSON.stringify({ ...INFO, bitcoinRpc: undefined });
+  expect(() => parseRegtestInfo(`KONTOR_REGTEST_INFO ${noBitcoinRpc}\n`)).toThrow(
     /missing string field 'bitcoinRpc'/,
+  );
+  const noUtxo = JSON.stringify({ ...INFO, devFundingUtxo: undefined });
+  expect(() => parseRegtestInfo(`KONTOR_REGTEST_INFO ${noUtxo}\n`)).toThrow(
+    /devFundingUtxo/,
   );
 });
 

--- a/sdk/test/transfer.regtest.test.ts
+++ b/sdk/test/transfer.regtest.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Live regtest capstone — the depth-first slice end to end against a
+ * real `kontor regtest` chain: bind the codegen'd token `Contract`,
+ * `transfer(...)` (submit → poll → wait), and confirm the recipient's
+ * `balance()` view reflects the credit.
+ *
+ * The devnet is started once by `vitest.regtest.globalSetup.ts`; this
+ * file is a pure HTTP client, so it runs in Node and the browser
+ * alike. Run via `npm run test:regtest` / `npm run test:regtest:browser`.
+ */
+import { test, expect, inject } from "vitest";
+import { Decimal, KontorSession, LocalAccount, http } from "@kontor/sdk";
+import { regtestChain } from "@kontor/sdk/regtest";
+import { Contract } from "./__generated__/token.js";
+
+interface RegtestInfo {
+  apiUrl: string;
+  bitcoinRpc: string;
+  devPrivateKey: string;
+  devFundingUtxo: {
+    txid: string;
+    vout: number;
+    value: string;
+    scriptPubKey: string;
+  };
+}
+
+declare module "vitest" {
+  interface ProvidedContext {
+    regtest: RegtestInfo;
+  }
+}
+
+test("transfer(): submit/wait moves tokens; balance() view reflects it", async () => {
+  const rt = inject("regtest");
+  const chain = regtestChain({ apiUrl: rt.apiUrl, bitcoinRpc: rt.bitcoinRpc });
+
+  const account = LocalAccount.fromPrivateKey({
+    privateKey: rt.devPrivateKey,
+    chain,
+  });
+  // A fresh, never-funded recipient — its balance starts empty.
+  const recipient = LocalAccount.fromPrivateKey({
+    privateKey: "22".repeat(32),
+    chain,
+  });
+  const funding = {
+    ...rt.devFundingUtxo,
+    value: BigInt(rt.devFundingUtxo.value),
+  };
+
+  const session = new KontorSession({
+    chain,
+    account,
+    transport: ({ chain, account }) =>
+      http({ chain, account, utxos: () => Promise.resolve([funding]) }),
+  });
+
+  try {
+    await session.ready();
+    const token = session.bind(Contract, "token@0.0");
+
+    const before = await token.balance(recipient.holderRef);
+    expect(before == null || before.toString() === "0").toBe(true);
+
+    // `await` on the proc Inst fires submit → wait; throws on a non-Ok
+    // op status, so reaching here means the transfer landed.
+    const result = await token.transfer(recipient.holderRef, Decimal.from("1"));
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") throw new Error("transfer returned err");
+    expect(result.value.amt.toString()).toBe("1");
+
+    const after = await token.balance(recipient.holderRef);
+    expect(after?.toString()).toBe("1");
+  } finally {
+    session.close();
+  }
+});

--- a/sdk/test/transport.test.ts
+++ b/sdk/test/transport.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for `HttpTransport.view` — the read-only, account-free
+ * transport operation. A mock `fetch` stands in for the indexer; these
+ * pin the request shape and the Ok / Err / HTTP-error handling.
+ */
+import { test, expect } from "vitest";
+import { HttpTransport } from "../src/transport/http.js";
+import { ContractAddress } from "../src/canonical/ContractAddress.js";
+import { ContractError, TransportError } from "../src/errors.js";
+import { HolderRef } from "../src/canonical/HolderRef.js";
+import { signet } from "../src/chains.js";
+import type { Account } from "../src/account/index.js";
+
+/** Throwaway account — `view` never signs, but the option is required. */
+const stubAccount: Account = {
+  xOnlyPubKey: "00".repeat(32),
+  address: "tb1pstub",
+  holderRef: HolderRef.xOnlyPubkey("00".repeat(32)),
+  signMessage: () => Promise.reject(new Error("stub")),
+  signPsbt: () => Promise.reject(new Error("stub")),
+};
+
+function transportWith(fetchImpl: typeof fetch): HttpTransport {
+  return new HttpTransport({
+    chain: signet,
+    account: stubAccount,
+    url: "http://test/api",
+    fetch: fetchImpl,
+  });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const token = new ContractAddress("token", 0n, 0n);
+
+test("HttpTransport.view: posts to /contracts/{addr} and returns the Ok value", async () => {
+  let seen: { url: string; init: RequestInit } | undefined;
+  const t = transportWith((async (url, init) => {
+    seen = { url: url as string, init: init! };
+    return jsonResponse({ result: { type: "Ok", value: "some(42)" } });
+  }) as typeof fetch);
+
+  const out = await t.view(token, "balance(core)");
+
+  expect(out).toBe("some(42)");
+  expect(seen!.url).toBe("http://test/api/contracts/token_0_0");
+  expect(seen!.init.method).toBe("POST");
+  expect(JSON.parse(seen!.init.body as string)).toEqual({ expr: "balance(core)" });
+});
+
+test("HttpTransport.view: throws ContractError on an Err result", async () => {
+  const t = transportWith((async () =>
+    jsonResponse({ result: { type: "Err", message: "no such function" } })) as typeof fetch);
+
+  await expect(t.view(token, "bogus()")).rejects.toBeInstanceOf(ContractError);
+  await expect(t.view(token, "bogus()")).rejects.toThrow(/no such function/);
+});
+
+test("HttpTransport.view: throws TransportError on a non-2xx response", async () => {
+  const t = transportWith((async () =>
+    jsonResponse({ error: "Bad request: invalid address" }, 400)) as typeof fetch);
+
+  await expect(t.view(token, "balance(core)")).rejects.toBeInstanceOf(
+    TransportError,
+  );
+  await expect(t.view(token, "balance(core)")).rejects.toThrow(/HTTP 400/);
+});
+
+test("HttpTransport.view: throws TransportError when the node is unreachable", async () => {
+  const t = transportWith((() =>
+    Promise.reject(new Error("ECONNREFUSED"))) as typeof fetch);
+
+  await expect(t.view(token, "balance(core)")).rejects.toBeInstanceOf(
+    TransportError,
+  );
+});
+
+test("HttpTransport.view: throws TransportError on a non-JSON body", async () => {
+  const t = transportWith((async () =>
+    new Response("<html>502 Bad Gateway</html>", { status: 200 })) as typeof fetch);
+
+  await expect(t.view(token, "balance(core)")).rejects.toThrow(/non-JSON/);
+});

--- a/sdk/vite.config.ts
+++ b/sdk/vite.config.ts
@@ -32,11 +32,15 @@ export default defineConfig({
     target: "es2022",
     emptyOutDir: true,
     rollupOptions: {
-      // `vite` is a peer dep (only required if the plugin entry is
-      // imported), so don't bundle it.
+      // Keep npm dependencies out of the bundle: `vite` is a peer dep,
+      // and the `@scure/*` / `@noble/*` crypto libs are regular runtime
+      // deps — consumers resolve them from `package.json`, so bundling
+      // them in would just bloat the output and risk duplicate copies.
       external: (id) =>
         id.startsWith("node:") ||
         id === "vite" ||
+        id.startsWith("@scure/") ||
+        id.startsWith("@noble/") ||
         id.includes("/component/kontor-sdk"),
       output: {
         // Restore the shebang Rollup strips from CLI sources, so the

--- a/sdk/vitest.config.js
+++ b/sdk/vitest.config.js
@@ -1,9 +1,12 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 import { playwright } from "@vitest/browser-playwright";
 
 export default defineConfig({
   test: {
     globalSetup: ["./vitest.globalSetup.ts"],
+    // The live regtest suite has its own config (`vitest.regtest.config.ts`)
+    // — it needs a `bitcoind` devnet, so it's kept out of the fast suite.
+    exclude: [...configDefaults.exclude, "**/*.regtest.test.ts"],
     browser: {
       enabled: false,
       provider: playwright(),

--- a/sdk/vitest.globalSetup.ts
+++ b/sdk/vitest.globalSetup.ts
@@ -1,9 +1,9 @@
 /**
  * Pre-generate the token contract's TS bindings into
- * `test/__generated__/token.ts` so the e2e test can static-import
- * them. Runs in Node before vitest collects tests, regardless of
- * whether tests will execute in Node or a browser — globalSetup
- * always runs in the test orchestrator's environment.
+ * `test/__generated__/token.ts` so tests can static-import them. Runs
+ * in Node before vitest collects tests, regardless of whether tests
+ * will execute in Node or a browser — globalSetup always runs in the
+ * test orchestrator's environment.
  */
 import { writeFileSync, mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
@@ -11,14 +11,21 @@ import { fileURLToPath } from "node:url";
 import { generate } from "@kontor/sdk";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
-const tokenWit = readFileSync(
-  path.join(here, "..", "native-contracts", "token", "wit", "contract.wit"),
-  "utf8",
-);
 
-export default async function setup(): Promise<void> {
-  const out = generate(tokenWit);
+/**
+ * Generate `test/__generated__/token.ts` from the native token's WIT.
+ * Shared by the unit suite's globalSetup and the regtest suite's.
+ */
+export function generateTokenBindings(): void {
+  const tokenWit = readFileSync(
+    path.join(here, "..", "native-contracts", "token", "wit", "contract.wit"),
+    "utf8",
+  );
   const dir = path.join(here, "test", "__generated__");
   mkdirSync(dir, { recursive: true });
-  writeFileSync(path.join(dir, "token.ts"), out);
+  writeFileSync(path.join(dir, "token.ts"), generate(tokenWit));
+}
+
+export default async function setup(): Promise<void> {
+  generateTokenBindings();
 }

--- a/sdk/vitest.regtest.config.ts
+++ b/sdk/vitest.regtest.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from "vitest/config";
+import { playwright } from "@vitest/browser-playwright";
+
+// The live regtest suite — `*.regtest.test.ts`, driving a real
+// `kontor regtest` devnet. Separate from the default `vitest` run
+// (the unit suite, which excludes this glob) because bringup needs
+// `bitcoind` and is minute-scale. Run via `npm run test:regtest`
+// (node) or `npm run test:regtest:browser` (chromium).
+export default defineConfig({
+  // Pre-bundle the SDK's crypto deps so the browser run doesn't
+  // discover + reload them mid-test (vitest flags that as flaky).
+  optimizeDeps: {
+    include: [
+      "@scure/base",
+      "@scure/btc-signer",
+      "@scure/bip32",
+      "@scure/bip39",
+    ],
+  },
+  test: {
+    globalSetup: ["./vitest.regtest.globalSetup.ts"],
+    include: ["test/**/*.regtest.test.ts"],
+    // A submit → block → result round-trip on the auto-mined devnet.
+    testTimeout: 120_000,
+    browser: {
+      enabled: false,
+      provider: playwright(),
+      instances: [{ browser: "chromium" }],
+    },
+  },
+});

--- a/sdk/vitest.regtest.globalSetup.ts
+++ b/sdk/vitest.regtest.globalSetup.ts
@@ -1,0 +1,37 @@
+/**
+ * globalSetup for the live regtest suite. Runs in Node (always — even
+ * when the tests themselves run in a browser): generates the token
+ * bindings, stands up a `kontor regtest` devnet, and `provide()`s its
+ * connection details to the tests. The returned teardown stops it.
+ *
+ * The tests stay pure HTTP clients — the chain is started here, once.
+ */
+import type { GlobalSetupContext } from "vitest/node";
+import { startRegtest, type Regtest } from "./src/regtest.js";
+import { generateTokenBindings } from "./vitest.globalSetup.js";
+
+export default async function setup({ provide }: GlobalSetupContext) {
+  generateTokenBindings();
+
+  const devnet: Regtest = await startRegtest({
+    kontorBin: process.env.KONTOR_BIN ?? "../core/target/release/kontor",
+  });
+
+  // `provide` values cross into (possibly browser) test workers, so the
+  // funding UTXO's bigint `value` goes over as a string.
+  provide("regtest", {
+    apiUrl: devnet.apiUrl,
+    bitcoinRpc: devnet.bitcoinRpc,
+    devPrivateKey: devnet.devPrivateKey,
+    devFundingUtxo: {
+      txid: devnet.devFundingUtxo.txid,
+      vout: devnet.devFundingUtxo.vout,
+      value: devnet.devFundingUtxo.value.toString(),
+      scriptPubKey: devnet.devFundingUtxo.scriptPubKey,
+    },
+  });
+
+  return async () => {
+    await devnet.stop();
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new transaction broadcast relay (`/api/transactions/broadcast`) and implements SDK-side key management and PSBT signing/broadcast, which affects transaction submission flow and could fail in subtle Bitcoin/mempool edge cases. CI now runs a live regtest SDK test, increasing confidence but also adding integration complexity and flakiness risk.
> 
> **Overview**
> Enables **end-to-end SDK contract calls** by implementing real transaction submission and result waiting: `Inst.submit()` now broadcasts and `wait()` consumes the poller’s event stream (with timeout/abort support) to resolve the correct op outcome.
> 
> Adds an indexer-side broadcast relay `POST /api/transactions/broadcast` that forwards a dependency-ordered tx package to bitcoind via `submitpackage`, plus the supporting RPC types, and updates `kontor regtest` to emit a spendable dev funding UTXO for SDK-driven submits.
> 
> Builds out core SDK plumbing to make this work in practice: a functional `HttpTransport` that calls compose, signs commit+reveal PSBTs (including reveal script-path witness assembly), and uses the new broadcast endpoint; a real `LocalAccount` signer with BIP-86 derivation and PSBT signing; richer poller outcomes (canonicalizing per-op results) and corrected info endpoint paths; and new unit + live regtest tests with CI running the regtest suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2de800f6d7b4ec5808bac999f2a31aa480215534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->