### PR TITLE
sdk: support sats-connect browser wallets

### DIFF
--- a/sdk/src/account/index.ts
+++ b/sdk/src/account/index.ts
@@ -77,20 +77,6 @@ export interface Account {
   signPsbt(psbt: Uint8Array, opts?: SignPsbtOptions): Promise<Uint8Array>;
 
   /**
-   * BIP-340 schnorr-sign a raw 32-byte digest with this account's key,
-   * returning the 64-byte signature. Deterministic — no auxiliary
-   * randomness — matching what Bitcoin Core itself does and what the
-   * indexer's `bls-crypto::RegistrationProof` produces.
-   *
-   * This is **not** BIP-322 message signing. It's the lower-level
-   * primitive used to construct registration proofs and other in-chain
-   * authorizations the SDK has to assemble itself. Most account
-   * impls back this directly with their private key; wallet-mediated
-   * accounts will typically not expose it and throw `SignerError`.
-   */
-  signSchnorr(digest: Uint8Array): Promise<Uint8Array>;
-
-  /**
    * Serialize broadcast-mutating sequences that read or update this
    * account's funding state. The transport's `submitReveal`,
    * `inspect`, and `simulate` paths all route through here so two
@@ -103,4 +89,30 @@ export interface Account {
    * any other locked critical section.
    */
   runExclusive<T>(fn: () => Promise<T>): Promise<T>;
+}
+
+/**
+ * An `Account` that can also produce a raw BIP-340 Schnorr signature over a
+ * 32-byte digest. Required to build the Taproot↔BLS registration binding
+ * (`buildRegistrationProof` / `session.registerBls`).
+ *
+ * Seed-holding accounts (`LocalAccount`) are `BlsCapableAccount`; wallet-
+ * mediated accounts (`WalletAccount`) are not — browser wallets don't expose
+ * raw Schnorr-over-digest, and BLS keys need seed access anyway (EIP-2333), so
+ * BLS is a seed-holding-only capability rather than a divergent account flavor.
+ */
+export interface BlsCapableAccount extends Account {
+  /**
+   * BIP-340 Schnorr-sign a raw 32-byte digest, returning the 64-byte
+   * signature. Deterministic (no auxiliary randomness), matching the indexer's
+   * `bls-crypto::RegistrationProof`. This is **not** BIP-322 message signing.
+   */
+  signSchnorr(digest: Uint8Array): Promise<Uint8Array>;
+}
+
+/** Narrow an `Account` to `BlsCapableAccount` (it exposes `signSchnorr`). */
+export function isBlsCapable(account: Account): account is BlsCapableAccount {
+  return (
+    typeof (account as Partial<BlsCapableAccount>).signSchnorr === "function"
+  );
 }

--- a/sdk/src/account/local.ts
+++ b/sdk/src/account/local.ts
@@ -28,7 +28,11 @@ import { signSchnorr } from "@scure/btc-signer/utils.js";
 
 import { HolderRef } from "../canonical/HolderRef.js";
 import { SignerError } from "../errors.js";
-import type { Account, SighashKind, SignPsbtOptions } from "./index.js";
+import type {
+  BlsCapableAccount,
+  SighashKind,
+  SignPsbtOptions,
+} from "./index.js";
 import { AccountLock } from "./lock.js";
 import type { BitcoinNetwork, Chain } from "../chains.js";
 
@@ -75,7 +79,7 @@ export interface FromMnemonicOptions extends Bip86Indices {
   passphrase?: string;
 }
 
