### PR TITLE
test: assert storage creation-fee burn through the e2e path

### DIFF
--- a/core/indexer/tests/contracts/file_storage_tests/native_filestorage_contract.rs
+++ b/core/indexer/tests/contracts/file_storage_tests/native_filestorage_contract.rs
@@ -8,6 +8,13 @@ import!(
     path = "../../native-contracts/filestorage/wit",
 );
 
+import!(
+    name = "token",
+    height = 0,
+    tx_index = 0,
+    path = "../../native-contracts/token/wit",
+);
+
 fn has_node(nodes: &[filestorage::NodeInfo], node_id: &str, active: bool) -> bool {
     nodes
         .iter()
@@ -136,7 +143,25 @@ async fn filestorage_create_and_get(runtime: &mut Runtime) -> Result<()> {
     let signer = runtime.identity().await?;
     let descriptor = prepare_real_descriptor().await?;
 
+    // Economic state through the full execution path: the storage creation fee
+    // υ_f is burned from the creator, so total supply strictly decreases — by at
+    // least the fee (the remainder is gas, also burned). This runs in-process
+    // (the _local variant) and, via the regtest variant, end-to-end through a
+    // mined Bitcoin block → indexer → contract → asserted supply change.
+    let supply_before = token::total_supply(runtime).await?;
     let created = filestorage::create_agreement(runtime, &signer, descriptor.clone()).await??;
+    let supply_after = token::total_supply(runtime).await?;
+    let zero: Decimal = 0u64.try_into().unwrap();
+    assert!(created.fee > zero, "storage creation fee charged");
+    assert!(
+        supply_after < supply_before,
+        "creation fee burned: total supply must strictly decrease"
+    );
+    assert!(
+        supply_after + created.fee <= supply_before,
+        "total supply dropped by at least the creation fee υ_f"
+    );
+
     assert_eq!(created.agreement_id, descriptor.file_id);
 
     let got = filestorage::get_agreement(runtime, created.agreement_id.as_str()).await?;


### PR DESCRIPTION
Stacked on #441 (`feat/storage-economics`). Closes part of the economic-e2e gap surfaced by the test-strategy audit: no test asserted an economic state transition *through block processing*.

## What

`filestorage_create_and_get` previously asserted the storage creation fee υ_f was *charged* (`fee > 0`) but not that it was actually *burned from total supply*. This adds a supply-conservation assertion around `create_agreement`:

- total supply **strictly decreases** across the call (the fee is burned), and
- the drop is **at least** the returned `created.fee` (the remainder is gas, also burned).

`filestorage_create_and_get` is part of the dual-mode `test_file_storage_regtest` body, so the assertion runs:
- **in-process** via the `_local` variant (verified locally), and
- **end-to-end** via the regtest variant in CI — a mined Bitcoin block → indexer → contract → asserted supply change.

That's the missing leg: an economic state transition asserted through real block processing, not just an in-process property loop.

## Design decisions

- **`>= fee`, not `== fee`.** The supply drop is `fee + gas` (gas is also burned), so an exact-equality assertion is wrong; the robust invariant is strict decrease plus drop ≥ fee. Confirmed empirically (the exact form failed by exactly the gas amount).
- **Reused an existing dual-mode test** rather than adding a new one — `filestorage_create_and_get` already uses a real PoR descriptor that passes in both lite and regtest modes, avoiding the trivial-root rejection that a fresh `make_descriptor` would hit under regtest.
- **Added a `token` `import!`** to the module to read `total_supply` (mirrors `staking_contract.rs`).

## Scope note

The deeper economic-e2e paths — ordering-reward accrual and challenge-failure → slash through block processing — remain blocked on the reactor↔economics wiring (#442) and are out of scope here. This PR covers the user-driven path (creation-fee burn) that is drivable end-to-end today.

## Merge order

Touches `native_filestorage_contract.rs`, which #456 and #452 also modify. Merge after #441; coordinate with #452 (impl) / #456 (property tests) — additive changes, rebase whichever merges last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to contract integration tests; no production logic or auth paths modified.
> 
> **Overview**
> Extends **`filestorage_create_and_get`** so storage agreement creation is checked against **token total supply**, not only that **`created.fee > 0`**. The test now snapshots supply before/after **`create_agreement`**, asserts supply **strictly decreases**, and that the drop is **at least** the creation fee υ_f (allowing additional burn from gas).
> 
> A **`token`** WIT **`import!`** is added so the test can call **`token::total_supply`**. Because this helper runs under **`run_regtest`** / **`test_file_storage_regtest`**, the same assertions apply in-process and on the regtest path (mined block → indexer → contract).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e99dfcc7d093009ece00fd73925f3d66d3e273f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->