### PR TITLE
tests: congestion β(t) region/bound invariant property tests

### DIFF
--- a/core/indexer/tests/contracts/congestion.rs
+++ b/core/indexer/tests/contracts/congestion.rs
@@ -86,3 +86,78 @@ async fn congestion_smoothstep_band_and_decay_floor() -> Result<()> {
 
     Ok(())
 }
+
+/// β(t) region/bound invariants over a deterministic random walk of
+/// utilizations spanning all three regions. Checks the structural properties
+/// (robust to fixed-point rounding) rather than re-deriving exact values:
+/// region 1 decays (β'≤β), region 3 grows (β'≥max(β,1)), region 2 is bounded by
+/// the smoothstep ceiling (β'≤max(β,1)), β never goes negative, and the fee
+/// multiplier always equals φ_base·β.
+#[tokio::test]
+async fn congestion_beta_invariants_over_random_walk() -> Result<()> {
+    let (mut rt, _dir, _name) = test_runtime_with_genesis(&[]).await?;
+    let p = congestion::get_congestion_params(&mut rt).await?;
+    let one = dec(1);
+    let zero = dec(0);
+
+    let mut prev = congestion::get_beta(&mut rt).await?;
+    for seed in 0u64..60 {
+        let u_bps = seed.wrapping_mul(167).wrapping_add(13) % 10_001; // 0..=10000
+        let u = frac(u_bps, 10_000);
+
+        let b = congestion::update_beta(&mut rt, &core(), u)
+            .await?
+            .map_err(|e| anyhow!("{e:?}"))?;
+
+        assert!(b >= zero, "seed {seed}: β never negative");
+        if u_bps < p.u_low_bps {
+            assert!(b <= prev, "seed {seed}: region 1 decays (β' ≤ β)");
+        } else if u_bps > p.u_high_bps {
+            assert!(b >= one, "seed {seed}: region 3 β' ≥ 1");
+            assert!(b >= prev, "seed {seed}: region 3 grows (β' ≥ β)");
+        } else {
+            let ceil = if prev > one { prev } else { one };
+            assert!(
+                b <= ceil,
+                "seed {seed}: region 2 β' ≤ max(β,1) (smoothstep ≤ 1)"
+            );
+        }
+
+        let m = congestion::fee_multiplier(&mut rt)
+            .await?
+            .map_err(|e| anyhow!("{e:?}"))?;
+        assert_eq!(m, p.phi_base * b, "seed {seed}: fee multiplier = φ_base·β");
+
+        prev = b;
+    }
+    Ok(())
+}
+
+/// Smoothstep is continuous with the neighbouring regions at the band edges:
+/// at u_high, x=1 ⇒ S(1)=1 (joins region 3's floor); at u_low, x=0 ⇒ S(0)=0,
+/// so β' is the region-1 decay floor.
+#[tokio::test]
+async fn congestion_smoothstep_continuous_at_band_edges() -> Result<()> {
+    let (mut rt, _dir, _name) = test_runtime_with_genesis(&[]).await?;
+    let p = congestion::get_congestion_params(&mut rt).await?;
+    let u_low = frac(p.u_low_bps, 10_000); // 0.20
+    let u_high = frac(p.u_high_bps, 10_000); // 0.80
+
+    // Upper edge: from β=0, S(1)=1 ⇒ max(1, 0·0.95) = 1.
+    let b = congestion::update_beta(&mut rt, &core(), u_high)
+        .await?
+        .map_err(|e| anyhow!("{e:?}"))?;
+    assert_eq!(b, dec(1), "smoothstep top S(1)=1 at u_high");
+
+    // Lower edge: now β=1, S(0)=0 ⇒ max(0, 1·0.95) = 0.95 (decay floor).
+    let b = congestion::update_beta(&mut rt, &core(), u_low)
+        .await?
+        .map_err(|e| anyhow!("{e:?}"))?;
+    assert_eq!(
+        b,
+        frac(95, 100),
+        "smoothstep bottom S(0)=0, floored by decay 0.95"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Stacked on #445. Adds property tests for the β(t) congestion recurrence.

## Tests
- **`congestion_beta_invariants_over_random_walk`** — 60-step random walk of utilizations across all three regions, asserting: region 1 decays (β'≤β); region 3 grows (β'≥max(β,1)≥1); region 2 bounded by the smoothstep ceiling (β'≤max(β,1)); β never negative; `fee_multiplier == φ_base·β` throughout.
- **`congestion_smoothstep_continuous_at_band_edges`** — S(1)=1 at u_high (joins region 3's floor), S(0)=0 at u_low (joins region 1's decay floor).

## Design decision
The random-walk test asserts **structural invariants via comparisons** (≤/≥) rather than re-deriving exact β' values. Region-2's `x = (u−u_low)/(u_high−u_low)` is not always a terminating decimal, so exact re-derivation would couple the test to fixed-point rounding; the existing point tests already pin exact interior values (1.2 → 1.44 → 1.368, midpoint 0.5). The Python `test_congestion.py` remains the value oracle.

Test-only; no contract change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions to contract tests; no production, auth, or fee logic changes.
> 
> **Overview**
> Adds two **in-process contract tests** for the congestion β(t) recurrence in `congestion.rs`, complementing existing point-value checks.
> 
> **`congestion_beta_invariants_over_random_walk`** runs 60 deterministic utilization steps (0–100% in bps) and asserts structural properties via inequalities: low-util decay (β′ ≤ β), high-util growth (β′ ≥ 1 and ≥ prior β), mid-band smoothstep ceiling (β′ ≤ max(β, 1)), non-negative β, and **`fee_multiplier == φ_base · β`** each step—without pinning exact β′ in region 2 where fixed-point rounding would be brittle.
> 
> **`congestion_smoothstep_continuous_at_band_edges`** checks continuity at `u_low` / `u_high`: S(1)=1 at the upper band (β→1 from zero) and S(0)=0 at the lower band with the region-1 decay floor (β→0.95 from β=1).
> 
> No runtime or contract logic changes; Python remains the value oracle for exact numbers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21dd2bc93dadaec0bcf7eacfbbc27ed6ad8fcf74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->