### PR TITLE
docs: Phase 2 economy design — ordering/bond economy, reactor integration, determinism testing

### DIFF
--- a/docs/determinism-simulation-testing.md
+++ b/docs/determinism-simulation-testing.md
@@ -1,0 +1,111 @@
+# Deterministic Simulation Testing for Kontor
+
+**Status:** design proposal.
+**Thesis:** a reindex-diff is one assertion inside a much larger opportunity. Kontor is a deterministic state machine over Bitcoin — exactly the shape of system that FoundationDB, TigerBeetle, and CockroachDB test with **deterministic simulation + fault injection + invariant checking**, where every bug reduces to a single reproducible seed. We should build that, not a one-off oracle.
+
+---
+
+## 1. Why this, and why Kontor is unusually well-suited
+
+For a metaprotocol, *any* nondeterminism in a consensus-affecting path is a permanent chain fork. Conventional tests sample the happy path; the bugs that kill consensus chains live in the interleavings — a message reordered, a node crashed mid-apply, a Bitcoin reorg landing during reward settlement, a `HashMap` iterated in insertion order in one run and rowid order in the next. You cannot unit-test your way to confidence there.
+
+Kontor is well-positioned because determinism is already the *design goal*, and the scaffolding exists:
+- **`lite_executor`** — the whole multi-node Malachite BFT reactor runs in-process.
+- **`MockBitcoin`** — Bitcoin is already an injectable abstraction (blocks, confirmations, rollbacks).
+- **The checkpoint hash-chain** (`database/sql/checkpoint_trigger.sql`) — a SHA256 state-root over every `contract_state` row; all economic state is fingerprinted for free.
+- **`replay_blocks_from`** — state can already be re-derived.
+- **The `Deterministic` / `NonDeterministic` `ExecutionError` taxonomy** — the runtime already classifies divergence risk at the source.
+
+What's missing is the *driver* that turns these into a seeded simulator, the *faults*, and the *checkers*.
+
+## 2. The technique stack (and where each comes from)
+
+| Technique | Source | What we take |
+|---|---|---|
+| **Deterministic whole-system simulation** | FoundationDB (Flow), TigerBeetle (VOPR) | Run the *real* reactor single-threaded; route all I/O, time, network, and randomness through one seeded scheduler so a run is a pure function of its seed. |
+| **Fault injection / "Buggify"** | FoundationDB | Seeded, feature-gated hooks that randomly clog/swizzle/drop messages, kill+reboot nodes, corrupt-within-tolerance, partition — forcing adversarial interleavings. |
+| **History + invariant checker** | Jepsen, CockroachDB `kvnemesis` | Record the operation/result history and validate it against a model (here: economic conservation + the spec's ordering rules), not just a final snapshot. |
+| **Metamorphic relations** | CockroachDB metamorphic testing | Run the *same logical history* through different paths/knobs and assert *identical consensus state*. Reindex-diff is one such relation. |
+| **Golden state-roots** | general | Commit a checkpoint for a canonical history as a regression tripwire. |
+| **Swarm + seed reproduction + shrinking** | FoundationDB, Hypothesis/proptest, Antithesis | Sweep thousands of seeds with varied fault profiles; every failure prints a seed that reproduces it exactly; shrink the failing schedule to a minimal counterexample. |
+
+## 3. The Kontor instantiation
+
+### 3.1 The determinism contract (what the seed must control)
+
+A run must be a pure function of `(seed, scenario)`. Every nondeterminism source is routed through the seeded scheduler:
+- Bitcoin: block arrival timing, contents, and **reorg depth/timing** (via `MockBitcoin`).
+- BFT/network: message **delivery order, latency, duplication, loss**; proposer/leader timing.
+- Node lifecycle: **crash, restart, late-join** timing.
+- Inputs: transaction submission order / mempool contents.
+- Randomness: all of it seeded (challenge seeds are already HKDF-deterministic; assert nothing else draws entropy).
+
+Residual sources that must be **zero** in consensus paths — and which the simulator + reindex relation systematically flush out: wall-clock reads, `HashMap`/`Map::keys()` iteration order (the class of bug just fixed in challenge selection), and `f64` (the audit flagged a `reactor/batches.rs` instance). A **determinism-hardening audit** is part of this work, not separate from it.
+
+### 3.2 The simulation driver
+
+A single seeded loop. Each step the scheduler deterministically picks the next event — deliver message *m*, mine a Bitcoin block, crash node *n*, inject a depth-*d* reorg, submit tx *t* — advances exactly that, and records it. No real threads, no real sockets, no real clock. Reuses `lite_executor` + `MockBitcoin`. Runs far faster than real time, so a single core does thousands of simulated block-years.
+
+### 3.3 The fault catalog ("Buggify for Kontor")
+
+Feature-gated, seeded injection points:
+- **Message**: delay (clog), reorder (swizzle), drop, duplicate.
+- **Node**: crash + restart (forces replay/recovery), late-join (forces sync).
+- **Bitcoin**: reorg of depth *d* (rollback cascade), late-confirming tx, RBF replacement.
+- **Consensus adversary**: an **equivocating** staker (signs conflicting batches), a **silent** staker (liveness), a staker-set **partition** above/below the 2/3 quorum.
+- **Economic-targeted** (the high-value ones): batch **expiry**; a **confirmed conflict at expiry** (cascading rollback); and the nastiest — a **Bitcoin reorg landing mid-settlement**, while rewards are being distributed or bonds released.
+
+### 3.4 The invariant suite (the checker)
+
+Asserted continuously (after each step) and at quiescence:
+
+**Consensus safety**
+- All live nodes share one checkpoint at each height.
+- A finalized batch order never changes; no batched-UTXO is double-spent.
+
+**Determinism (metamorphic — §3.5)**
+- Reindex-equivalence and crash-restart-equivalence hold.
+
+**Economic conservation** (the reason this matters for the bond economy)
+- `Δtotal_supply == Σ mints − Σ burns` over any window.
+- No negative spendable or staked balance, ever.
+- `total_active_stake == Σ active validator stakes`.
+- For every bond: `reserved + available == deposited`; a reservation releases/burns exactly the amount it consumed.
+- A rolled-back transaction leaves **no** residual state.
+- An expiry penalty is applied **exactly once**, even under late-confirmation.
+
+**Ordering (spec conformance)**
+- Batch-Confirmed txs execute at `(batch_id, position)`; block-end txs at `(h, i)`; a rollback cascades all positions ≥ the conflict.
+
+**Liveness (weaker, sim-checked)**
+- Progress under `< 1/3` faulty stake; graceful degradation to Bitcoin-only finality when consensus stalls.
+
+### 3.5 Metamorphic relations
+
+Same logical history, different path, **identical consensus state**:
+1. **Reindex-equivalence** — index a history from genesis twice (fresh DB) → same checkpoint. The base case.
+2. **Crash-restart-equivalence** — a run with a crash + `replay_blocks_from` at block *N* vs. one without → same final checkpoint.
+3. **Batch-vs-block-end-equivalence** — a non-conflicting tx that gets *batched* vs. the same tx confirmed *without* batching (block-end append) → same final ordering/state (the spec says these converge).
+4. **Knob-invariance** — randomize non-consensus knobs (component-cache size, batch interval within bounds, fuel cache) → identical checkpoint. Consensus state must not depend on them. (CockroachDB's "metamorphic constant" idea.)
+
+### 3.6 Golden checkpoints & swarm CI
+
+- **Golden state-roots**: commit the checkpoint of a canonical, fault-free, economically-rich history; CI fails if any change perturbs it (a tripwire that turns "did this refactor change consensus state?" into a red test).
+- **Swarm job (nightly)**: thousands of seeds, each with a randomly-chosen fault profile (swarm testing: vary *which* faults are enabled, not just intensities). Bounded block budget per seed; run in release. On failure: print `seed` → one-command reproduction, then **shrink** the event schedule to a minimal counterexample.
+
+## 4. Build path & sequencing
+
+Reuse: `lite_executor`, `MockBitcoin`, the checkpoint chain, `replay_blocks_from`, the error taxonomy. Build: the seeded scheduler/driver, the feature-gated Buggify hooks, the invariant checkers, the metamorphic harness, seed-repro + golden fixtures, the CI swarm job, and the determinism-hardening audit.
+
+**Sequencing — it is a companion to the reactor wiring, not blocked on it:**
+1. **Now**: driver + checkpoint/reindex/crash-restart relations + the consensus-safety and ordering invariants, against *existing* paths (challenges, validators, batches, rollback). This alone is high-value — it hardens the current reactor and catches the residual `keys()`/`f64`/time nondeterminism systematically.
+2. **With Phase 2 wiring**: the economic-conservation invariants and the economic-targeted faults (bonds, slashing, rewards, reorg-mid-settlement) become live. The frozen-bond-replay rule (reactor spec §6.1) and two-clock atomicity (§5) are precisely what only this suite catches.
+3. **Ongoing**: grow the golden fixtures; widen the fault catalog; track simulated-block-years in CI as a coverage metric (FDB's headline number).
+
+## 5. The honest hard part
+
+The leverage is entirely in step 1's *first half*: making the whole system a pure function of a seed. Kontor is closer than most (deterministic-by-design, `MockBitcoin`, the lite cluster), but there will be a tail of residual nondeterminism to hunt down — and finding it *is the point*. Every source removed is a class of consensus fork eliminated, and the payoff compounds: once the simulator is sound, every future economic mechanism (every bond, every settlement path) inherits exhaustive, reproducible, fault-injected coverage for free.
+
+## References
+
+FoundationDB simulation & `BUGGIFY` (the canonical writeup: "Testing Distributed Systems w/ Deterministic Simulation", Will Wilson); TigerBeetle VOPR (Viewstamped Operation Replicator) & the deterministic state-machine model; CockroachDB `kvnemesis` and metamorphic testing; Jepsen (history generation + consistency checkers); Antithesis (autonomous deterministic-hypervisor testing). Kontor scaffolding: `core/indexer/src/reactor/{lite_executor,mock_bitcoin,consensus_state}.rs`, `database/sql/checkpoint_trigger.sql`, `reg_tester.rs:1586` / `reactor_cluster_tests.rs:667` (`assert_checkpoints_match`).

--- a/docs/phase2-ordering-economy.md
+++ b/docs/phase2-ordering-economy.md
@@ -1,0 +1,191 @@
+# Phase 2 — Ordering & Bond Economy: Implementation Design
+
+**Status:** proposal (design only; not yet scheduled for implementation)
+**Scope:** the optimistic-consensus economic layer — ordering fees, the three bond systems (expiry, user-griefing, publisher), expiry penalties, and equivocation settlement — and how to realize them across the Kontor contracts and reactor.
+**Out of scope here:** storage economy (Phase 1), governance/admin authority, parameter *values* (see the separate calibration note).
+
+---
+
+## 1. Why this is the hard part
+
+The optimistic pre-confirmation guarantee is only worth what's bonded behind it. Without the bond economy:
+- a user can grief the network by getting a tx ordered then double-spending it on Bitcoin (no cost),
+- a staker can sign a batch and walk away if it doesn't confirm (no liveness pressure),
+- equivocation has no teeth.
+
+So Phase 2 is *core security*, not polish. It is also the largest unbuilt subsystem (~30 mechanisms) and the one most exposed to two failure modes: **non-determinism** (any disagreement on a bond amount or settlement forks the chain) and **incentive bugs** (a mechanism that's deterministic but economically exploitable — exactly the `slash_equivocation` self-publication leak the audit just caught).
+
+The design below is organized to make both failure modes *testable up front* (§7–8).
+
+---
+
+## 2. Design principles
+
+These follow the pattern already established by the storage/staking economic primitives:
+
+1. **Contracts hold balances + deterministic primitives; the reactor orchestrates.** A contract method moves KOR (reserve/release/burn/pay) given an amount. The reactor decides *when* (batch lifecycle) and *how much* (frozen at sign). Contracts never read wall-clock, mempool, or optimistic state.
+
+2. **Bond amounts are frozen at sign time and stored in the batch.** `B_tx(t,h)` and `B_exp(t,h)` are computed once by the proposing staker using the deterministic fee signal `r_fee`, written into `batch.tx_bonds[i]`, and thereafter **read, never recomputed** (spec §user-griefing-bonds: "verifiers read the `tx_bonds[i]` value frozen in the batch"). Per-position records, not scalar totals — so a later parameter change can't retroactively alter an in-flight reservation. This is the determinism linchpin; every indexer replays the same amounts from the canonical batch log.
+
+3. **Two settlement clocks.** Storage settles per Bitcoin block (Phase 1, in `run_block_lifecycle`). Ordering settles per **batch-confirmation / expiry / rollback**, in the finality path (`reactor/consensus_state.rs:check_finality` → `mod.rs:377`). These are different code paths with different atomicity boundaries — call it out explicitly (see §6).
+
+4. **`r_fee` derives only from Bitcoin-confirmed data.** The fee-insufficiency signal that sizes bonds must be a deterministic function of confirmed Bitcoin fee state (percentiles), never of the optimistic mempool — otherwise two stakers compute different bonds. It's computed at sign and frozen anyway (principle 2), but the *source* must still be canonical so independent re-derivation (e.g. for an audit) agrees.
+
+5. **The checkpoint oracle is the determinism backstop.** All bond/fee state lives in `contract_state` and therefore in the SHA256 checkpoint chain; `assert_checkpoints_match` across nodes is the ready-made fork detector. Design every new piece of state as contract state so it's covered for free.
+
+---
+
+## 3. State model — where each bond lives
+
+| Mechanism | Home | Rationale |
+|---|---|---|
+| **User griefing bonds** (`B_min`/`B_tx`) | **new `bonds` contract** | Deposits of *spendable* KOR with per-position reservations + withdrawal delay. Self-contained, not tied to stake. |
+| **Publisher bonds** | **same `bonds` contract** | Identical lifecycle to user bonds, keyed by publisher (BIP-340) key instead of user. Share the code. |
+| **Expiry bonds** (`B_exp`) | **staking contract extension** | Reservations against *ordering stake* (`σ_avail = σ_s − A_s`); the penalty burns stake. Must live with the stake it encumbers. |
+| **Ordering fees** (`f_ord`, `τ_ord`) | **token escrow + staking payout** | Escrow `f_ord` at batch inclusion; on confirm burn `τ_ord` and pay signers via the existing stake-weighted `distribute_ordering_reward`. |
+| **Frozen amounts** `tx_bonds[i]`, per-batch `B_exp` | **batch structure (reactor)** | The canonical, replay-stable record of what was reserved. |
+| **`r_fee` signal** | **reactor (computed), frozen into batch** | Derived from confirmed Bitcoin fee state. |
+
+A **dedicated `bonds` contract** (rather than bolting onto `token`) keeps the reservation bookkeeping — which is intricate (per-position records, unlock delays, capacity predicates) — isolated and independently testable, and gives the publisher path free reuse.
+
+### 3.1 `bonds` contract state
+
+```
+GriefingBond { amount: Decimal, unlock_height: u64, reservations: Map<ResId, Reservation> }
+Reservation  { tx_id: String, position: String, sign_height: u64, amount: Decimal }
+BondsStorage {
+  user_bonds:      Map<Holder, GriefingBond>,
+  publisher_bonds: Map<PublisherKey, GriefingBond>,
+  min_amount:      Decimal,   // B_min, admin-tunable
+  burned_total:    Decimal,   // accounting / invariant aid
+}
+```
+
+`A_u = Σ reservations.amount`; `σ_avail = amount − A_u`; `HasCapacity ⟺ σ_avail ≥ B_tx`. These predicates are pure functions of contract state — checked at sign by the proposer (using its view) and re-derived deterministically at accounting time from the frozen `tx_bonds`.
+
+### 3.2 staking extension (expiry bonds)
+
+```
+ValidatorEntry += { expiry_reservations: Map<ResId, Decimal> }   // A_s = Σ
+// σ_avail(s) = stake − A_s ; HasExpiryBondCapacity ⟺ Σ batch B_exp · (σ_s/Quorum) ≤ σ_avail
+```
+
+---
+
+## 4. Contract surface (new core-context methods)
+
+All amount-bearing methods are **core-context** (reactor-only); the reactor supplies frozen amounts. User-facing deposit/withdraw are proc-context.
+
+**`bonds` contract**
+- `deposit(ctx, kind)` *(proc)* — move spendable KOR (`ctx.signer()` → escrow), set/extend `unlock_height = height + T_bond` on first deposit (top-ups don't extend). `kind ∈ {user, publisher}`.
+- `withdraw(ctx, amount)` *(proc)* — require `height ≥ unlock_height` and post-withdraw `amount ≥ A_u`; return KOR to signer.
+- `reserve(ctx, owner, res_id, tx_id, position, sign_height, amount)` *(core)* — append a `Reservation`; extend `unlock_height ← max(·, sign_height + W + k)`. Called on batch publication.
+- `release(ctx, owner, res_id)` *(core)* — drop the reservation, KOR stays in the bond (refundable). On Bitcoin-finalization, plain expiry, or cascading rollback of *other* users' txs.
+- `forfeit(ctx, owner)` *(core)* — burn the **entire** bond, drop all reservations. On attributable Bitcoin-confirmed conflict.
+- views: `get_bond`, `available`, `has_capacity`.
+
+**staking contract (extension)**
+- `reserve_expiry(ctx, validator, res_id, amount)` *(core)* — reserve `amount` against `σ_avail`; reject if it would drive `σ_avail < 0`.
+- `release_expiry(ctx, validator, res_id)` *(core)* — on batch-confirmed or rollback.
+- `burn_expiry(ctx, validator, res_id)` *(core)* — on expiry: reduce stake by the reserved amount and burn it (the expiry penalty, 100% burn).
+
+**token / staking (ordering fees)** — reuse where possible
+- `escrow_ordering_fee(ctx, payer, amount)` *(core)* — hold `f_ord` into escrow at batch inclusion.
+- on confirm: `token::burn(escrow, τ_ord·Σf_ord)` + `staking::distribute_ordering_reward((1−τ_ord)·Σf_ord)` (already built, stake-weighted, exact-conservation).
+- on expire/rollback: `token::burn(escrow, Σf_ord)` (100%).
+
+**equivocation** — already built (`staking::slash_equivocation`, now with the self-publication guard); Phase 2 only adds the **reactor wiring** (consume the `AppMsg::Finalized { evidence }` that is currently logged and discarded at `reactor/handlers.rs:234`) and the broader "publisher ∉ signers" check (reactor has the signer sets).
+
+---
+
+## 5. The five flows (end to end)
+
+1. **Ordering fee** — user attaches `f_ord`; escrowed at batch inclusion; on Batch-Confirmed, `τ_ord` (50%) burned, remainder paid stake-weighted to the batch's signers; on expiry/rollback, fully burned.
+2. **Expiry bond** — at sign, each signer reserves `B_exp·(σ_s/Σsigners)` against `σ_avail` (per-batch cap `ε_batch=10%·σ_s`); released on Batch-Confirmed/rollback; **burned on expiry** (applied once at `b.expiry`, even if later late-confirmed).
+3. **User griefing bond** — user maintains `≥ B_min` deposited; each ordered tx reserves frozen `B_tx`; released on Bitcoin-finalization/expiry/cascading-rollback; **entire bond burned** on attributable conflict.
+4. **Publisher bond** — identical to (3), keyed by the bundler's publisher key; the *only* burn path for bundled txs (rolled-back users' `B_tx` released, not burned).
+5. **Equivocation** — reactor detects conflicting signed batches at the same `batch_id`, verifies evidence, calls `slash_equivocation(offender, publisher)` (100% slash + eject; 5% bounty to publisher *iff* publisher ∉ signers, else full burn).
+
+---
+
+## 6. Batch-lifecycle integration (reactor hooks)
+
+Mapping to the real reactor (file:line from the lifecycle survey):
+
+| Lifecycle event | Reactor site | Economic action |
+|---|---|---|
+| **Sign** (proposer) | `batches.rs:make_value` (306) / sign in `consensus_state.rs:stream_proposal` (206) | compute `B_tx`/`B_exp` from `r_fee`, freeze into `tx_bonds`; check `EligibleForOrdering` / `HasExpiryBondCapacity` |
+| **Publish / decide** | `batches.rs:process_decided_batch` (142) | `bonds::reserve` per tx; `staking::reserve_expiry` per signer; `escrow_ordering_fee` |
+| **Confirm** | `consensus_state.rs:check_finality` (271) → `BatchFinalized` | pay ordering emission+fee to signers; `release` user/publisher reservations; `release_expiry` |
+| **Expire** | `batches.rs:ResolveExpiry` (1127 in spec mapping) / finality deadline | `burn_expiry` (signer penalty); `release` user `B_tx` (plain expiry) |
+| **Conflict / rollback** | `batches.rs:initiate_rollback` (523); `ResolveExpiry` conflict branch | `forfeit` responsible user/publisher bond; `release` downstream others; ordering fee burned |
+| **Equivocation evidence** | `reactor/handlers.rs:234` (`AppMsg::Finalized { evidence }`) | `slash_equivocation` |
+
+**Settlement savepoint discipline.** Confirm/expire/rollback run in the consensus result branch (`mod.rs:377`), outside the per-block savepoint that wraps storage settlement — so each settlement **event** opens its own savepoint and commits atomically. For one batch-confirmation that means paying every signer (emission + fee), releasing every `B_tx`/`B_exp` reservation, and burning the `τ_ord` share **all commit or all roll back** — never a partial payout (e.g. reservations released but fees unpaid). Group the savepoint by *event* (a confirmed batch, an expired batch, a rollback), not per-tx, and process events in canonical order (batch_id, then position). The checkpoint oracle (§7) catches any divergence if the discipline is violated.
+
+### 6.1 Bond amount schedules (frozen at sign)
+
+Both dynamic bonds are computed once by the proposing staker against the deterministic fee-insufficiency signal `r_fee(t,h) ∈ [0,1]` and frozen into the batch (`tx_bonds[i]` for `B_tx`; the per-signer `B_exp` reservation for the batch). They share one shape — the spec writes `B_exp` explicitly and says `B_tx` "mirrors" it; **pinned here** (the spec's stated gap):
+
+```
+B_exp(t,h) = min(B_exp,max, B_exp,base · (1 + k_exp · r_fee(t,h)))
+B_tx(t,h)  = min(B_tx,max,  B_tx,base  · (1 + k_tx  · r_fee(t,h)))
+```
+
+Defaults (params.typ): `B_exp,base=1000`, `B_exp,max=100000`, `k_exp=4`; `B_tx,base=1`, `B_tx,max=10`, `k_tx=4`. Because the amount is frozen and replayed from `tx_bonds`, a later change to any of these constants never alters an in-flight reservation.
+
+---
+
+## 7. Validation & testing strategy *(first-class — build alongside, not after)*
+
+Layered, cheapest-first; each layer targets a specific failure mode.
+
+**L0 — Property tests (economic invariants).** `proptest` is already a dependency but only used for BLS no-panic. Add, on the pure/contract logic:
+- *Conservation:* for any random sequence of deposit/reserve/release/forfeit, `bond.amount == σ_avail + A_u`; total KOR is conserved (escrow in == paid + burned + refunded); supply only ever decreases on burn.
+- *Reservation integrity:* a reservation always releases/burns exactly the amount it consumed (the frozen-amount invariant), across interleaved parameter changes.
+- *Bounds:* `B_tx ∈ [B_tx,base, B_tx,max]`, `B_exp ∈ [B_exp,base, B_exp,max]`, `σ_avail ≥ 0` always, `Σ B_exp per batch ≤ ε_batch·σ_s`.
+- *Settlement conservation:* ordering-fee split `τ_ord·F` burned + `(1−τ_ord)·F` paid == `F` exactly (mirror of the existing distribute conservation tests).
+
+**L1 — Lite contract tests.** Per-method, in the `test_runtime_with_genesis` harness (fast, funded identities): deposit/withdraw delays, capacity rejection, reserve→release vs reserve→forfeit, expiry burn reduces stake, self-publication already covered. One adversarial test per flow (the audit caught a real bug this way — make it routine).
+
+**L2 — Consensus determinism (the ready oracle).** Extend `reactor_cluster_tests` (in-process BFT + MockBitcoin) and `RegTesterCluster` with scenarios that drive bonds through the full lifecycle — order→confirm→pay, order→expire→burn, order→conflict→forfeit→cascade — and assert `assert_checkpoints_match` across all nodes per height. Because all bond state flows through `insert_contract_state`, the checkpoint chain already fingerprints it; a single diverging bond balance fails the test. This is the strongest existing tool — lean on it hard.
+
+**L3 — Adversarial / incentive tests.** Encode the attacks the spec names: double-spend grief (bond must burn), expiry grief (penalty must bite), equivocation + self-publication (bounty must be denied), low-fee unconfirmable batch (must be refused), Sybil bond churn. Each is a test that the *economically correct* outcome occurs.
+
+**L4 — Economic simulation (see §8 — new infra).** Property/lite/cluster tests prove the *code* is correct and deterministic; they do **not** prove the *economics* are sound (is honesty the dominant strategy? do the bond sizes actually deter grief at the calibrated values?). That requires simulation.
+
+---
+
+## 8. Validation infrastructure — what exists, what's missing
+
+**The economic model already exists** — `Documentation/modeling/` (the `kontor_v1` Python package): closed-form equilibrium + congestion simulator + Monte-Carlo tail-risk harness, with a pytest/Hypothesis suite and a reproducibility test that re-derives the v1-Parameter-Report numbers. It already pins ~80% of parameters, **including the bond/ordering economics** (`analyses/05_slashing_deterrence`, `06_ordering_bonds`, `07_griefing_bond_calibration`). So Phase 2's economic *parameters* are largely calibrated already; bond sizes (`B_exp,base=1000`, `B_min=100`, `B_tx∈[1,10]`, `ε_batch=10%`, `r_evid=5%`, `λ_slash=30`) come from it. **Do not rebuild this** — extend it.
+
+What's genuinely missing, in priority order:
+
+1. **The model↔implementation conformance bridge — the real gap.** The Python model is tested against `specs/params.typ` (`test_spec_consistency.py`), but **nothing checks that the Rust contract defaults match the spec/model values.** The deployed `staking`/`token`/`filestorage`/`bonds` defaults could silently drift from the recommended numbers. Close the loop: a single source of truth (`specs/params.typ`) and a check, per layer, that the model, the spec, and the Rust contract defaults agree. This is the conformance guardrail (project task #4) and it's what makes "calibrated" mean something at deploy time.
+2. **The four un-pinned anchor parameters** (`c_stake`, `F_scale`, `φ_base`, `σ_min`) — the model deliberately leaves these to launch-time anchoring. Extend `modeling/` with analyses that recommend them given the reference assumptions (KOR/USD, target `|F|`, target USD-per-gas, decentralization preference). See the calibration note.
+3. **Rust-side property tests** for the bond/settlement conservation invariants (L0) — `proptest` is already a Kontor dependency but used only for BLS no-panic. Cheap; adopt as standard.
+4. **Differential / replay determinism oracle** — today only *cross-node agreement* is tested (the checkpoint chain); there's no *reindex-equivalence* (one indexer twice over the same history → identical checkpoint) or golden-checkpoint fixtures. A two-settlement-clock bond economy with frozen-amount replay is exactly where a reindex bug hides. (Fuzzing also absent; lower priority.)
+
+---
+
+## 9. Suggested implementation milestones
+
+1. **Validate on the existing model first** — the bond/ordering economics are already in `Documentation/modeling/` (analyses 05–07); extend it for any new mechanism shape before writing contract code, rather than building from scratch.
+2. **`bonds` contract** + property tests (user + publisher griefing bonds, deposit/withdraw/reserve/release/forfeit).
+3. **staking expiry-bond extension** + ordering-fee escrow/settle (reuse `distribute_ordering_reward`).
+4. **Reactor wiring** — the six hooks in §6, behind the existing finality path; equivocation evidence consumption.
+5. **L2/L3 cluster + adversarial tests**; differential replay oracle.
+6. **Calibration pass** with the simulator; freeze parameter defaults.
+
+Milestones 2–3 are contract work (this track); 4 is reactor work (coordination with the consensus-engine owner); 1, 5, 6 are validation/analysis (this track).
+
+---
+
+## 10. Open questions
+
+- **`r_fee` source of truth** — exact confirmed-Bitcoin percentile definition; must be pinned so independent re-derivation agrees. (The amount it feeds is frozen at sign per §6.1, so this only needs to be canonical enough that an auditor re-deriving a historical bond agrees.)
+- **Bonds contract vs. staking for expiry bonds** — confirmed split here (griefing→bonds, expiry→staking); revisit if the reservation code wants to be shared.
+- **Distribute-Equally remainder rule** — reconcile the spec's `H(seed‖id)` ranking with the implementation's sorted-last-absorbs-remainder (carries into ordering-fee payout); pick one canonical rule.
+
+Resolved in this revision: the `B_tx` schedule (§6.1) and the settlement savepoint discipline (§6).

--- a/docs/reactor-economic-integration.md
+++ b/docs/reactor-economic-integration.md
@@ -1,0 +1,112 @@
+# Reactor ⇄ Economic-Contract Integration Spec
+
+**Status:** proposal / hand-off spec.
+**Audience:** the reactor (indexer-proper) owner. Consolidates the wiring sketched in tracking issue #442 and Phase 2 design (#443 §6) into one boundary contract.
+**Scope:** how the reactor drives the native-contract economic primitives — what it calls, when, with what privilege, and under what atomicity and determinism rules. It does **not** redesign the contracts (those are specified per-contract) or the consensus protocol.
+
+---
+
+## 1. The model in one paragraph
+
+The native contracts hold balances and expose deterministic primitives that *move KOR given an amount*. The reactor owns the lifecycle and supplies the amounts. Nothing in a contract reads wall-clock, mempool, or optimistic state; the reactor passes everything in. This mirrors how challenge generation and validator processing are already wired — the economic settlement is more of the same, on two clocks.
+
+## 2. Two settlement clocks
+
+| Clock | Trigger | Reactor site | Settles |
+|---|---|---|---|
+| **Per Bitcoin block** | block finalized | `run_block_lifecycle` (`reactor/blocks.rs:196`), inside the block savepoint | emissions mint, storage rewards, proof-failure slashing, validator/epoch transitions, equivocation |
+| **Per batch event** | batch confirm / expire / rollback | finality path (`consensus_state.rs:check_finality` → `mod.rs:377`), own per-event savepoint | ordering fees + emissions to signers, expiry-bond burns, griefing/publisher-bond release/forfeit |
+
+The privilege handle for every state-changing call is the existing core signer: `Signer::Core(Box::new(Signer::Nobody))` (`blocks.rs:197`), which resolves to `CORE_SIGNER_ID` and bypasses gas. All economic methods below are `core-context`.
+
+## 3. Per-block sequence (extends `run_block_lifecycle`)
+
+```
+run_block_lifecycle(block):                         [inside the block savepoint]
+  set_context(height)                               [existing]
+
+  ── Phase 0 · Mint ───────────────────────────────────────────────
+  e = token::mint_emission()        → {total, storage=(1-χ)·e, ordering=χ·e} to CORE
+                                       (new call, before challenges)
+
+  ── Phase 1 · Storage audit ──────────────────────────────────────
+  expire_challenges(height)                         [existing]
+  generate_challenges_for_block(height, hash)       [existing]
+
+  ── Phase 2 · Storage settlement (new) ───────────────────────────
+  for (node, k_f) in filestorage::collect_failed_challenges():     ← affordance #1
+      r = staking::slash(node, λ_slash · k_f)
+      staking::distribute_slash(co_nodes, r.redistributable)
+  for (node, amt) in filestorage::distribute_storage_rewards(e.storage):
+      token::issue_to(node, amt)
+
+  ── Phase 3 · Validators (existing + extend) ─────────────────────
+  process_pending_validators(height)                [existing]
+  for ev in evidence_this_block():                  ← from AppMsg::Finalized, today dropped
+      staking::slash_equivocation(ev.offender, ev.publisher)
+
+  ── Phase 4 · Epoch boundary (new, gated) ────────────────────────
+  if height % EPOCH == 0: snapshot staker set; process service-unbonding queue
+  commit()                                          [existing]
+```
+
+## 4. Per-batch sequence (finality path)
+
+Each event opens its own savepoint and is **all-or-nothing** (see §5). Process events in canonical order `(batch_id, position)`.
+
+```
+on batch-confirmed   (check_finality → BatchFinalized):
+    pay signers: ε_ordering share (stake-weighted) + (1-τ_ord)·Σf_ord ; burn τ_ord·Σf_ord
+    release every B_tx (user/publisher) and B_exp (signer) reservation for the batch
+on expire            (deadline passed, not confirmed):
+    burn each signer's B_exp penalty (once, even if later late-confirmed)
+    release the users' B_tx (plain expiry, refundable)
+on rollback/conflict (initiate_rollback / ResolveExpiry conflict branch):
+    forfeit (burn) the responsible user OR publisher griefing bond
+    release downstream other-user reservations ; burn the ordering fee
+```
+
+Bond amounts are **read from the batch's frozen `tx_bonds`**, never recomputed (the determinism linchpin — see §6 and #443 §6.1).
+
+## 5. Atomicity & privilege rules
+
+- **Block clock**: Phase 0–4 run inside the existing block savepoint (`blocks.rs:288`–`302`), so they're atomic with the block. A failure in any phase rolls back the whole block.
+- **Batch clock**: runs *outside* the block savepoint. Each settlement event (one confirmed batch, one expired batch, one rollback) gets its own savepoint and commits atomically — paying signers, releasing reservations, and burning either all commit or all roll back. Never leave reservations released but fees unpaid. Group by event, not per-tx.
+- **Privilege**: every call uses the core signer; no user signer ever reaches these paths. Crediting `token::issue_to` / burning / transferring is the reactor's responsibility — the contracts compute and return allocations (the established `distribute_*` pattern), the reactor moves the KOR.
+
+## 6. Determinism requirements (non-negotiable)
+
+Any divergence here forks the chain. The reactor MUST:
+1. **Replay frozen bond amounts** from `tx_bonds` — never recompute `B_tx`/`B_exp` from current `r_fee` at settlement.
+2. Derive `r_fee(t,h)` only from **Bitcoin-confirmed** fee state, never optimistic mempool.
+3. Iterate every settlement set in a **sorted, canonical order** (the same discipline the contracts now use after the challenge-selection fix).
+4. Use **no wall-clock, no `HashMap` iteration, no `f64`** in any consensus-affecting path.
+
+These are exactly the properties the determinism-simulation suite (`docs/determinism-simulation-testing.md`) is built to enforce.
+
+## 7. Contract-side prerequisites (what must exist before wiring)
+
+These affordances don't exist yet; they're contract work (the economic-layer track), and they gate the wiring:
+
+- [ ] **#1** `filestorage::collect_failed_challenges() → [(node, k_f)]` — expose failed/expired challenge results for the slash loop.
+- [ ] **#2** node-identity coupling — `filestorage` node ids are free-form strings today; they must map to staking identities for slashing/stake-sufficiency.
+- [ ] **#3** `token::mint_emission` callable per-block by the reactor (it already reads supply; confirm the call shape).
+- [ ] **#4** `staking::slash` to take `k_f` and apply `λ_slash` internally, or the reactor computes `λ_slash·k_f` (decide where `λ_slash` lives).
+- [ ] **#5 (Phase 2)** the `bonds` contract + the staking expiry-bond extension + ordering-fee escrow must exist before the per-batch clock can be wired.
+
+The storage/staking per-block half (§3) is wireable once #1–#4 land; the per-batch half (§4) needs the Phase 2 contracts (#443).
+
+## 8. Validation
+
+The checkpoint hash-chain (`database/sql/checkpoint_trigger.sql`) already fingerprints all economic state, so cross-node agreement is checked for free by `assert_checkpoints_match`. Beyond that, every rule in §5–§6 is a target of the **deterministic-simulation test suite** — see the companion design `docs/determinism-simulation-testing.md`. In particular the frozen-amount replay rule (§6.1) and the two-clock atomicity (§5) are precisely the properties that only a reindex/fault-injection oracle catches.
+
+## 9. Ownership
+
+| Piece | Owner |
+|---|---|
+| §3–§5 reactor wiring | reactor / indexer-proper |
+| §7 contract affordances | economic-layer track |
+| §4 ordering/bond clock | needs Phase 2 contracts first (economic track), then reactor wiring |
+| §8 determinism suite | shared (testing infrastructure) |
+
+References: tracking issue #442, Phase 2 design #443, `reactor/{blocks,batches,consensus_state,handlers}.rs`, `native-contracts/{token,staking,filestorage}`.

--- a/docs/reactor-economic-integration.md
+++ b/docs/reactor-economic-integration.md
@@ -70,7 +70,7 @@ Bond amounts are **read from the batch's frozen `tx_bonds`**, never recomputed (
 
 ## 5. Atomicity & privilege rules
 
-- **Block clock**: Phase 0–4 run inside the existing block savepoint (`blocks.rs:288`–`302`), so they're atomic with the block. A failure in any phase rolls back the whole block.
+- **Block clock**: Phase 0–4 run inside the existing block savepoint (`blocks.rs:290`–`304`), so they're atomic with the block. A failure in any phase rolls back the whole block.
 - **Batch clock**: runs *outside* the block savepoint. Each settlement event (one confirmed batch, one expired batch, one rollback) gets its own savepoint and commits atomically — paying signers, releasing reservations, and burning either all commit or all roll back. Never leave reservations released but fees unpaid. Group by event, not per-tx.
 - **Privilege**: every call uses the core signer; no user signer ever reaches these paths. Crediting `token::issue_to` / burning / transferring is the reactor's responsibility — the contracts compute and return allocations (the established `distribute_*` pattern), the reactor moves the KOR.
 
@@ -98,7 +98,7 @@ The storage/staking per-block half (§3) is wireable once #1–#4 land; the per-
 
 ## 8. Validation
 
-The checkpoint hash-chain (`database/sql/checkpoint_trigger.sql`) already fingerprints all economic state, so cross-node agreement is checked for free by `assert_checkpoints_match`. Beyond that, every rule in §5–§6 is a target of the **deterministic-simulation test suite** — see the companion design `docs/determinism-simulation-testing.md`. In particular the frozen-amount replay rule (§6.1) and the two-clock atomicity (§5) are precisely the properties that only a reindex/fault-injection oracle catches.
+The checkpoint hash-chain (`database/sql/checkpoint_trigger.sql`) already fingerprints all economic state, so cross-node agreement is checked for free by `assert_checkpoints_match`. Beyond that, every rule in §5–§6 is a target of the **deterministic-simulation test suite** — see the companion design `docs/determinism-simulation-testing.md`. In particular the frozen-amount replay rule (#443 §6.1) and the two-clock atomicity (§5) are precisely the properties that only a reindex/fault-injection oracle catches.
 
 ## 9. Ownership
 


### PR DESCRIPTION
Three companion design docs for the economic layer and its validation (design-only; no code):

1. **`phase2-ordering-economy.md`** — the ordering/bond economy: contract↔reactor split, frozen-at-sign determinism, the six reactor hooks, layered validation, the `B_tx` schedule + settlement-savepoint discipline (both spec gaps, pinned here).
2. **`reactor-economic-integration.md`** — consolidates the wiring (#442 per-block storage/staking + this doc's per-batch ordering/bond) into one hand-off for the reactor owner: two settlement clocks, call sequence, privilege/atomicity rules, determinism requirements, and the contract-side affordances that gate it.
3. **`determinism-simulation-testing.md`** — a deterministic-simulation test suite (FoundationDB `BUGGIFY` + TigerBeetle VOPR + CockroachDB `kvnemesis`/metamorphic): seeded whole-system sim over `lite_executor`+`MockBitcoin`, fault injection, a continuous economic/consensus invariant checker, metamorphic relations (reindex/crash-restart/batch-vs-block-end equivalence, knob-invariance), golden state-roots, swarm CI with per-seed reproduction. Reindex-diff is one relation within it.

Pairs with tracking issue #442.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or contract behavior; risk is limited to design accuracy for future implementation.
> 
> **Overview**
> Adds three **design-only** docs (no code) that define Phase 2 ordering/bond economics, reactor hand-off, and deterministic simulation testing.
> 
> **`phase2-ordering-economy.md`** specifies the optimistic bond economy: contracts vs reactor orchestration, **frozen-at-sign** `B_tx`/`B_exp` in `tx_bonds`, a new **`bonds`** contract plus staking expiry reservations, ordering-fee escrow/settlement, six batch-lifecycle hooks mapped to reactor sites, **per-event savepoint** discipline, pinned **`B_tx`/`B_exp` schedules** from `r_fee`, layered validation (property → cluster → adversarial), and milestones tied to existing `Documentation/modeling/`.
> 
> **`reactor-economic-integration.md`** is a single boundary spec for the reactor owner: **two settlement clocks** (per-block `run_block_lifecycle` vs per-batch finality), concrete call sequences (mint, storage slash/rewards, equivocation evidence), core-signer privilege, determinism rules (replay frozen bonds, no mempool/`HashMap`/`f64`), and **contract affordances** that gate wiring (#442 / Phase 2).
> 
> **`determinism-simulation-testing.md`** proposes a seeded in-process simulator over existing **`lite_executor`**, **`MockBitcoin`**, checkpoints, and `replay_blocks_from`: fault injection, economic/consensus invariants, metamorphic relations (reindex, crash-restart, etc.), golden state-roots, and swarm CI—with sequencing that can start before full Phase 2 wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 160f373272e257cda68c157af8608d6c16cc163e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->