### PR TITLE
api: add checkpoints-by-height endpoint, make checkpoint test race-free

### DIFF
--- a/core/indexer-types/src/lib.rs
+++ b/core/indexer-types/src/lib.rs
@@ -581,6 +581,14 @@ pub enum OpKind {
     Sponsor,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "../../../sdk/src/bindings.d.ts")]
+pub struct CheckpointRow {
+    #[ts(type = "number")]
+    pub height: u64,
+    pub hash: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Builder, TS)]
 #[ts(export, export_to = "../../../sdk/src/bindings.d.ts")]
 pub struct BlockRow {

--- a/core/indexer/src/api/client.rs
+++ b/core/indexer/src/api/client.rs
@@ -1,7 +1,7 @@
 use anyhow::{Result, anyhow};
 use indexer_types::{
-    CommitOutputs, ComposeOutputs, ContractResponse, ErrorResponse, Info, OpWithResult,
-    ResultResponse, ResultRow, Reveal, RevealOutputs, SignerResponse, TransactionHex,
+    CheckpointRow, CommitOutputs, ComposeOutputs, ContractResponse, ErrorResponse, Info,
+    OpWithResult, ResultResponse, ResultRow, Reveal, RevealOutputs, SignerResponse, TransactionHex,
     TransactionRow, ViewExpr, ViewResult,
 };
 use reqwest::{Client as HttpClient, ClientBuilder, Response, StatusCode};
@@ -54,6 +54,17 @@ impl Client {
         // `since` is a sha256 hex digest — URL-safe, no escaping needed.
         let url = format!("{}?wait={}&since={}", &self.url, wait_ms, since);
         Self::handle_response(self.client.get(url).send().await?).await
+    }
+
+    /// The node's checkpoint as of `height` (latest checkpoint at or before it).
+    pub async fn checkpoint_at(&self, height: u64) -> Result<CheckpointRow> {
+        Self::handle_response(
+            self.client
+                .get(format!("{}/checkpoints/{height}", &self.url))
+                .send()
+                .await?,
+        )
+        .await
     }
 
     pub async fn compose(&self, reveal: Reveal) -> Result<ComposeOutputs> {

--- a/core/indexer/src/api/handlers/checkpoints.rs
+++ b/core/indexer/src/api/handlers/checkpoints.rs
@@ -1,0 +1,20 @@
+use axum::extract::{Path, State};
+use indexer_types::CheckpointRow;
+
+use crate::api::{Env, error::HttpError, result::Result};
+use crate::database::queries::get_checkpoint_as_of_height;
+
+/// Return the checkpoint as of `height` (the latest checkpoint at or before it).
+/// Comparing this across nodes at a fixed past height is race-free, since a past
+/// checkpoint is immutable once a node has processed beyond it.
+pub async fn get_checkpoint(
+    State(env): State<Env>,
+    Path(height): Path<u64>,
+) -> Result<CheckpointRow> {
+    match get_checkpoint_as_of_height(&*env.reader.connection().await?, height).await? {
+        Some(checkpoint) => Ok(checkpoint.into()),
+        None => {
+            Err(HttpError::NotFound(format!("no checkpoint at or before height {height}")).into())
+        }
+    }
+}

--- a/core/indexer/src/api/handlers/mod.rs
+++ b/core/indexer/src/api/handlers/mod.rs
@@ -1,4 +1,5 @@
 mod blocks;
+mod checkpoints;
 mod compose;
 mod contracts;
 mod fees;
@@ -9,6 +10,7 @@ mod signers;
 mod transactions;
 
 pub use blocks::*;
+pub use checkpoints::*;
 pub use compose::*;
 pub use contracts::*;
 pub use fees::*;

--- a/core/indexer/src/api/router.rs
+++ b/core/indexer/src/api/router.rs
@@ -31,7 +31,9 @@ use crate::api::handlers::{
 use super::{
     API_REQUEST_TIMEOUT_MS, Env,
     error::HttpError,
-    handlers::{get_block, get_block_latest, post_compose_commit, post_compose_reveal},
+    handlers::{
+        get_block, get_block_latest, get_checkpoint, post_compose_commit, post_compose_reveal,
+    },
 };
 
 #[derive(Clone)]
@@ -164,6 +166,7 @@ pub fn new(context: Env, prom_handle: PrometheusHandle) -> Router {
                 .route("/", get(get_results))
                 .route("/{id}", get(get_result)),
         )
+        .route("/checkpoints/{height}", get(get_checkpoint))
         .route("/signers/{identifier}", get(get_signer))
         .layer(from_fn_with_state(context.clone(), require_available));
 

--- a/core/indexer/src/database/queries/checkpoints.rs
+++ b/core/indexer/src/database/queries/checkpoints.rs
@@ -1,7 +1,25 @@
 use libsql::{Connection, de::from_row, params};
 
+use indexer_types::CheckpointRow;
+
 use super::Error;
-use crate::database::types::CheckpointRow;
+
+/// The latest checkpoint at or before `height`. Well-defined for any height
+/// (the trigger only writes a checkpoint where contract state changed), and
+/// immutable once a node has processed past `height` — so it's safe to compare
+/// across nodes regardless of how far each has since advanced.
+pub async fn get_checkpoint_as_of_height(
+    conn: &Connection,
+    height: u64,
+) -> Result<Option<CheckpointRow>, Error> {
+    let mut row = conn
+        .query(
+            "SELECT height, hash FROM checkpoints WHERE height <= ? ORDER BY height DESC LIMIT 1",
+            params![height],
+        )
+        .await?;
+    Ok(row.next().await?.map(|r| from_row(&r)).transpose()?)
+}
 
 pub async fn get_checkpoint_by_height(
     conn: &Connection,

--- a/core/indexer/src/database/types.rs
+++ b/core/indexer/src/database/types.rs
@@ -70,12 +70,6 @@ impl HasRowId for BlockRow {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
-pub struct CheckpointRow {
-    pub height: u64,
-    pub hash: String,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Identity {
     signer_id: u64,

--- a/core/indexer/src/reg_tester.rs
+++ b/core/indexer/src/reg_tester.rs
@@ -1582,26 +1582,39 @@ impl RegTesterCluster {
         )
     }
 
-    /// Assert all running nodes have matching non-empty checkpoints. Returns the checkpoint value.
+    /// Assert all running nodes agree on state, by comparing each node's checkpoint
+    /// at a common past height. Returns that checkpoint hash.
+    ///
+    /// Comparing nodes' *current* checkpoints is racy — the auto-miner keeps
+    /// advancing block height and a late joiner may still be catching up, so two
+    /// nodes read back-to-back can be at different heights (different checkpoints).
+    /// Instead we anchor on the lowest height any node has reached and compare each
+    /// node's checkpoint *as of* that height: a past checkpoint is immutable once
+    /// processed, so it's comparable regardless of how far each node has advanced.
     pub async fn assert_checkpoints_match(&self) -> Result<String> {
-        let mut checkpoints = Vec::new();
-        for (i, nc) in self.node_configs.iter().enumerate() {
+        let mut min_height = u64::MAX;
+        for nc in &self.node_configs {
             if let Some(cn) = &nc.running {
-                let info = cn.client.index().await?;
-                let checkpoint = info
-                    .checkpoint
-                    .unwrap_or_else(|| panic!("Node {i} should have a checkpoint"));
-                checkpoints.push((i, info.height, info.consensus_height, checkpoint));
+                min_height = min_height.min(cn.client.index().await?.height);
             }
         }
-        let (ref_node, _, _, ref_cp) = &checkpoints[0];
-        for (i, height, consensus_height, cp) in &checkpoints[1..] {
-            assert_eq!(
-                cp, ref_cp,
-                "Node {i} checkpoint mismatch with node {ref_node} (height={height}, consensus_height={consensus_height:?})"
-            );
+
+        let mut reference: Option<(usize, String)> = None;
+        for (i, nc) in self.node_configs.iter().enumerate() {
+            if let Some(cn) = &nc.running {
+                let cp = cn.client.checkpoint_at(min_height).await?;
+                match &reference {
+                    None => reference = Some((i, cp.hash)),
+                    Some((ref_node, ref_hash)) => assert_eq!(
+                        &cp.hash, ref_hash,
+                        "Node {i} checkpoint diverges from node {ref_node} at height {min_height}"
+                    ),
+                }
+            }
         }
-        Ok(checkpoints.into_iter().next().unwrap().3)
+        Ok(reference
+            .expect("no running nodes to compare checkpoints")
+            .1)
     }
 
     /// Shut down all nodes.

--- a/sdk/src/bindings.d.ts
+++ b/sdk/src/bindings.d.ts
@@ -46,6 +46,8 @@ export type BroadcastQuery = { transactions: Array<string> };
  */
 export type BroadcastResult = { txid: string };
 
+export type CheckpointRow = { height: number; hash: string };
+
 /**
  * Response from `compose_commit`: one `CommitTx` per Build participant,
  * plus the input `Reveal` with each Build participant's `CommitSource`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Read-only API and test-harness logic; no auth, payment, or consensus execution changes.
> 
> **Overview**
> Adds **`GET /api/checkpoints/{height}`**, returning the latest stored checkpoint at or before that height (`height` + state `hash`), backed by a new DB query and shared **`CheckpointRow`** type in `indexer-types` / SDK bindings.
> 
> The HTTP client gains **`checkpoint_at(height)`** for callers (including regtest). Cluster **`assert_checkpoints_match`** no longer compares each node’s *current* checkpoint from `Info` (racey under auto-mining and catch-up); it takes the **minimum indexed height** across running nodes and asserts all **`checkpoint_at(min_height)`** hashes agree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef61f112af0bd5bb45ac2dd86e9e5c8452382d63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->