### PR TITLE
docs: add SECURITY.md + drop unaudited disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/KontorProtocol/Kontor/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/KontorProtocol/Kontor/actions)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-> **⚠️ WARNING: This code is unaudited and experimental. Use at your own risk.**
+> **⚠️ WARNING: This code is experimental and pre-release. Use at your own risk.**
 
 This repo contains the indexer for the [Kontor Protocol](https://docs.kontor.network/), comprised of:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,64 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in Kontor, please report
+it **privately**. Do not open a public issue, pull request, or discussion for
+security-sensitive reports.
+
+Use GitHub's private vulnerability reporting — the **"Report a vulnerability"**
+button under this repository's **Security** tab.
+
+Please include:
+
+- a description of the issue and its security impact;
+- steps to reproduce or a proof of concept;
+- the affected component(s) and the version or commit; and
+- any suggested remediation.
+
+We aim to acknowledge reports within **3 business days** and to share a
+remediation timeline after triage. Please give us a reasonable window to address
+the issue before public disclosure; we are glad to coordinate a disclosure date
+and to credit reporters who wish to be named.
+
+## Scope
+
+In scope:
+
+- The Kontor indexer / consensus node (`core/`): the reactor, the WASM contract
+  runtime, Bitcoin transaction parsing, and the HTTP/WS API.
+- The native contracts (`native-contracts/`).
+- **Consensus-safety and determinism** issues — anything that could fork the
+  metaprotocol or cause honest nodes to derive divergent state.
+
+Reported separately:
+
+- The proof-of-retrievability proof system lives in
+  **`KontorProtocol/Kontor-Crypto`**; report circuit/SNARK issues there.
+
+Generally out of scope:
+
+- Denial of service from validly-priced transactions or ordinary resource use,
+  and theoretical issues with no practical attack path.
+- Advisories in third-party dependencies that are not reachable from Kontor
+  (see `core/.cargo/audit.toml` for the documented, non-reachable set).
+- Findings that require a compromised operator host or already-leaked keys.
+
+## Threat Model
+
+The protocol-level threat models are documented in the specifications
+(`KontorProtocol/Documentation`):
+
+- **Optimistic consensus** — Byzantine adversary ≤ 1/3 stake, with safety,
+  liveness, and accountability properties (Optimistic Consensus spec,
+  §Threat Model).
+- **Storage protocol** — adversary capabilities, trust assumptions, and
+  out-of-scope items (Storage Protocol spec, §Threat Model and the Layer 1–7
+  security analysis).
+- **Bridge / kBTC** (post-v1) — trust assumptions and attack vectors (Economics
+  / Bridge spec).
+
+## Status
+
+Kontor is **pre-mainnet** software under active development; do not use it to
+secure funds at risk.


### PR DESCRIPTION
Adds a `SECURITY.md` (private vulnerability reporting via GitHub's Security tab, scope, and pointers to the spec-level threat models) and rewords the README's experimental warning to drop the "unaudited" framing. Docs only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, API, or security logic modifications.
> 
> **Overview**
> Adds a **`SECURITY.md`** that directs researchers to GitHub private vulnerability reporting, defines in-scope components (`core/`, `native-contracts/`, consensus/determinism), what to report elsewhere (`Kontor-Crypto`), and links to spec-level threat models plus a pre-mainnet status note.
> 
> The **README** warning is reworded from *unaudited and experimental* to *experimental and pre-release*, removing the explicit unaudited label while keeping a use-at-your-own-risk disclaimer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e32ffd95959a9ce732baefea9ce2491fa0a2d9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->