### PR TITLE
chore(audit): restore green cargo-audit gate (document un-patchable transitive advisories)

### DIFF
--- a/core/.cargo/audit.toml
+++ b/core/.cargo/audit.toml
@@ -1,0 +1,41 @@
+# cargo-audit configuration for the `core` workspace.
+#
+# The advisories ignored below are all in TRANSITIVE dependencies that cannot
+# currently be patched at the lockfile level — each is pinned by a major
+# dependency (libsql, or the circlefin/malachite consensus fork via libp2p)
+# whose fixed release would require a breaking upgrade out of scope for a
+# routine audit pass. Each entry documents why it is not reachable on Kontor's
+# critical path and what upstream bump would clear it. Re-audit and prune this
+# list whenever those upstreams move.
+#
+# Run `cargo audit` after any dependency change to confirm no NEW advisory is
+# silently swept under these ignores — the list is intentionally explicit (no
+# wildcards) so a fresh advisory still fails the build.
+
+[advisories]
+ignore = [
+    # ── rustls-webpki 0.102.8 ────────────────────────────────────────────────
+    # Pulled in only by libsql 0.9.30 → hyper-rustls 0.25 → rustls 0.22, i.e.
+    # libsql's *remote* (Turso/sqld over HTTPS) client path. Kontor uses libsql
+    # in embedded/local mode; the outbound-TLS code these advisories live in is
+    # not exercised, and all are reachable only when validating certificates
+    # from an attacker-controlled TLS endpoint. The fixed line (rustls-webpki
+    # 0.103.x) is already present elsewhere in the tree — only libsql's rustls
+    # 0.22 pin holds 0.102 here. Cleared by libsql 0.10 (rustls 0.23 / webpki
+    # 0.103); tracked for a deliberate libsql major bump.
+    "RUSTSEC-2026-0104", # reachable panic parsing a certificate revocation list
+    "RUSTSEC-2026-0098", # URI-name name-constraints incorrectly accepted
+    "RUSTSEC-2026-0099", # wildcard-name name-constraints incorrectly accepted
+    "RUSTSEC-2026-0049", # CRL distribution-point authority matching logic
+
+    # ── hickory-proto 0.25.2 ─────────────────────────────────────────────────
+    # Pulled in only by libp2p 0.56 (mDNS / DNS peer discovery), itself pinned
+    # by the circlefin/malachite fork at git rev 9109e96e4547. Both advisories
+    # are DoS-class (CPU exhaustion / unbounded loop) reachable only by a
+    # malicious DNS responder during libp2p peer discovery on the local network.
+    # 0119 is fixed in hickory 0.26.1; 0118 has no fixed release yet. Both are
+    # cleared only by a libp2p upgrade, which requires advancing the pinned
+    # malachite fork rev — tracked against that upstream bump.
+    "RUSTSEC-2026-0119", # O(n²) name compression → CPU exhaustion on encode
+    "RUSTSEC-2026-0118", # NSEC3 closest-encloser proof → unbounded loop
+]


### PR DESCRIPTION
## Problem

The `core` workspace's `cargo audit` gate (run by both the pre-push hook and CI) is red on **6 vulnerabilities**, all in **transitive** dependencies. This blocks every push that runs the hook, forcing `--no-verify` bypasses. None of the six originate from our code, and none can be patched at the lockfile level:

| Advisory | Crate | Pinned by | Fixed in |
|----------|-------|-----------|----------|
| RUSTSEC-2026-0104/0098/0099/0049 | `rustls-webpki 0.102.8` | `libsql 0.9.30` → hyper-rustls 0.25 → rustls 0.22 | `libsql 0.10` (rustls 0.23 / webpki 0.103) |
| RUSTSEC-2026-0119 | `hickory-proto 0.25.2` | `libp2p 0.56` via circlefin/malachite fork rev | hickory 0.26.1 (needs libp2p bump) |
| RUSTSEC-2026-0118 | `hickory-proto 0.25.2` | same | *no fixed release yet* |

`cargo update` cannot move either: `libsql 0.9.x` tops out at 0.9.30 (the fix is only in the `0.10.0-pre` line — a pre-release database library, out of scope for a routine audit pass), and `hickory-proto` is locked behind the pinned `circlefin/malachite` git rev via `libp2p 0.56`.

## Approach (best practice, no bypass)

Add `core/.cargo/audit.toml` with an **explicit, per-advisory ignore-list** — RustSec's recommended handling for transitive advisories you can't immediately patch. Each entry documents:
- why it is **not reachable** on Kontor's critical path (libsql runs embedded → its remote-TLS path is unused; hickory is DoS-class, reachable only by a malicious DNS responder during libp2p peer discovery), and
- the **upstream bump** (libsql major / malachite fork rev) that will clear it.

The list uses **no wildcards**, so a newly disclosed advisory still fails the build. This restores a green pre-push/CI audit gate so we can stop using `--no-verify`.

## Verification

The full pre-push hook (fmt + clippy + audit + test compilation across all three workspaces) passes end-to-end on this branch — `cargo audit` in `core` now exits 0 (the remaining 8 are non-fatal unmaintained-crate *warnings*, consistent with native-contracts' existing `registry` warning).

## Follow-up

When `libsql` is bumped to 0.10+ and/or the `malachite` fork advances `libp2p`, re-run `cargo audit` and prune the corresponding entries from the ignore-list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change for dependency audit tooling; no runtime, auth, or application logic is modified.
> 
> **Overview**
> Adds **`core/.cargo/audit.toml`** so the **`core`** workspace **`cargo audit`** step (pre-push / CI) passes again without **`--no-verify`**.
> 
> The file lists **six** explicit **`RUSTSEC`** ignores—**four** on transitive **`rustls-webpki`** (via **`libsql`** remote TLS, documented as unused in embedded mode) and **two** on **`hickory-proto`** (via **`libp2p`** / malachite). Comments record reachability rationale and which upstream bumps (**`libsql` 0.10**, malachite/**`libp2p`**) should remove each entry later. **No wildcards**, so new advisories still fail the gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 816e73b47dff1f17a4a998c9c31a71411ab54b24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->