### PR TITLE
security: redact consensus key on mainnet + cap contract decompression

### DIFF
--- a/core/indexer/src/main.rs
+++ b/core/indexer/src/main.rs
@@ -176,7 +176,16 @@ async fn run_daemon(config: Config) -> Result<()> {
         version = built_info::PKG_VERSION,
         target = built_info::TARGET
     );
-    info!("{:#?}", config);
+    // Log the resolved config. On mainnet, redact the inline consensus key
+    // (`CONSENSUS_PRIVATE_KEY`) so it never hits the logs; on dev networks
+    // (regtest/signet/testnet) it's left in for debugging convenience.
+    if config.network == bitcoin::Network::Bitcoin && config.consensus_private_key.is_some() {
+        let mut redacted = config.clone();
+        redacted.consensus_private_key = Some("<redacted>".to_string());
+        info!("{:#?}", redacted);
+    } else {
+        info!("{:#?}", config);
+    }
     let bitcoin = bitcoin_client::Client::new_from_config(&config)?;
     let cancel_token = CancellationToken::new();
     let panic_token = cancel_token.clone();

--- a/core/indexer/src/runtime/storage.rs
+++ b/core/indexer/src/runtime/storage.rs
@@ -361,9 +361,22 @@ impl Storage {
             .await?
             .ok_or(anyhow!("Contract not found when trying to load component"))?;
         let module_bytes = tokio::task::spawn_blocking(move || {
-            let mut decompressor = brotli::Decompressor::new(&compressed_bytes[..], 4096);
+            // Cap decompressed size: a tiny on-chain brotli blob can otherwise
+            // inflate without bound in memory on every node that loads the
+            // contract (decompression bomb). 64 MiB is far above any legitimate
+            // WASM component.
+            const MAX_DECOMPRESSED: u64 = 64 * 1024 * 1024;
+            let decompressor = brotli::Decompressor::new(&compressed_bytes[..], 4096);
             let mut module_bytes = Vec::new();
-            decompressor.read_to_end(&mut module_bytes)?;
+            decompressor
+                .take(MAX_DECOMPRESSED + 1)
+                .read_to_end(&mut module_bytes)?;
+            if module_bytes.len() as u64 > MAX_DECOMPRESSED {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "decompressed contract component exceeds maximum size",
+                ));
+            }
             Ok::<_, std::io::Error>(module_bytes)
         })
         .await??;


### PR DESCRIPTION
Two small, isolated hardening fixes (single function each, no API/type changes; off `main` to stay clear of in-flight work).

1. **Consensus key in startup logs.** `info!("{:#?}", config)` (`main.rs`) dumped the resolved `Config` including `CONSENSUS_PRIVATE_KEY` in plaintext. Now redacted **on mainnet**; dev networks (regtest/signet/testnet) still log it for debugging convenience. (The `_FILE` key path was already safe.)
2. **Contract decompression bomb.** `Storage::component_bytes` brotli-decompressed an on-chain contract blob with an unbounded `read_to_end`, so a tiny blob could inflate without limit in memory on every node that loads the contract. Capped at 64 MiB (far above any legitimate WASM component); oversized blobs are rejected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized operational hardening with no API or type changes; decompression cap could reject malicious oversized blobs but should not affect legitimate WASM components.
> 
> **Overview**
> **Startup logging** no longer prints the resolved `Config` verbatim on **mainnet** when `consensus_private_key` is set inline—it clones config and substitutes `"<redacted>"` before `info!("{:#?}", …)`. Dev networks still log the full config for debugging.
> 
> **Contract loading** in `Storage::component_bytes` limits brotli output to **64 MiB** via `take(MAX_DECOMPRESSED + 1)` and rejects larger decompressed payloads with `InvalidData`, instead of unbounded `read_to_end` on every node that loads an on-chain contract blob.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 855bb3ca2b0d7ab482ba388ae37ac873120c29c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->