### PR TITLE
tests: emission-split conservation property tests (token)

### DIFF
--- a/core/indexer/tests/contracts/token_emission.rs
+++ b/core/indexer/tests/contracts/token_emission.rs
@@ -63,3 +63,72 @@ async fn mint_emission_computes_epsilon_and_splits() -> Result<()> {
     );
     Ok(())
 }
+
+/// The emission split conserves over random (supply, μ₀, χ, B): `storage +
+/// ordering == total`, `0 ≤ ordering ≤ total`, `storage ≥ 0`, and the total
+/// supply grows by exactly the minted ε.
+#[tokio::test]
+async fn emission_split_conserves_over_random_params() -> Result<()> {
+    let zero = dec(0);
+    for seed in 0u64..24 {
+        let supply = 1_000 + (seed.wrapping_mul(7331).wrapping_add(17) % 1_000_000);
+        let mu0_bps = 1 + (seed.wrapping_mul(53).wrapping_add(3) % 10_000); // 1..=10000
+        let chi_bps = seed.wrapping_mul(411).wrapping_add(1) % 10_001; // 0..=10000
+        let b = 1 + (seed.wrapping_mul(29).wrapping_add(1) % 100_000);
+
+        let (mut rt, _dir, _name) = test_runtime_with_genesis(&one_validator(supply)).await?;
+        let before = token::total_supply(&mut rt).await?;
+        assert_eq!(before, dec(supply), "seed {seed}: genesis supply == stake");
+
+        token::set_emission_params(&mut rt, &core(), mu0_bps, chi_bps, b)
+            .await?
+            .map_err(|e| anyhow!("{e:?}"))?;
+        let r = token::mint_emission(&mut rt, &core())
+            .await?
+            .map_err(|e| anyhow!("{e:?}"))?;
+
+        // Conservation: the split sums to the total (storage = total − ordering).
+        assert_eq!(
+            r.storage + r.ordering,
+            r.total,
+            "seed {seed}: storage + ordering == total"
+        );
+        assert!(r.total >= zero, "seed {seed}: ε ≥ 0");
+        assert!(r.ordering >= zero, "seed {seed}: ordering ≥ 0");
+        assert!(r.ordering <= r.total, "seed {seed}: ordering ≤ ε");
+        assert!(r.storage >= zero, "seed {seed}: storage ≥ 0");
+
+        let after = token::total_supply(&mut rt).await?;
+        assert_eq!(
+            after,
+            before + r.total,
+            "seed {seed}: supply grew by exactly ε"
+        );
+    }
+    Ok(())
+}
+
+/// Split extremes: χ=0 routes all of ε to storage; χ=100% routes all to ordering.
+#[tokio::test]
+async fn emission_split_extremes() -> Result<()> {
+    let (mut rt, _dir, _name) = test_runtime_with_genesis(&one_validator(1000)).await?;
+    token::set_emission_params(&mut rt, &core(), 10_000, 0, 10)
+        .await?
+        .map_err(|e| anyhow!("{e:?}"))?;
+    let r = token::mint_emission(&mut rt, &core())
+        .await?
+        .map_err(|e| anyhow!("{e:?}"))?;
+    assert_eq!(r.ordering, dec(0), "χ=0 ⇒ no ordering share");
+    assert_eq!(r.storage, r.total, "χ=0 ⇒ all storage");
+
+    let (mut rt, _dir, _name) = test_runtime_with_genesis(&one_validator(1000)).await?;
+    token::set_emission_params(&mut rt, &core(), 10_000, 10_000, 10)
+        .await?
+        .map_err(|e| anyhow!("{e:?}"))?;
+    let r = token::mint_emission(&mut rt, &core())
+        .await?
+        .map_err(|e| anyhow!("{e:?}"))?;
+    assert_eq!(r.storage, dec(0), "χ=100% ⇒ no storage share");
+    assert_eq!(r.ordering, r.total, "χ=100% ⇒ all ordering");
+    Ok(())
+}


### PR DESCRIPTION
Stacked on #439. Adds property tests for the μ₀ service-emission split (`ε = supply·μ₀/B`, split into storage/ordering by χ).

## Tests
- **`emission_split_conserves_over_random_params`** — over random (supply, μ₀, χ, B): `storage + ordering == total` (the split sums to ε); `0 ≤ ordering ≤ total`; `storage ≥ 0`; total supply grows by exactly the minted ε.
- **`emission_split_extremes`** — χ=0 routes all of ε to storage; χ=100% all to ordering.

## Design decision
Asserts the **conservation/bound invariants** via `+`/comparison (robust to fixed-point rounding) rather than re-deriving `ε = supply·μ₀/B` for random params — the existing `mint_emission_computes_epsilon_and_splits` point test pins the exact formula (ε=100, ordering=20, storage=80).

Test-only; no contract change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Indexer contract tests only; no production, token contract, or emission logic changes.
> 
> **Overview**
> Adds **property-style lite tests** in `token_emission.rs` for the token contract’s `mint_emission` storage/ordering split (ε split by χ), with **no contract or runtime changes**.
> 
> **`emission_split_conserves_over_random_params`** runs 24 seeded cases over varied supply, μ₀, χ, and B. It checks conservation and bounds (`storage + ordering == total`, non-negative shares, ordering ≤ ε) and that **total supply increases by exactly the minted ε**, without re-asserting the closed-form ε formula (left to the existing point test).
> 
> **`emission_split_extremes`** pins boundary behavior: χ=0 sends all of ε to storage; χ=100% sends all to ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f2c3f58fbf4af2f2dec7d0cd122e92967ffa1fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->