-export class LocalAccount implements Account {
+export class LocalAccount implements BlsCapableAccount {
   readonly xOnlyPubKey: string;
   readonly address: string;
   readonly holderRef: HolderRef;

--- a/sdk/src/account/wallet.ts
+++ b/sdk/src/account/wallet.ts
@@ -59,15 +59,6 @@ export class WalletAccount implements Account {
     throw new SignerError("WalletAccount.signPsbt: not implemented");
   }
 
-  signSchnorr(_digest: Uint8Array): Promise<Uint8Array> {
-    return Promise.reject(
-      new SignerError(
-        "WalletAccount.signSchnorr: not implemented — most sats-connect " +
-          "wallets don't expose raw schnorr-sign of arbitrary digests",
-        { docsPath: "/sdk/account/wallet" },
-      ),
-    );
-  }
 
   runExclusive<T>(fn: () => Promise<T>): Promise<T> {
     return this.lock.runExclusive(fn);

--- a/sdk/src/account/wallet.ts
+++ b/sdk/src/account/wallet.ts
@@ -1,31 +1,66 @@
 /**
- * Account backed by an external browser wallet (Xverse, Leather,
- * OKX, etc.) via sats-connect. Signing happens in the wallet's
- * sandbox — the SDK never sees the private key.
+ * Account backed by an external browser wallet (Xverse, Leather, OKX,
+ * Magic Eden, Phantom, UniSat, …) reached through a sats-connect-style
+ * provider. Signing happens in the wallet's sandbox — the SDK never sees
+ * the private key.
  *
- * Use this when building browser frontends. For backend services and
- * tests, use `LocalAccount`.
+ * The provider is an injected `request(method, params)` function (the
+ * shape `sats-connect`'s `request` exports). Pass sats-connect's `request`
+ * in real apps; tests pass a fake. The SDK does not depend on sats-connect
+ * — it only speaks this small request contract, so any conforming provider
+ * (a future bespoke adapter, a mock) drops in unchanged.
  *
- * The sats-connect API is RPC-style: each `signMessage` / `signPsbt`
- * call dispatches a request to the connected wallet, which prompts
- * the user. The wallet's response includes the signature bytes; we
- * unmarshal them back into the same `Uint8Array` shape `LocalAccount`
- * produces, so callers can stay agnostic.
+ * Bitcoin identity model: Kontor identities are x-only **Taproot (P2TR)**
+ * keys, so `WalletAccount` binds to the wallet's P2TR address and signs
+ * Taproot inputs with it. The user funds that Taproot address (the compose
+ * pipeline builds Taproot-only reveal inputs today). BLS is *not* available
+ * on a wallet account — it's a seed-holding-only capability, so this
+ * implements the base `Account`, not `BlsCapableAccount`.
  */
+
+import { base64, hex } from "@scure/base";
+import { SigHash } from "@scure/btc-signer";
 
 import { HolderRef } from "../canonical/HolderRef.js";
 import { SignerError } from "../errors.js";
-import type { Account, SignPsbtOptions } from "./index.js";
+import type { Account, SighashKind, SignInput, SignPsbtOptions } from "./index.js";
 import { AccountLock } from "./lock.js";
 import type { Chain } from "../chains.js";
 
+/** A sats-connect-style RPC response envelope. */
+export type WalletRpcResponse =
+  | { status: "success"; result: unknown }
+  | { status: "error"; error?: { code?: number | string; message?: string } };
+
+/**
+ * A sats-connect-style request function. In apps, pass `request` imported
+ * from `sats-connect`; in tests, pass a fake that conforms to this shape.
+ */
+export type WalletRequest = (
+  method: string,
+  params?: unknown,
+) => Promise<WalletRpcResponse>;
+
 export interface ConnectOptions {
   chain: Chain;
-  /**
-   * Optional preferred wallet identifier (e.g. `"xverse"`,
-   * `"leather"`). If omitted, sats-connect shows the wallet picker.
-   */
-  walletId?: string;
+  /** sats-connect's `request` (or any conforming provider function). */
+  request: WalletRequest;
+  /** Prompt shown to the user during the connect request. */
+  message?: string;
+}
+
+/** `SighashKind` → the numeric sighash sats-connect's `allowedSignHash` wants.
+ *  `default` is absent — a default-sighash call omits `allowedSignHash`. */
+const SIGHASH_NUMBER: Record<Exclude<SighashKind, "default">, number> = {
+  all: SigHash.ALL,
+  "single-anyonecanpay": SigHash.SINGLE_ANYONECANPAY,
+};
+
+interface AddressEntry {
+  address: string;
+  publicKey: string;
+  addressType?: string;
+  purpose?: string;
 }
 
 export class WalletAccount implements Account {
@@ -34,33 +69,152 @@ export class WalletAccount implements Account {
   readonly holderRef: HolderRef;
   private readonly lock = new AccountLock();
 
-  private constructor(xOnlyPubKey: string, address: string) {
+  private constructor(
+    private readonly request: WalletRequest,
+    xOnlyPubKey: string,
+    address: string,
+  ) {
     this.xOnlyPubKey = xOnlyPubKey;
     this.address = address;
     this.holderRef = HolderRef.xOnlyPubkey(xOnlyPubKey);
   }
 
   /**
-   * Trigger the wallet's connect flow (the user picks a wallet and
-   * approves access). Resolves to a `WalletAccount` bound to the
-   * payment address the wallet exposes.
+   * Trigger the wallet's connect flow and bind to its Taproot (P2TR)
+   * address. The wallet prompts the user; on approval we read the P2TR
+   * address and its x-only public key — Kontor's identity.
    */
-  static connect(_opts: ConnectOptions): Promise<WalletAccount> {
-    throw new SignerError("WalletAccount.connect: not implemented", {
-      docsPath: "/sdk/account/wallet",
-    });
+  static async connect(opts: ConnectOptions): Promise<WalletAccount> {
+    const result = unwrap(
+      await opts.request("getAccounts", {
+        purposes: ["payment", "ordinals"],
+        message: opts.message ?? "Connect your Kontor account",
+      }),
+      "getAccounts",
+    );
+
+    const entries = asAddressEntries(result);
+    const taproot = pickTaprootAddress(entries);
+    if (taproot == null) {
+      throw new SignerError(
+        "WalletAccount.connect: the wallet exposed no Taproot (p2tr) address — " +
+          "Kontor requires a P2TR identity",
+        { docsPath: "/sdk/account/wallet" },
+      );
+    }
+
+    const hrp = opts.chain.network.bech32;
+    if (!taproot.address.startsWith(`${hrp}1p`)) {
+      throw new SignerError(
+        `WalletAccount.connect: wallet returned a "${taproot.address.slice(0, 6)}…" ` +
+          `address, but this session is bound to the "${hrp}" network`,
+        { docsPath: "/sdk/account/wallet" },
+      );
+    }
+
+    return new WalletAccount(
+      opts.request,
+      normalizeXOnly(taproot.publicKey),
+      taproot.address,
+    );
   }
 
-  signMessage(_message: string | Uint8Array): Promise<string> {
-    throw new SignerError("WalletAccount.signMessage: not implemented");
+  async signMessage(message: string | Uint8Array): Promise<string> {
+    const msg = typeof message === "string" ? message : hex.encode(message);
+    const result = unwrap(
+      await this.request("signMessage", { address: this.address, message: msg }),
+      "signMessage",
+    ) as { signature?: string };
+    if (typeof result.signature !== "string") {
+      throw new SignerError("WalletAccount.signMessage: wallet returned no signature");
+    }
+    return result.signature;
   }
 
-  signPsbt(_psbt: Uint8Array, _opts?: SignPsbtOptions): Promise<Uint8Array> {
-    throw new SignerError("WalletAccount.signPsbt: not implemented");
-  }
+  async signPsbt(psbt: Uint8Array, opts?: SignPsbtOptions): Promise<Uint8Array> {
+    if (opts?.inputs == null) {
+      // The SDK's signCommit/signReveal always pass an explicit inputs spec
+      // (sats-connect-style wallets require one), so we never have to walk
+      // the PSBT to discover owned inputs.
+      throw new SignerError(
+        "WalletAccount.signPsbt requires an explicit `inputs` spec",
+        { docsPath: "/sdk/account/wallet" },
+      );
+    }
 
+    const params: Record<string, unknown> = {
+      psbt: base64.encode(psbt),
+      signInputs: { [this.address]: opts.inputs.map((i) => i.index) },
+      broadcast: false,
+    };
+    const allowedSignHash = resolveAllowedSignHash(opts.inputs);
+    if (allowedSignHash != null) params.allowedSignHash = allowedSignHash;
+
+    const result = unwrap(
+      await this.request("signPsbt", params),
+      "signPsbt",
+    ) as { psbt?: string };
+    if (typeof result.psbt !== "string") {
+      throw new SignerError("WalletAccount.signPsbt: wallet returned no signed PSBT");
+    }
+    return base64.decode(result.psbt);
+  }
 
   runExclusive<T>(fn: () => Promise<T>): Promise<T> {
     return this.lock.runExclusive(fn);
   }
+}
+
+/** Pull `result` out of the RPC envelope, or throw on a rejection. */
+function unwrap(res: WalletRpcResponse, method: string): unknown {
+  if (res.status === "success") return res.result;
+  const detail = res.error?.message ? `: ${res.error.message}` : "";
+  throw new SignerError(`WalletAccount: wallet rejected "${method}"${detail}`, {
+    docsPath: "/sdk/account/wallet",
+  });
+}
+
+/** Normalize the `getAccounts` result into a flat address array. Wallets
+ *  return either the array directly or under an `addresses` key. */
+function asAddressEntries(result: unknown): AddressEntry[] {
+  if (Array.isArray(result)) return result as AddressEntry[];
+  const wrapped = (result as { addresses?: AddressEntry[] }).addresses;
+  return Array.isArray(wrapped) ? wrapped : [];
+}
+
+/** The wallet's Taproot address — preferring the `payment` purpose (where a
+ *  taproot-native wallet keeps spendable funds) over `ordinals`. */
+function pickTaprootAddress(entries: AddressEntry[]): AddressEntry | undefined {
+  const p2tr = entries.filter(
+    (e) => e.addressType === "p2tr" || /^(bc|tb|bcrt)1p/.test(e.address),
+  );
+  return p2tr.find((e) => e.purpose === "payment") ?? p2tr[0];
+}
+
+/** A wallet may return the 32-byte x-only key or a 33-byte compressed key;
+ *  Kontor's identity is the 32-byte x-only form. */
+function normalizeXOnly(publicKey: string): string {
+  const h = publicKey.toLowerCase().replace(/^0x/, "");
+  if (h.length === 64) return h;
+  if (h.length === 66) return h.slice(2); // drop the 02/03 compression prefix byte
+  throw new SignerError(
+    `WalletAccount: unexpected public key length (${h.length} hex chars)`,
+    { docsPath: "/sdk/account/wallet" },
+  );
+}
+
+/** sats-connect carries a single per-request `allowedSignHash`, so every
+ *  input in one call must share a sighash. Our flows do (each party signs
+ *  its own inputs under one sighash); a mix is a programming error. */
+function resolveAllowedSignHash(inputs: SignInput[]): number | undefined {
+  const kinds = new Set(inputs.map((i) => i.sighash ?? "default"));
+  if (kinds.size > 1) {
+    throw new SignerError(
+      "WalletAccount.signPsbt: one signPsbt call can't mix sighash types — " +
+        "sats-connect's allowedSignHash is per-request",
+      { docsPath: "/sdk/account/wallet" },
+    );
+  }
+  const [kind] = kinds as Set<SighashKind>;
+  return kind === "default" ? undefined : SIGHASH_NUMBER[kind];
 }

--- a/sdk/src/account/wallet.ts
+++ b/sdk/src/account/wallet.ts
@@ -142,6 +142,13 @@ export class WalletAccount implements Account {
       );
     }
 
+    if (opts.inputs.length === 0) {
+      // No owned inputs to sign (e.g. signReveal where this account owns none
+      // of the reveal's inputs). Match LocalAccount: no-op, don't prompt the
+      // wallet to sign nothing. Returning the PSBT unchanged.
+      return psbt;
+    }
+
     const kind = resolveSighashKind(opts.inputs);
 
     // Pin the sighash onto the PSBT inputs (like LocalAccount does), not just

--- a/sdk/src/account/wallet.ts
+++ b/sdk/src/account/wallet.ts
@@ -19,7 +19,7 @@
  */
 
 import { base64, hex } from "@scure/base";
-import { SigHash } from "@scure/btc-signer";
+import { SigHash, Transaction } from "@scure/btc-signer";
 
 import { HolderRef } from "../canonical/HolderRef.js";
 import { SignerError } from "../errors.js";
@@ -142,13 +142,28 @@ export class WalletAccount implements Account {
       );
     }
 
+    const kind = resolveSighashKind(opts.inputs);
+
+    // Pin the sighash onto the PSBT inputs (like LocalAccount does), not just
+    // on sats-connect's `allowedSignHash`. Some wallets derive the sighash to
+    // sign with from PSBT_IN_SIGHASH_TYPE, not from allowedSignHash; without
+    // the field they'd sign a non-default input (e.g. a SIGHASH_SINGLE|
+    // ANYONECANPAY marketplace detach) with the default taproot sighash and
+    // produce an invalid signature. Setting both covers either mechanism.
+    let outgoing = psbt;
+    if (kind !== "default") {
+      const flag = SIGHASH_NUMBER[kind];
+      const tx = Transaction.fromPSBT(psbt);
+      for (const i of opts.inputs) tx.updateInput(i.index, { sighashType: flag });
+      outgoing = tx.toPSBT();
+    }
+
     const params: Record<string, unknown> = {
-      psbt: base64.encode(psbt),
+      psbt: base64.encode(outgoing),
       signInputs: { [this.address]: opts.inputs.map((i) => i.index) },
       broadcast: false,
     };
-    const allowedSignHash = resolveAllowedSignHash(opts.inputs);
-    if (allowedSignHash != null) params.allowedSignHash = allowedSignHash;
+    if (kind !== "default") params.allowedSignHash = SIGHASH_NUMBER[kind];
 
     const result = unwrap(
       await this.request("signPsbt", params),
@@ -206,7 +221,7 @@ function normalizeXOnly(publicKey: string): string {
 /** sats-connect carries a single per-request `allowedSignHash`, so every
  *  input in one call must share a sighash. Our flows do (each party signs
  *  its own inputs under one sighash); a mix is a programming error. */
-function resolveAllowedSignHash(inputs: SignInput[]): number | undefined {
+function resolveSighashKind(inputs: SignInput[]): SighashKind {
   const kinds = new Set(inputs.map((i) => i.sighash ?? "default"));
   if (kinds.size > 1) {
     throw new SignerError(
@@ -216,5 +231,5 @@ function resolveAllowedSignHash(inputs: SignInput[]): number | undefined {
     );
   }
   const [kind] = kinds as Set<SighashKind>;
-  return kind === "default" ? undefined : SIGHASH_NUMBER[kind];
+  return kind;
 }

--- a/sdk/src/bls.ts
+++ b/sdk/src/bls.ts
@@ -19,7 +19,7 @@ import { hex } from "@scure/base";
 import { utils as btcUtils } from "@scure/btc-signer";
 import { sha256 } from "@scure/btc-signer/utils.js";
 
-import type { Account } from "./account/index.js";
+import type { BlsCapableAccount } from "./account/index.js";
 import {
   blsPubkeyFromSecret,
   blsSecretFromSeedEip2333,
@@ -136,7 +136,7 @@ const BLS_BINDING_PREFIX = new TextEncoder().encode("KONTOR_BLS_TO_XONLY_V1");
  * via the generated `Inst.RegisterBlsKey` shape from `bindings`.
  */
 export async function buildRegistrationProof(
-  account: Account,
+  account: BlsCapableAccount,
   blsKey: BlsKey,
 ): Promise<{ blsPubkey: Uint8Array; schnorrSig: Uint8Array; blsSig: Uint8Array }> {
   const schnorrMsg = sha256(

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -45,10 +45,12 @@ export { signet } from "./chains";
 export type { Chain } from "./chains";
 export type {
   Account,
+  BlsCapableAccount,
   SighashKind,
   SignInput,
   SignPsbtOptions,
 } from "./account/index";
+export { isBlsCapable } from "./account/index";
 export { LocalAccount } from "./account/local";
 export { BlsKey, blsDerivationPath } from "./bls";
 export type {

--- a/sdk/src/session.ts
+++ b/sdk/src/session.ts
@@ -32,7 +32,7 @@
  */
 
 import { ContractAddress } from "./canonical/ContractAddress.js";
-import type { Account } from "./account/index.js";
+import { isBlsCapable, type Account } from "./account/index.js";
 import { BlsKey, buildRegistrationProof } from "./bls.js";
 import type { Chain } from "./chains.js";
 import { hex } from "@scure/base";
@@ -213,6 +213,13 @@ export class KontorSession {
    * different non-thenable handle when that work lands.
    */
   async registerBls(blsKey: BlsKey): Promise<void> {
+    if (!isBlsCapable(this.account)) {
+      throw new SignerError(
+        "registerBls requires a seed-holding (BLS-capable) account — a " +
+          "browser-wallet account can't produce the Taproot↔BLS binding signature",
+        { docsPath: "/sdk/bls" },
+      );
+    }
     const proof = await buildRegistrationProof(this.account, blsKey);
     const inst = new Inst<void>(
       this,

--- a/sdk/test/mock-wallet.ts
+++ b/sdk/test/mock-wallet.ts
@@ -1,0 +1,88 @@
+/**
+ * A headless test "wallet": a sats-connect-style `request(method, params)`
+ * function backed by a real `LocalAccount`, so it produces genuine
+ * signatures (PSBTs come out valid and finalizable) without a browser, an
+ * extension, or user prompts. The linchpin fixture for the tier-1 tests;
+ * a browser test can also register it under `window.btc_providers`.
+ */
+import { base64 } from "@scure/base";
+import { SigHash } from "@scure/btc-signer";
+import type { LocalAccount } from "../src/account/local.js";
+import type { SighashKind } from "../src/account/index.js";
+import type {
+  WalletRequest,
+  WalletRpcResponse,
+} from "../src/account/wallet.js";
+
+export interface MockWalletOptions {
+  /** `addressType` the mock reports for its address (default `"p2tr"`). */
+  addressType?: string;
+  /** Public-key form the mock returns: x-only (default) or 33-byte compressed. */
+  pubkeyForm?: "x-only" | "compressed";
+}
+
+/** Build a `WalletRequest` that signs with `account`. */
+export function mockWalletRequest(
+  account: LocalAccount,
+  opts?: MockWalletOptions,
+): WalletRequest {
+  return async (method, params): Promise<WalletRpcResponse> => {
+    switch (method) {
+      case "getAccounts":
+      case "getAddresses": {
+        // A fake `02` prefix is fine — `normalizeXOnly` only strips a byte.
+        const publicKey =
+          opts?.pubkeyForm === "compressed"
+            ? `02${account.xOnlyPubKey}`
+            : account.xOnlyPubKey;
+        return {
+          status: "success",
+          result: [
+            {
+              address: account.address,
+              publicKey,
+              addressType: opts?.addressType ?? "p2tr",
+              purpose: "payment",
+            },
+          ],
+        };
+      }
+
+      case "signMessage": {
+        // LocalAccount's BIP-322 signMessage isn't implemented; return a
+        // deterministic placeholder so the request path stays testable.
+        return {
+          status: "success",
+          result: { signature: base64.encode(new TextEncoder().encode("mock-sig")) },
+        };
+      }
+
+      case "signPsbt": {
+        const p = params as {
+          psbt: string;
+          signInputs: Record<string, number[]>;
+          allowedSignHash?: number;
+        };
+        const indexes = p.signInputs[account.address] ?? [];
+        const sighash = allowedSignHashToKind(p.allowedSignHash);
+        const signed = await account.signPsbt(base64.decode(p.psbt), {
+          inputs: indexes.map((index) => ({ index, sighash })),
+        });
+        return { status: "success", result: { psbt: base64.encode(signed) } };
+      }
+
+      default:
+        return {
+          status: "error",
+          error: { message: `mock wallet: unhandled method "${method}"` },
+        };
+    }
+  };
+}
+
+function allowedSignHashToKind(n: number | undefined): SighashKind {
+  if (n == null) return "default";
+  if (n === SigHash.ALL) return "all";
+  if (n === SigHash.SINGLE_ANYONECANPAY) return "single-anyonecanpay";
+  throw new Error(`mock wallet: unsupported allowedSignHash ${n}`);
+}

--- a/sdk/test/wallet-account.test.ts
+++ b/sdk/test/wallet-account.test.ts
@@ -153,6 +153,17 @@ test("signPsbt: rejects a mixed-sighash request", async () => {
   ).rejects.toThrow(/can't mix sighash/);
 });
 
+test("signPsbt: empty inputs no-ops without calling the wallet", async () => {
+  const { local, request, calls } = fixture();
+  const acct = await WalletAccount.connect({ chain: signet, request });
+  const psbt = taprootPsbt(local.xOnlyPubKey, local.address);
+
+  const out = await acct.signPsbt(psbt, { inputs: [] });
+
+  expect(out).toEqual(psbt);
+  expect(calls.some((c) => c.method === "signPsbt")).toBe(false);
+});
+
 test("signPsbt: requires an explicit inputs spec", async () => {
   const { local, request } = fixture();
   const acct = await WalletAccount.connect({ chain: signet, request });

--- a/sdk/test/wallet-account.test.ts
+++ b/sdk/test/wallet-account.test.ts
@@ -6,6 +6,7 @@
  * envelope) without a wallet extension or prompts.
  */
 import { test, expect } from "vitest";
+import { base64 } from "@scure/base";
 import { Transaction, p2tr } from "@scure/btc-signer";
 
 import { LocalAccount } from "../src/account/local.js";
@@ -112,15 +113,20 @@ test("signPsbt: maps single-anyonecanpay to allowedSignHash 131", async () => {
 
   // The request carried allowedSignHash 131 (= SIGHASH_SINGLE|ANYONECANPAY).
   const signPsbtCall = calls.find((c) => c.method === "signPsbt")!;
-  expect((signPsbtCall.params as { allowedSignHash?: number }).allowedSignHash).toBe(0x83);
+  const params = signPsbtCall.params as {
+    psbt: string;
+    allowedSignHash?: number;
+    signInputs: Record<string, number[]>;
+  };
+  expect(params.allowedSignHash).toBe(0x83);
   // signInputs is keyed by the account address.
-  expect(
-    (signPsbtCall.params as { signInputs: Record<string, number[]> }).signInputs[
-      local.address
-    ],
-  ).toEqual([0]);
+  expect(params.signInputs[local.address]).toEqual([0]);
 
-  // And the signed input is pinned to 0x83.
+  // The sighash is ALSO pinned on the PSBT we hand the wallet (not only via
+  // allowedSignHash), so wallets that read PSBT_IN_SIGHASH_TYPE sign 0x83.
+  expect(Transaction.fromPSBT(base64.decode(params.psbt)).getInput(0).sighashType).toBe(0x83);
+
+  // And the returned signed input is pinned to 0x83.
   expect(Transaction.fromPSBT(signed).getInput(0).sighashType).toBe(0x83);
 });
 

--- a/sdk/test/wallet-account.test.ts
+++ b/sdk/test/wallet-account.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tier-1 unit tests for `WalletAccount` (Node, no browser). Drives the
+ * account through a `LocalAccount`-backed mock provider so signatures are
+ * real: PSBTs go in, valid/finalizable PSBTs come out — exercising all the
+ * marshaling (base64, signInputs, sighash→allowedSignHash, the RPC
+ * envelope) without a wallet extension or prompts.
+ */
+import { test, expect } from "vitest";
+import { Transaction, p2tr } from "@scure/btc-signer";
+
+import { LocalAccount } from "../src/account/local.js";
+import { WalletAccount } from "../src/account/wallet.js";
+import type { WalletRequest } from "../src/account/wallet.js";
+import { SignerError } from "../src/errors.js";
+import { regtestChain, signet } from "../src/chains.js";
+import { mockWalletRequest } from "./mock-wallet.js";
+
+const MNEMONIC =
+  "test test test test test test test test test test test junk";
+
+function xOnlyBytes(h: string): Uint8Array {
+  return Uint8Array.from(h.match(/.{2}/g)!.map((b) => parseInt(b, 16)));
+}
+
+/** A LocalAccount + a request fn that records every call made to it. */
+function fixture(opts?: Parameters<typeof mockWalletRequest>[1]) {
+  const local = LocalAccount.fromMnemonic({ mnemonic: MNEMONIC, chain: signet });
+  const inner = mockWalletRequest(local, opts);
+  const calls: { method: string; params: unknown }[] = [];
+  const request: WalletRequest = (method, params) => {
+    calls.push({ method, params });
+    return inner(method, params);
+  };
+  return { local, request, calls };
+}
+
+/** A taproot key-path PSBT spending one input back to `address`. */
+function taprootPsbt(xOnlyHex: string, address: string): Uint8Array {
+  const payment = p2tr(xOnlyBytes(xOnlyHex), undefined, signet.network);
+  const tx = new Transaction();
+  tx.addInput({
+    txid: "00".repeat(32),
+    index: 0,
+    witnessUtxo: { script: payment.script, amount: 100_000n },
+    tapInternalKey: payment.tapInternalKey,
+  });
+  tx.addOutputAddress(address, 90_000n, signet.network);
+  return tx.toPSBT();
+}
+
+test("connect: binds to the wallet's P2TR address + x-only key", async () => {
+  const { local, request } = fixture();
+  const acct = await WalletAccount.connect({ chain: signet, request });
+  expect(acct.address).toBe(local.address);
+  expect(acct.xOnlyPubKey).toBe(local.xOnlyPubKey);
+  expect(acct.holderRef.kind).toBe("x-only-pubkey");
+});
+
+test("connect: normalizes a 33-byte compressed pubkey to x-only", async () => {
+  const { local, request } = fixture({ pubkeyForm: "compressed" });
+  const acct = await WalletAccount.connect({ chain: signet, request });
+  expect(acct.xOnlyPubKey).toBe(local.xOnlyPubKey);
+});
+
+test("connect: rejects an address on the wrong network", async () => {
+  // Wallet reports a regtest (bcrt1p) address while the session is signet (tb).
+  const regtest = regtestChain({
+    apiUrl: "http://localhost:1/api",
+    bitcoinRpc: "http://localhost:2",
+  });
+  const local = LocalAccount.fromMnemonic({ mnemonic: MNEMONIC, chain: regtest });
+  await expect(
+    WalletAccount.connect({ chain: signet, request: mockWalletRequest(local) }),
+  ).rejects.toBeInstanceOf(SignerError);
+});
+
+test("connect: rejects a wallet with no Taproot address", async () => {
+  const request: WalletRequest = async (method) =>
+    method === "getAccounts"
+      ? {
+          status: "success",
+          result: [
+            { address: "tb1qexamplepaymentaddrxxxxxxxxxxxxxxxxxxxx", publicKey: "ab".repeat(33), addressType: "p2wpkh", purpose: "payment" },
+          ],
+        }
+      : { status: "error", error: { message: "unexpected" } };
+  await expect(
+    WalletAccount.connect({ chain: signet, request }),
+  ).rejects.toThrow(/no Taproot/);
+});
+
+test("signPsbt: produces a valid, finalizable signed PSBT", async () => {
+  const { local, request } = fixture();
+  const acct = await WalletAccount.connect({ chain: signet, request });
+  const psbt = taprootPsbt(local.xOnlyPubKey, local.address);
+
+  const signed = await acct.signPsbt(psbt, { inputs: [{ index: 0 }] });
+
+  const reparsed = Transaction.fromPSBT(signed);
+  reparsed.finalize();
+  expect(reparsed.isFinal).toBe(true);
+});
+
+test("signPsbt: maps single-anyonecanpay to allowedSignHash 131", async () => {
+  const { local, request, calls } = fixture();
+  const acct = await WalletAccount.connect({ chain: signet, request });
+  const psbt = taprootPsbt(local.xOnlyPubKey, local.address);
+
+  const signed = await acct.signPsbt(psbt, {
+    inputs: [{ index: 0, sighash: "single-anyonecanpay" }],
+  });
+
+  // The request carried allowedSignHash 131 (= SIGHASH_SINGLE|ANYONECANPAY).
+  const signPsbtCall = calls.find((c) => c.method === "signPsbt")!;
+  expect((signPsbtCall.params as { allowedSignHash?: number }).allowedSignHash).toBe(0x83);
+  // signInputs is keyed by the account address.
+  expect(
+    (signPsbtCall.params as { signInputs: Record<string, number[]> }).signInputs[
+      local.address
+    ],
+  ).toEqual([0]);
+
+  // And the signed input is pinned to 0x83.
+  expect(Transaction.fromPSBT(signed).getInput(0).sighashType).toBe(0x83);
+});
+
+test("signPsbt: default sighash omits allowedSignHash", async () => {
+  const { local, request, calls } = fixture();
+  const acct = await WalletAccount.connect({ chain: signet, request });
+  await acct.signPsbt(taprootPsbt(local.xOnlyPubKey, local.address), {
+    inputs: [{ index: 0 }],
+  });
+  const call = calls.find((c) => c.method === "signPsbt")!;
+  expect("allowedSignHash" in (call.params as object)).toBe(false);
+});
+
+test("signPsbt: rejects a mixed-sighash request", async () => {
+  const { local, request } = fixture();
+  const acct = await WalletAccount.connect({ chain: signet, request });
+  await expect(
+    acct.signPsbt(taprootPsbt(local.xOnlyPubKey, local.address), {
+      inputs: [
+        { index: 0 },
+        { index: 1, sighash: "single-anyonecanpay" },
+      ],
+    }),
+  ).rejects.toThrow(/can't mix sighash/);
+});
+
+test("signPsbt: requires an explicit inputs spec", async () => {
+  const { local, request } = fixture();
+  const acct = await WalletAccount.connect({ chain: signet, request });
+  await expect(
+    acct.signPsbt(taprootPsbt(local.xOnlyPubKey, local.address)),
+  ).rejects.toThrow(/explicit `inputs`/);
+});
+
+test("signPsbt: surfaces a wallet rejection as SignerError", async () => {
+  const { local } = fixture();
+  // A request that connects fine but rejects the signPsbt.
+  const base = mockWalletRequest(local);
+  const request: WalletRequest = (method, params) =>
+    method === "signPsbt"
+      ? Promise.resolve({ status: "error", error: { message: "user declined" } })
+      : base(method, params);
+  const acct = await WalletAccount.connect({ chain: signet, request });
+  await expect(
+    acct.signPsbt(taprootPsbt(local.xOnlyPubKey, local.address), {
+      inputs: [{ index: 0 }],
+    }),
+  ).rejects.toThrow(/user declined/);
+});
+
+test("signMessage: delegates to the wallet and returns its signature", async () => {
+  const { request, calls } = fixture();
+  const acct = await WalletAccount.connect({ chain: signet, request });
+  const sig = await acct.signMessage("hello kontor");
+  expect(typeof sig).toBe("string");
+  const call = calls.find((c) => c.method === "signMessage")!;
+  expect((call.params as { message: string }).message).toBe("hello kontor");
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New signing and wallet-RPC paths affect how PSBTs are prepared and signed in production; BLS API narrowing could break callers that assumed every Account had signSchnorr.
> 
> **Overview**
> Implements **`WalletAccount`** for browser wallets via a small **sats-connect-style** `request(method, params)` contract (no hard dependency on the `sats-connect` package). **`connect`** selects the wallet’s **P2TR** identity, normalizes the pubkey to x-only, and validates the address matches the session **chain** HRP.
> 
> **`signPsbt`** requires an explicit `inputs` list, no-ops on empty inputs, maps sighashes to **`allowedSignHash`** and also pins **`PSBT_IN_SIGHASH_TYPE`** for wallets that ignore the RPC flag, and rejects mixed sighashes per call. **`signMessage`** delegates to the provider; wallet RPC errors surface as **`SignerError`**.
> 
> BLS registration is split out: **`signSchnorr`** moves from base **`Account`** to **`BlsCapableAccount`** with **`isBlsCapable`**, **`LocalAccount`** implements it, and **`session.registerBls`** / **`buildRegistrationProof`** reject non–seed-holding accounts. Public exports add **`BlsCapableAccount`** and **`isBlsCapable`**; tier-1 tests use **`mockWalletRequest`** backed by **`LocalAccount`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15d5a48eedea62a3bec04498b7149a80719f26f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->