### PR TITLE
sdk: wallet adapter pattern + React-ready sessions + Prettier setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # Node + format check first, so a formatting violation fails in
+      # seconds rather than after the release `cargo build`.
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install SDK dependencies
+        run: npm ci
+        working-directory: ./sdk
+      - name: Check formatting (sdk)
+        run: npm run format:check
+        working-directory: ./sdk
       - uses: dtolnay/rust-toolchain@stable
       - name: Cache Cargo registry
         uses: actions/cache@v4
@@ -168,13 +180,6 @@ jobs:
       - name: Build kontor binary
         run: cargo build --release --bin kontor
         working-directory: ./core
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-      - name: Install SDK dependencies
-        run: npm ci
-        working-directory: ./sdk
       - name: Build SDK
         run: npm run build
         working-directory: ./sdk

--- a/sdk/.prettierignore
+++ b/sdk/.prettierignore
@@ -1,0 +1,13 @@
+# Build output
+dist
+
+# Dependencies
+node_modules
+
+# Generated code (don't format — regenerated from source of truth)
+src/component
+src/bindings.d.ts
+test/__generated__
+
+# Lockfile
+package-lock.json

--- a/sdk/.prettierrc
+++ b/sdk/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all"
+}

--- a/sdk/.zed/settings.json
+++ b/sdk/.zed/settings.json
@@ -1,0 +1,8 @@
+{
+  "languages": {
+    "TypeScript": { "formatter": "prettier", "format_on_save": "on" },
+    "TSX": { "formatter": "prettier", "format_on_save": "on" },
+    "JavaScript": { "formatter": "prettier", "format_on_save": "on" },
+    "JSON": { "formatter": "prettier", "format_on_save": "on" }
+  }
+}

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -2,7 +2,6 @@
 
 Types and utilities useful for working with the Kontor indexer.
 
-
 ```bash
 # setup
 npm install

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontor/sdk",
-  "version": "0.3.0",
+  "version": "0.3.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontor/sdk",
-      "version": "0.3.0",
+      "version": "0.3.0-rc.1",
       "dependencies": {
         "@scure/base": "^2.2.0",
         "@scure/bip32": "^2.2.0",
@@ -20,6 +20,7 @@
         "@bytecodealliance/jco": "^1.19.0",
         "@types/node": "^25.8.0",
         "@vitest/browser-playwright": "^4.1.6",
+        "prettier": "^3.8.3",
         "typescript": "^6.0.3",
         "vite": "^8.0.13",
         "vite-plugin-dts": "^5.0.0",
@@ -243,31 +244,6 @@
       ],
       "bin": {
         "wizer-win32-x64": "wizer"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -3216,6 +3192,22 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/process-nextick-args": {

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -43,9 +43,9 @@
       "license": "MIT"
     },
     "node_modules/@bytecodealliance/componentize-js": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/componentize-js/-/componentize-js-0.20.0.tgz",
-      "integrity": "sha512-JPRYUTD8v1QUsZ5eqhCtQR7amOTugjV2ofSjFv1/zAGksf4AZUoCFYiKTQ61E+hKUVNJKIdYLOw+stGqAL9qAg==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/componentize-js/-/componentize-js-0.21.0.tgz",
+      "integrity": "sha512-Av/XS3bJXE812P/bff3qtrJmehpgD0niK2A0fF3YIdM+jOD6E+mFrxOmuAgaIR0GNkpnm03+GE3ttt/+muqyCQ==",
       "dev": true,
       "workspaces": [
         "."
@@ -81,15 +81,16 @@
       }
     },
     "node_modules/@bytecodealliance/jco": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-1.19.0.tgz",
-      "integrity": "sha512-I57cVbL24/u/zCBwHq7D9PyIMP81hFFYF4hL/pW5biRGVLQAZuwEAUaEmghOouyt77bU2ExqscP2wkLvr3nfDw==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-1.20.0.tgz",
+      "integrity": "sha512-E3CNiV+yFEMIE69RnzOgN0vvCGr90+32rX7VBeerxadcAONnclFrXLba243XIuLuiUHQIa9IFcWkiq6dhF5pVw==",
       "dev": true,
       "license": "(Apache-2.0 WITH LLVM-exception)",
       "dependencies": {
-        "@bytecodealliance/componentize-js": "^0.20.0",
+        "@bytecodealliance/componentize-js": "^0.21.0",
         "@bytecodealliance/componentize-js-0-19-3": "npm:@bytecodealliance/componentize-js@^0.19.3",
         "@bytecodealliance/preview2-shim": "^0.17.9",
+        "@bytecodealliance/preview3-shim": "^0.1.0",
         "binaryen": "^123.0.0",
         "commander": "^14",
         "mkdirp": "^3",
@@ -106,6 +107,16 @@
       "integrity": "sha512-i0R3eQBe6PA/o/1EFE3Owe4In2rcccb6QxnjpntM/lPe3/duJ0bRQTVZM2Ufpo99X4eofGeltQUkape1C91FFA==",
       "dev": true,
       "license": "(Apache-2.0 WITH LLVM-exception)"
+    },
+    "node_modules/@bytecodealliance/preview3-shim": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/preview3-shim/-/preview3-shim-0.1.0.tgz",
+      "integrity": "sha512-aw7wk/zMgtwLDve2RvnVJ196QPLq2J5lCd+bP24G1ELx6hZuSLFp/APCzKfdJ5Z4leG2SbRyHneSXwkH8pYYlQ==",
+      "dev": true,
+      "license": "(Apache-2.0 WITH LLVM-exception)",
+      "dependencies": {
+        "@bytecodealliance/preview2-shim": "^0.17.3"
+      }
     },
     "node_modules/@bytecodealliance/weval": {
       "version": "0.4.1",
@@ -244,6 +255,31 @@
       ],
       "bin": {
         "wizer-win32-x64": "wizer"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -972,9 +1008,9 @@
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
-      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -989,9 +1025,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
-      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -1006,9 +1042,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
-      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -1023,9 +1059,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
-      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -1040,9 +1076,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
-      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -1057,9 +1093,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
-      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -1074,9 +1110,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
-      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -1091,9 +1127,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
-      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -1108,9 +1144,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
-      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -1125,9 +1161,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
-      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -1142,9 +1178,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
-      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -1159,9 +1195,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
-      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -1176,9 +1212,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
-      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -1195,9 +1231,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
-      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -1212,9 +1248,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
-      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -1236,9 +1272,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
-      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1371,15 +1407,15 @@
       }
     },
     "node_modules/@vitest/browser": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.7.tgz",
-      "integrity": "sha512-N2JFGfXoEGVAut+kHeru9dD4BUMq/q5xDvBARNl0tUsly3m5KglLOu8VO/6MkDfOlgxXTycojkt6gBKsuyR+IQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.8.tgz",
+      "integrity": "sha512-u21VzX07HzlJYpFgkxmjEXar/tG2UqWGgyGG/46SrrPc7rSdCTPw5vuowopO9CIqF8UCUQzDFdbVnNpw6N0BfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@blazediff/core": "1.9.1",
-        "@vitest/mocker": "4.1.7",
-        "@vitest/utils": "4.1.7",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "magic-string": "^0.30.21",
         "pngjs": "^7.0.0",
         "sirv": "^3.0.2",
@@ -1390,19 +1426,19 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.1.7"
+        "vitest": "4.1.8"
       }
     },
     "node_modules/@vitest/browser-playwright": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.7.tgz",
-      "integrity": "sha512-OlTlJej7YN6VwV7zJJoNeaCsctF+JXpzpZ4oBHUbrQFfIq+0KW2f07rprCLh9N/zRIZ0v4Mchn1QDDmWMUhPKw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.8.tgz",
+      "integrity": "sha512-SR7FqgegaexEg73xvf3ArtygXegagMdXnL0EZMpxrWvvhQxvicD/E8p0ib0J91riPRtQUViyh67Xjw3NqvyhVg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@vitest/browser": "4.1.7",
-        "@vitest/mocker": "4.1.7",
+        "@vitest/browser": "4.1.8",
+        "@vitest/mocker": "4.1.8",
         "tinyrainbow": "^3.1.0"
       },
       "funding": {
@@ -1410,7 +1446,7 @@
       },
       "peerDependencies": {
         "playwright": "*",
-        "vitest": "4.1.7"
+        "vitest": "4.1.8"
       },
       "peerDependenciesMeta": {
         "playwright": {
@@ -1419,16 +1455,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
-      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.7",
-        "@vitest/utils": "4.1.7",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1437,13 +1473,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
-      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.7",
+        "@vitest/spy": "4.1.8",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1464,9 +1500,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
-      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1477,13 +1513,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
-      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.7",
+        "@vitest/utils": "4.1.8",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1491,14 +1527,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
-      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.7",
-        "@vitest/utils": "4.1.7",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1507,9 +1543,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
-      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1517,13 +1553,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
-      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.7",
+        "@vitest/pretty-format": "4.1.8",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2078,9 +2114,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2332,9 +2368,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3275,14 +3311,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
-      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@oxc-project/types": "=0.132.0",
+        "@oxc-project/types": "=0.133.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -3292,27 +3328,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.2",
-        "@rolldown/binding-darwin-arm64": "1.0.2",
-        "@rolldown/binding-darwin-x64": "1.0.2",
-        "@rolldown/binding-freebsd-x64": "1.0.2",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
-        "@rolldown/binding-linux-arm64-musl": "1.0.2",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
-        "@rolldown/binding-linux-x64-gnu": "1.0.2",
-        "@rolldown/binding-linux-x64-musl": "1.0.2",
-        "@rolldown/binding-openharmony-arm64": "1.0.2",
-        "@rolldown/binding-wasm32-wasi": "1.0.2",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
-        "@rolldown/binding-win32-x64-msvc": "1.0.2"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/rolldown/node_modules/@oxc-project/types": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
-      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3593,9 +3629,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
-      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3603,9 +3639,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3741,9 +3777,9 @@
       }
     },
     "node_modules/unplugin-dts": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unplugin-dts/-/unplugin-dts-1.0.1.tgz",
-      "integrity": "sha512-EdJZxdWP4Tm/xhe58/zAge3Tu0OKDYygm8rucRrcCZ4XzgA31jexUKhaJuEMddOPBDs9ONnq6vwigbjeBqkfuw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unplugin-dts/-/unplugin-dts-1.0.2.tgz",
+      "integrity": "sha512-VbNiMD0LMl/t6nJueGtrCp79N7ZO1nquxj/FUybJDnKwZGsnW2wjdwBSzA3QEHujoxmxZIptsG43hL7LzXE96w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3802,9 +3838,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.0.14",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
-      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3812,8 +3848,8 @@
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.15",
-        "rolldown": "1.0.2",
-        "tinyglobby": "^0.2.16"
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -3881,13 +3917,13 @@
       }
     },
     "node_modules/vite-plugin-dts": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-5.0.1.tgz",
-      "integrity": "sha512-1L+x8bVPDhlI4kLzRIIGqO+b1VnvtY6CoHrU+riaipHJUAxayM0i1HObqeBv33Svil9hW64Z2KNiOn6UrKWCbA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-5.0.2.tgz",
+      "integrity": "sha512-lNeHS+dwGju6eRmNvZQt8Shwv9j3m98hbHse/lIbLq9q3yE2DcIOBBYQEVUF6tS0kOmv+VA9Z5FqmzFnGe4U8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "unplugin-dts": "1.0.1"
+        "unplugin-dts": "1.0.2"
       },
       "peerDependencies": {
         "@microsoft/api-extractor": ">=7",
@@ -3922,20 +3958,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
-      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@vitest/expect": "4.1.7",
-        "@vitest/mocker": "4.1.7",
-        "@vitest/pretty-format": "4.1.7",
-        "@vitest/runner": "4.1.7",
-        "@vitest/snapshot": "4.1.7",
-        "@vitest/spy": "4.1.7",
-        "@vitest/utils": "4.1.7",
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -3963,12 +3999,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.7",
-        "@vitest/browser-preview": "4.1.7",
-        "@vitest/browser-webdriverio": "4.1.7",
-        "@vitest/coverage-istanbul": "4.1.7",
-        "@vitest/coverage-v8": "4.1.7",
-        "@vitest/ui": "4.1.7",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -4034,14 +4070,14 @@
       "license": "MIT"
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.21.tgz",
+      "integrity": "sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",
@@ -4080,9 +4116,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -53,12 +53,15 @@
     "test": "vitest",
     "test:browser": "vitest --browser",
     "test:regtest": "npm run build && vitest --config vitest.regtest.config.ts",
-    "test:regtest:browser": "npm run build && vitest --config vitest.regtest.config.ts --browser"
+    "test:regtest:browser": "npm run build && vitest --config vitest.regtest.config.ts --browser",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "devDependencies": {
     "@bytecodealliance/jco": "^1.19.0",
     "@types/node": "^25.8.0",
     "@vitest/browser-playwright": "^4.1.6",
+    "prettier": "^3.8.3",
     "typescript": "^6.0.3",
     "vite": "^8.0.13",
     "vite-plugin-dts": "^5.0.0",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -28,6 +28,10 @@
     "./regtest": {
       "types": "./dist/regtest.d.ts",
       "import": "./dist/regtest.js"
+    },
+    "./wallets/sats-connect": {
+      "types": "./dist/wallets/sats-connect.d.ts",
+      "import": "./dist/wallets/sats-connect.js"
     }
   },
   "bin": {

--- a/sdk/src/aggregate.ts
+++ b/sdk/src/aggregate.ts
@@ -29,10 +29,7 @@
 
 import { hex } from "@scure/base";
 
-import {
-  aggregateSigningMessage,
-  blsVerify,
-} from "./component/kontor-sdk.js";
+import { aggregateSigningMessage, blsVerify } from "./component/kontor-sdk.js";
 import { SignerError } from "./errors.js";
 import type { WireInst } from "./json-codec.js";
 

--- a/sdk/src/attach.ts
+++ b/sdk/src/attach.ts
@@ -75,13 +75,17 @@ export class Attachment<T> {
     // ChainedEnvelope output committing to the detach for the future
     // buyer to spend, and Change back to the seller (last position).
     const sellerScriptPubKey = hex.encode(
-      p2tr(hex.decode(identity.xOnlyPubKey), undefined, this.session.chain.network).script,
+      p2tr(
+        hex.decode(identity.xOnlyPubKey),
+        undefined,
+        this.session.chain.network,
+      ).script,
     );
     // Route through `submitReveal` so utxos/compose/sign/broadcast/track
     // run as one atomic block under the account's lock — no race with
     // a concurrent `submit` or marketplace flow on the same account.
-    const { composed, revealHex: attachRevealHex } = await transport.submitReveal(
-      async (utxos) => {
+    const { composed, revealHex: attachRevealHex } =
+      await transport.submitReveal(async (utxos) => {
         const reveal: Reveal = {
           sat_per_vbyte: this.session.feeRate,
           participants: [
@@ -110,8 +114,7 @@ export class Attachment<T> {
           ],
         };
         return transport.composeAndSign(reveal);
-      },
-    );
+      });
 
     // The chained detach leaf script (for the future buyer to spend the
     // escrow output) lives on output 0 of the reveal — same position as

--- a/sdk/src/attach.ts
+++ b/sdk/src/attach.ts
@@ -56,6 +56,12 @@ export class Attachment<T> {
    */
   async offer(opts: { price: bigint }): Promise<Offer> {
     const { transport, identity, signing } = this.session;
+    if (signing == null) {
+      throw new TransportError(
+        "Attachment.offer requires a signer — this is a read-only session",
+        { docsPath: "/sdk/offer" },
+      );
+    }
     const attachWire: WireInsts = {
       ops: [instToWire(this.attach)],
       aggregate: null,

--- a/sdk/src/bls.ts
+++ b/sdk/src/bls.ts
@@ -117,7 +117,9 @@ export class BlsKey {
 export { BLS_PUBKEY_BYTES, BLS_SECRET_BYTES, BLS_SIG_BYTES };
 
 /** Protocol prefix the schnorr binding signs (`KONTOR_XONLY_TO_BLS_V1`). */
-const SCHNORR_BINDING_PREFIX = new TextEncoder().encode("KONTOR_XONLY_TO_BLS_V1");
+const SCHNORR_BINDING_PREFIX = new TextEncoder().encode(
+  "KONTOR_XONLY_TO_BLS_V1",
+);
 /** Protocol prefix the BLS binding signs (`KONTOR_BLS_TO_XONLY_V1`). */
 const BLS_BINDING_PREFIX = new TextEncoder().encode("KONTOR_BLS_TO_XONLY_V1");
 
@@ -138,7 +140,11 @@ const BLS_BINDING_PREFIX = new TextEncoder().encode("KONTOR_BLS_TO_XONLY_V1");
 export async function buildRegistrationProof(
   signing: Signing & { schnorr(digest: Uint8Array): Promise<Uint8Array> },
   blsKey: BlsKey,
-): Promise<{ blsPubkey: Uint8Array; schnorrSig: Uint8Array; blsSig: Uint8Array }> {
+): Promise<{
+  blsPubkey: Uint8Array;
+  schnorrSig: Uint8Array;
+  blsSig: Uint8Array;
+}> {
   const schnorrMsg = sha256(
     btcUtils.concatBytes(SCHNORR_BINDING_PREFIX, blsKey.pubkey),
   );

--- a/sdk/src/codegen.ts
+++ b/sdk/src/codegen.ts
@@ -548,9 +548,7 @@ function emitAttachment(
   detach: WitFunction,
   ctx: Ctx,
 ): string[] {
-  const attachArgs = attach.params
-    .slice(1)
-    .filter((p) => p.name !== "vout");
+  const attachArgs = attach.params.slice(1).filter((p) => p.name !== "vout");
   const sig = attachArgs
     .map((p) => `${toCamel(p.name)}: ${typeRefToTs(p.type, ctx)}`)
     .join(", ");

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -83,10 +83,7 @@ export class BaseError extends Error {
   }
 }
 
-function walkCause(
-  err: unknown,
-  fn?: (err: unknown) => boolean,
-): unknown {
+function walkCause(err: unknown, fn?: (err: unknown) => boolean): unknown {
   if (fn?.(err)) return err;
   if (err && typeof err === "object" && "cause" in err && err.cause != null) {
     return walkCause(err.cause, fn);

--- a/sdk/src/funding.ts
+++ b/sdk/src/funding.ts
@@ -34,7 +34,8 @@ export interface FundingSource {
   release(taken: Utxo[]): void;
 }
 
-const keyOf = (u: { txid: string; vout: number }): string => `${u.txid}:${u.vout}`;
+const keyOf = (u: { txid: string; vout: number }): string =>
+  `${u.txid}:${u.vout}`;
 
 /** Order UTXOs smallest-value-first. `take()` hands the pool to the
  *  indexer's greedy head-walking selector, so dust at the head gets pulled
@@ -42,7 +43,9 @@ const keyOf = (u: { txid: string; vout: number }): string => `${u.txid}:${u.vout
  *  dust outputs (the 330-sat reveal change) accumulate over many submits.
  *  Value is sats (`bigint`); compare directly, no `Number()` precision risk. */
 function dustFirst(utxos: Utxo[]): Utxo[] {
-  return [...utxos].sort((a, b) => (a.value < b.value ? -1 : a.value > b.value ? 1 : 0));
+  return [...utxos].sort((a, b) =>
+    a.value < b.value ? -1 : a.value > b.value ? 1 : 0,
+  );
 }
 
 /**
@@ -75,9 +78,12 @@ export function inMemoryFunding(initial: Utxo[]): FundingSource {
       }
       if (pool.length === 0) {
         return Promise.reject(
-          new ChainError("inMemoryFunding: no spendable UTXOs left in the pool", {
-            docsPath: "/sdk/funding",
-          }),
+          new ChainError(
+            "inMemoryFunding: no spendable UTXOs left in the pool",
+            {
+              docsPath: "/sdk/funding",
+            },
+          ),
         );
       }
       // Reserve synchronously — no await between read and remove, so two
@@ -89,7 +95,9 @@ export function inMemoryFunding(initial: Utxo[]): FundingSource {
 
     settle({ spent, change }): void {
       const spentKeys = new Set(spent.map(keyOf));
-      const unspent = (outstanding ?? []).filter((u) => !spentKeys.has(keyOf(u)));
+      const unspent = (outstanding ?? []).filter(
+        (u) => !spentKeys.has(keyOf(u)),
+      );
       pool = dustFirst([...change, ...unspent]);
       outstanding = null;
     },

--- a/sdk/src/identity.ts
+++ b/sdk/src/identity.ts
@@ -35,7 +35,9 @@ export const Identity = {
     const lower = xOnlyPubKey.toLowerCase().replace(/^0x/, "");
     const payment = p2tr(hex.decode(lower), undefined, chain.network);
     if (payment.address == null) {
-      throw new SignerError("Identity.fromXOnly: could not derive a P2TR address");
+      throw new SignerError(
+        "Identity.fromXOnly: could not derive a P2TR address",
+      );
     }
     return {
       xOnlyPubKey: lower,

--- a/sdk/src/inst.ts
+++ b/sdk/src/inst.ts
@@ -43,11 +43,7 @@ import type {
 import { ContractAddress } from "./canonical/ContractAddress.js";
 import { ContractError, SignerError, TransportError } from "./errors.js";
 import type { ChainEvent } from "./events.js";
-import type {
-  BroadcastResult,
-  OpResult,
-  OpResultRaw,
-} from "./json-codec.js";
+import type { BroadcastResult, OpResult, OpResultRaw } from "./json-codec.js";
 import type { KontorSession } from "./session.js";
 
 /**

--- a/sdk/src/inst.ts
+++ b/sdk/src/inst.ts
@@ -176,6 +176,8 @@ export class Inst<T> implements PromiseLike<T> {
    * once the indexer surfaces the outcome.
    */
   async submit(): Promise<SubmittedTx<OpResult<T>>> {
+    // Reject a read-only submit before any side effect (starting the poller).
+    this.session.assertWritable();
     const wire: WireInsts = { ops: [instToWire(this)], aggregate: null };
     // Attach to the poller's event stream *before* broadcasting, so the
     // tx's result event can't slip past between broadcast and wait().

--- a/sdk/src/insts.ts
+++ b/sdk/src/insts.ts
@@ -167,10 +167,9 @@ function unwrapAllOrThrow<T extends readonly unknown[]>(
     if (r.status === "Ok" && r.value !== undefined) {
       out.push(r.value);
     } else {
-      throw new ContractError(
-        `bulk Inst failed with status: ${r.status}`,
-        { details: r.error },
-      );
+      throw new ContractError(`bulk Inst failed with status: ${r.status}`, {
+        details: r.error,
+      });
     }
   }
   return out as unknown as T;

--- a/sdk/src/insts.ts
+++ b/sdk/src/insts.ts
@@ -88,6 +88,8 @@ export class Insts<T extends readonly unknown[]> implements PromiseLike<T> {
    * `OpResult`s (`InstsOpResults<T>`) once the indexer surfaces them.
    */
   async submit(): Promise<SubmittedTx<InstsOpResults<T>>> {
+    // Reject a read-only submit before any side effect (starting the poller).
+    this.session.assertWritable();
     // Attach to the poller before broadcasting — same race-close as
     // `Inst.submit`.
     const events = this.session.events();

--- a/sdk/src/local-key.ts
+++ b/sdk/src/local-key.ts
@@ -23,7 +23,12 @@ import { hex } from "@scure/base";
 import { HDKey } from "@scure/bip32";
 import { mnemonicToSeedSync, validateMnemonic } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english.js";
-import { SigHash, Transaction, p2tr, utils as btcUtils } from "@scure/btc-signer";
+import {
+  SigHash,
+  Transaction,
+  p2tr,
+  utils as btcUtils,
+} from "@scure/btc-signer";
 import { signSchnorr } from "@scure/btc-signer/utils.js";
 
 import { HolderRef } from "./canonical/HolderRef.js";
@@ -193,7 +198,9 @@ export class LocalKey implements Signing {
   schnorr(digest: Uint8Array): Promise<Uint8Array> {
     if (digest.length !== 32) {
       return Promise.reject(
-        new SignerError(`signSchnorr: digest must be 32 bytes, got ${digest.length}`),
+        new SignerError(
+          `signSchnorr: digest must be 32 bytes, got ${digest.length}`,
+        ),
       );
     }
     // Deterministic schnorr (no aux rand) — matches the indexer-side

--- a/sdk/src/offer.ts
+++ b/sdk/src/offer.ts
@@ -21,7 +21,12 @@
  */
 
 import { hex } from "@scure/base";
-import { TaprootControlBlock, Transaction, p2tr, utils as btcUtils } from "@scure/btc-signer";
+import {
+  TaprootControlBlock,
+  Transaction,
+  p2tr,
+  utils as btcUtils,
+} from "@scure/btc-signer";
 
 import type { Signing } from "./signing.js";
 import type { Reveal, TapLeafScript } from "./bindings.js";
@@ -41,10 +46,7 @@ function opReturnScript(payload: Uint8Array): Uint8Array {
   if (payload.length >= 0x4c) {
     throw new SignerError("offer: OP_RETURN payload too large");
   }
-  return btcUtils.concatBytes(
-    new Uint8Array([0x6a, payload.length]),
-    payload,
-  );
+  return btcUtils.concatBytes(new Uint8Array([0x6a, payload.length]), payload);
 }
 
 /**
@@ -116,7 +118,10 @@ export class Offer {
     const { identity, chain, transport } = this.session;
 
     // The escrow — the attach reveal's output 0.
-    const attachReveal = Transaction.fromRaw(hex.decode(data.attachReveal), LENIENT_TX);
+    const attachReveal = Transaction.fromRaw(
+      hex.decode(data.attachReveal),
+      LENIENT_TX,
+    );
     const escrow = attachReveal.getOutput(0);
     if (escrow.script == null || escrow.amount == null) {
       throw new SignerError("revoke: attach reveal has no escrow output 0", {

--- a/sdk/src/poller.ts
+++ b/sdk/src/poller.ts
@@ -23,7 +23,12 @@
  * share one polling loop, each getting its own fan-out queue.
  */
 
-import type { BlockRow, Info, PaginatedResponse, ResultRow } from "./bindings.js";
+import type {
+  BlockRow,
+  Info,
+  PaginatedResponse,
+  ResultRow,
+} from "./bindings.js";
 import type { ChainEvent, EventsFilter } from "./events.js";
 import { DeepReorgError, TransportError } from "./errors.js";
 import type { OpResultRaw } from "./json-codec.js";
@@ -236,7 +241,9 @@ export class ResultsPoller {
         // retry, since an always-on poller must survive these.
         if (e instanceof DeepReorgError) throw e;
         failures += 1;
-        await this.sleep(Math.min(this.backoff * failures, MAX_RETRY_BACKOFF_MS));
+        await this.sleep(
+          Math.min(this.backoff * failures, MAX_RETRY_BACKOFF_MS),
+        );
       }
     }
   }
@@ -286,7 +293,9 @@ export class ResultsPoller {
    * window; if every cached height there disagrees, the slow path
    * walks `/api/blocks/{h}` down to the fork.
    */
-  private async detectReorg(recent: ReadonlyArray<Info["recent_blocks"][number]>): Promise<void> {
+  private async detectReorg(
+    recent: ReadonlyArray<Info["recent_blocks"][number]>,
+  ): Promise<void> {
     const diverged = recent.some((b) => {
       const cached = this.cache.get(b.height);
       return cached !== undefined && cached !== b.hash;

--- a/sdk/src/regtest.ts
+++ b/sdk/src/regtest.ts
@@ -292,7 +292,9 @@ function parseIdentity(raw: unknown): RegtestIdentity {
     typeof i.publicKey !== "string" ||
     typeof i.address !== "string"
   ) {
-    throw new Error("KONTOR_REGTEST_INFO: identity has missing or mistyped fields");
+    throw new Error(
+      "KONTOR_REGTEST_INFO: identity has missing or mistyped fields",
+    );
   }
   return {
     privateKey: i.privateKey,
@@ -305,7 +307,9 @@ function parseIdentity(raw: unknown): RegtestIdentity {
 /** Parse + validate one funding-UTXO object into a `Utxo`. */
 function parseFundingUtxo(raw: unknown): Utxo {
   if (typeof raw !== "object" || raw === null) {
-    throw new Error("KONTOR_REGTEST_INFO: fundingUtxo missing or not an object");
+    throw new Error(
+      "KONTOR_REGTEST_INFO: fundingUtxo missing or not an object",
+    );
   }
   const u = raw as Record<string, unknown>;
   if (
@@ -314,10 +318,17 @@ function parseFundingUtxo(raw: unknown): Utxo {
     typeof u.value !== "number" ||
     typeof u.scriptPubKey !== "string"
   ) {
-    throw new Error("KONTOR_REGTEST_INFO: fundingUtxo has missing or mistyped fields");
+    throw new Error(
+      "KONTOR_REGTEST_INFO: fundingUtxo has missing or mistyped fields",
+    );
   }
   // `value` arrives as a JSON number of satoshis; `Utxo.value` is bigint.
-  return { txid: u.txid, vout: u.vout, value: BigInt(u.value), scriptPubKey: u.scriptPubKey };
+  return {
+    txid: u.txid,
+    vout: u.vout,
+    value: BigInt(u.value),
+    scriptPubKey: u.scriptPubKey,
+  };
 }
 
 /** Resolve the `kontor` binary path: explicit option → `$KONTOR_BIN` → PATH. */
@@ -344,7 +355,12 @@ async function bitcoinRpc(
       "content-type": "application/json",
       ...(auth != null ? { authorization: `Basic ${auth}` } : {}),
     },
-    body: JSON.stringify({ jsonrpc: "1.0", id: "kontor-regtest", method, params }),
+    body: JSON.stringify({
+      jsonrpc: "1.0",
+      id: "kontor-regtest",
+      method,
+      params,
+    }),
   });
   const json = (await res.json()) as { result?: unknown; error?: unknown };
   if (json.error != null) {
@@ -607,7 +623,9 @@ export async function startRegtest(
     }
 
     function onError(err: Error): void {
-      finish(new Error(`startRegtest: failed to spawn '${bin}': ${err.message}`));
+      finish(
+        new Error(`startRegtest: failed to spawn '${bin}': ${err.message}`),
+      );
     }
 
     function onExit(code: number | null, signal: NodeJS.Signals | null): void {

--- a/sdk/src/session.ts
+++ b/sdk/src/session.ts
@@ -408,6 +408,23 @@ export class KontorSession {
   }
 
   /**
+   * Throw if this session can't broadcast (read-only — built with a bare
+   * `identity`, no `signing`). The submit paths call this *before*
+   * `events()`, so a read-only `submit()` fails without the side effect of
+   * starting the background poller. Keeps a read-only session genuinely
+   * side-effect-free / server-safe even if `submit` is called by mistake.
+   */
+  assertWritable(): void {
+    if (this.signing == null) {
+      throw new SignerError(
+        "submit requires a signer — this is a read-only session (construct " +
+          "with `signing`)",
+        { docsPath: "/sdk/session" },
+      );
+    }
+  }
+
+  /**
    * Follow chain events — the indexer-following API. Returns a fresh
    * async iterator over `ChainEvent`s (tx outcomes + reorg signals),
    * attached to the session's already-running poller. Multiple

--- a/sdk/src/session.ts
+++ b/sdk/src/session.ts
@@ -377,9 +377,7 @@ export class KontorSession {
    * result types don't survive the serialization boundary, so the
    * aggregator's `wait()` returns the raw WAVE strings.
    */
-  combineAggregate(
-    fragments: readonly AggregateFragment[],
-  ): Insts<unknown[]> {
+  combineAggregate(fragments: readonly AggregateFragment[]): Insts<unknown[]> {
     if (fragments.length === 0) {
       throw new SignerError(
         "combineAggregate: requires at least one fragment",
@@ -478,9 +476,7 @@ function decodeContractAddressWave(wave: string): ContractAddress {
     /^\{\s*name:\s*"([^"]*)"\s*,\s*height:\s*(\d+)\s*,\s*tx-index:\s*(\d+)\s*\}$/,
   );
   if (m == null) {
-    throw new Error(
-      `expected contract-address WAVE record, got: ${wave}`,
-    );
+    throw new Error(`expected contract-address WAVE record, got: ${wave}`);
   }
   return new ContractAddress(m[1]!, BigInt(m[2]!), BigInt(m[3]!));
 }

--- a/sdk/src/session.ts
+++ b/sdk/src/session.ts
@@ -57,9 +57,20 @@ import type { KontorTransport } from "./json-codec.js";
 
 export interface KontorSessionOptions {
   chain: Chain;
-  /** The signing capability for this session. Carries its own `identity`
-   *  (so identity and key can't be mismatched). */
-  signing: Signing;
+  /**
+   * The signing capability for this session. Carries its own `identity`
+   * (so identity and key can't be mismatched). Omit for a **read-only**
+   * session — pass `identity` instead. A read-only session can `view`
+   * (and is safe to build on a server / in an RSC); `submit` / `inspect`
+   * / `simulate` / `registerBls` throw.
+   */
+  signing?: Signing;
+  /**
+   * Identity for a read-only session, when no `signing` is given. Ignored
+   * if `signing` is present (its `signing.identity` wins). A plain
+   * serializable value — no key material — so it's safe server-side.
+   */
+  identity?: Identity;
   /**
    * Where the default transport gets spendable UTXOs (and reports back
    * spent/change). Use `inMemoryFunding([utxo])` for optimistic chaining
@@ -77,7 +88,8 @@ export interface KontorSessionOptions {
   transport?: (opts: {
     chain: Chain;
     identity: Identity;
-    signing: Signing;
+    /** Absent for a read-only session. */
+    signing: Signing | undefined;
     feeRate: number | null;
   }) => KontorTransport;
   /**
@@ -127,9 +139,11 @@ type InstResults<Ts extends readonly Inst<unknown>[]> = {
 
 export class KontorSession {
   readonly chain: Chain;
-  /** The signing capability bound to this session. */
-  readonly signing: Signing;
-  /** Who this session acts as — `signing.identity`, cached. */
+  /** The signing capability bound to this session, or `undefined` for a
+   *  read-only session. */
+  readonly signing: Signing | undefined;
+  /** Who this session acts as — from `signing.identity` or the read-only
+   *  `identity` option. */
   readonly identity: Identity;
   /** Public so `Inst<T>` / `Insts<T>` can route through it directly. */
   readonly transport: KontorTransport;
@@ -139,15 +153,24 @@ export class KontorSession {
    *  indexer pick its current `fastest_fee`. */
   readonly feeRate: number | null;
   /**
-   * The session's results poller — one shared loop, started here in the
-   * constructor. Backs `events()` and (later) `inst.submit().wait()`.
+   * The session's results poller — one shared loop. Started lazily on the
+   * first `events()` / `ready()` (and thus `submit().wait()`), so just
+   * constructing a session has no side effects and a read-only / view-only
+   * session never starts a loop. `close()` stops it.
    */
   private readonly poller: ResultsPoller;
 
   constructor(opts: KontorSessionOptions) {
+    const identity = opts.signing?.identity ?? opts.identity;
+    if (identity == null) {
+      throw new SignerError(
+        "KontorSession requires `signing` (read+write) or `identity` (read-only)",
+        { docsPath: "/sdk/session" },
+      );
+    }
     this.chain = opts.chain;
     this.signing = opts.signing;
-    this.identity = opts.signing.identity;
+    this.identity = identity;
     this.defaultGasLimit = opts.defaultGasLimit ?? DEFAULT_GAS_LIMIT;
     this.feeRate = opts.feeRate ?? null;
     const make =
@@ -172,7 +195,6 @@ export class KontorSession {
       from: opts.events?.from,
       filter: opts.events?.filter,
     });
-    this.poller.start();
   }
 
   /**
@@ -238,10 +260,11 @@ export class KontorSession {
    */
   async registerBls(blsKey: BlsKey): Promise<void> {
     const signing = this.signing;
-    if (!canSignSchnorr(signing)) {
+    if (signing == null || !canSignSchnorr(signing)) {
       throw new SignerError(
         "registerBls requires a seed-holding (BLS-capable) signer — a " +
-          "browser-wallet signer can't produce the Taproot↔BLS binding signature",
+          "read-only or browser-wallet session can't produce the Taproot↔BLS " +
+          "binding signature",
         { docsPath: "/sdk/bls" },
       );
     }
@@ -405,6 +428,7 @@ export class KontorSession {
    * via `KontorSessionOptions.events` — not per call.
    */
   events(): AsyncIterableIterator<ChainEvent> {
+    this.poller.start(); // idempotent — lazy-starts the loop on first use
     return this.poller.events();
   }
 
@@ -414,6 +438,7 @@ export class KontorSession {
    * after the poller's bootstrap retries.
    */
   ready(): Promise<void> {
+    this.poller.start(); // idempotent — lazy-starts the loop on first use
     return this.poller.ready();
   }
 

--- a/sdk/src/transport/http.ts
+++ b/sdk/src/transport/http.ts
@@ -56,8 +56,10 @@ export interface HttpTransportOptions {
   chain: Chain;
   /** Identity funding + signing for this transport (the P2TR address/key). */
   identity: Identity;
-  /** Signing capability — the SDK calls `signing.psbt(...)` to authorize. */
-  signing: Signing;
+  /** Signing capability — the SDK calls `signing.psbt(...)` to authorize.
+   *  Absent for a read-only transport (`view` works; submit/inspect/simulate
+   *  throw). */
+  signing?: Signing;
 
   /** Override the chain's HTTP endpoint. */
   url?: string;
@@ -107,6 +109,18 @@ export class HttpTransport implements KontorTransport {
   constructor(private readonly opts: HttpTransportOptions) {
     this.baseUrl = (opts.url ?? opts.chain.urls.http).replace(/\/+$/, "");
     this.fetchImpl = opts.fetch ?? globalThis.fetch.bind(globalThis);
+  }
+
+  /** The signer, or a clear error on a read-only transport. */
+  private requireSigning(): Signing {
+    if (this.opts.signing == null) {
+      throw new ChainError(
+        "this is a read-only session (no signer) — only `view` is available; " +
+          "construct with `signing` to submit/inspect/simulate",
+        { docsPath: "/sdk/session" },
+      );
+    }
+    return this.opts.signing;
   }
 
   /** The funding source, or a clear error if none was configured. */
@@ -244,7 +258,7 @@ export class HttpTransport implements KontorTransport {
     revealTx: Transaction;
     composed: ComposeOutputs;
   }> {
-    const { signing } = this.opts;
+    const signing = this.requireSigning();
     const composed = await this.compose(reveal);
     const commitHexes = await Promise.all(
       composed.commits.map((c) => signCommit(signing, c.psbt_hex)),

--- a/sdk/src/transport/http.ts
+++ b/sdk/src/transport/http.ts
@@ -279,7 +279,8 @@ export class HttpTransport implements KontorTransport {
   ): Promise<Reveal> {
     const { identity } = this.opts;
     const scriptPubKeyHex = hex.encode(
-      p2tr(hex.decode(identity.xOnlyPubKey), undefined, this.opts.chain.network).script,
+      p2tr(hex.decode(identity.xOnlyPubKey), undefined, this.opts.chain.network)
+        .script,
     );
     return {
       sat_per_vbyte: this.opts.feeRate ?? null,
@@ -360,7 +361,9 @@ export class HttpTransport implements KontorTransport {
       funding.release(taken);
       throw err;
     }
-    funding.settle(this.computeFundingDelta({ suppliedUtxos: taken, composed, commitHexes }));
+    funding.settle(
+      this.computeFundingDelta({ suppliedUtxos: taken, composed, commitHexes }),
+    );
     return { result, commitHexes, revealHex, composed };
   }
 
@@ -457,10 +460,9 @@ export class HttpTransport implements KontorTransport {
     try {
       const reveal = await this.buildSimpleReveal(insts, taken);
       const { revealTx } = await this.composeAndSign(reveal);
-      const ops = await this.postJson<OpWithResult[]>(
-        "/transactions/inspect",
-        { hex: hex.encode(revealTx.extract()) },
-      );
+      const ops = await this.postJson<OpWithResult[]>("/transactions/inspect", {
+        hex: hex.encode(revealTx.extract()),
+      });
       return ops.map(opWithResultToRaw);
     } finally {
       funding.release(taken);
@@ -541,4 +543,3 @@ function opWithResultToRaw(o: OpWithResult): OpResultRaw {
 export function http(opts: HttpTransportOptions): HttpTransport {
   return new HttpTransport(opts);
 }
-

--- a/sdk/src/transport/signing.ts
+++ b/sdk/src/transport/signing.ts
@@ -33,9 +33,12 @@ export async function signCommit(
   // (the indexer fills `funding_utxo_ids` only with the seller's
   // UTXOs), so sign each one with the default sighash.
   const prep = Transaction.fromPSBT(hex.decode(psbtHex));
-  const inputsToSign = Array.from({ length: prep.inputsLength }, (_, index) => ({
-    index,
-  }));
+  const inputsToSign = Array.from(
+    { length: prep.inputsLength },
+    (_, index) => ({
+      index,
+    }),
+  );
   const signed = await signing.psbt(hex.decode(psbtHex), {
     inputs: inputsToSign,
   });
@@ -105,7 +108,11 @@ export async function signReveal(
       // wants the script bytes alone and the encoded control block.
       const script = scriptWithVersion.slice(0, -1);
       tx.updateInput(i, {
-        finalScriptWitness: [sig, script, TaprootControlBlock.encode(controlBlock)],
+        finalScriptWitness: [
+          sig,
+          script,
+          TaprootControlBlock.encode(controlBlock),
+        ],
       });
     } else {
       const sig = input.tapKeySig;

--- a/sdk/src/vite.ts
+++ b/sdk/src/vite.ts
@@ -41,8 +41,7 @@ export function kontor(opts: KontorPluginOptions): Plugin {
   let root = process.cwd();
   const inputs = Array.isArray(opts.input) ? opts.input : [opts.input];
 
-  const resolved = (): string[] =>
-    inputs.map((p) => path.resolve(root, p));
+  const resolved = (): string[] => inputs.map((p) => path.resolve(root, p));
 
   const targetFor = (witAbs: string): string =>
     path.resolve(root, opts.outDir, `${path.basename(witAbs, ".wit")}.ts`);

--- a/sdk/src/wallets/sats-connect.ts
+++ b/sdk/src/wallets/sats-connect.ts
@@ -25,7 +25,12 @@ import { SigHash, Transaction } from "@scure/btc-signer";
 import { HolderRef } from "../canonical/HolderRef.js";
 import { SignerError } from "../errors.js";
 import type { Identity } from "../identity.js";
-import type { Signing, SighashKind, SignInput, SignPsbtOptions } from "../signing.js";
+import type {
+  Signing,
+  SighashKind,
+  SignInput,
+  SignPsbtOptions,
+} from "../signing.js";
 import type { Chain } from "../chains.js";
 
 /** A sats-connect-style RPC response envelope. */
@@ -131,7 +136,9 @@ class SatsConnectSigning implements Signing {
       "signMessage",
     ) as { signature?: string };
     if (typeof result.signature !== "string") {
-      throw new SignerError("sats-connect: wallet returned no message signature");
+      throw new SignerError(
+        "sats-connect: wallet returned no message signature",
+      );
     }
     return result.signature;
   }
@@ -166,7 +173,8 @@ class SatsConnectSigning implements Signing {
     if (kind !== "default") {
       const flag = SIGHASH_NUMBER[kind];
       const tx = Transaction.fromPSBT(psbt);
-      for (const i of opts.inputs) tx.updateInput(i.index, { sighashType: flag });
+      for (const i of opts.inputs)
+        tx.updateInput(i.index, { sighashType: flag });
       outgoing = tx.toPSBT();
     }
 

--- a/sdk/src/wallets/sats-connect.ts
+++ b/sdk/src/wallets/sats-connect.ts
@@ -1,21 +1,22 @@
 /**
- * Account backed by an external browser wallet (Xverse, Leather, OKX,
- * Magic Eden, Phantom, UniSat, …) reached through a sats-connect-style
- * provider. Signing happens in the wallet's sandbox — the SDK never sees
+ * `@kontor/sdk/wallets/sats-connect` — a wallet `Signing` adapter for any
+ * sats-connect-style provider (Xverse, Leather, OKX, Magic Eden, Phantom,
+ * UniSat, …). Signing happens in the wallet's sandbox; the SDK never sees
  * the private key.
  *
- * The provider is an injected `request(method, params)` function (the
- * shape `sats-connect`'s `request` exports). Pass sats-connect's `request`
- * in real apps; tests pass a fake. The SDK does not depend on sats-connect
- * — it only speaks this small request contract, so any conforming provider
- * (a future bespoke adapter, a mock) drops in unchanged.
+ * This is the **reference wallet adapter**. A new wallet adapter is a
+ * module under `src/wallets/<name>.ts` that:
+ *   - exports a `connect(opts)` returning a `Signing` (identity + `psbt`,
+ *     resolved from the wallet at connect time),
+ *   - takes its wallet's SDK as an *optional peer dependency* (this one
+ *     takes none — it speaks a small injected `request` contract instead),
+ *   - is wired as a `@kontor/sdk/wallets/<name>` subpath export.
+ * To add Horizon (or any wallet), copy this file and swap the wallet calls.
  *
- * Bitcoin identity model: Kontor identities are x-only **Taproot (P2TR)**
- * keys, so `WalletAccount` binds to the wallet's P2TR address and signs
- * Taproot inputs with it. The user funds that Taproot address (the compose
- * pipeline builds Taproot-only reveal inputs today). BLS is *not* available
- * on a wallet account — it's a seed-holding-only capability, so this
- * implements the base `Account`, not `BlsCapableAccount`.
+ * BLS is *not* part of a wallet adapter — `Signing` here has `psbt` but no
+ * `schnorr`. BLS binding is an optional capability sourced separately for
+ * the identity (a key-holding signer); a wallet adapter stays a pure
+ * Bitcoin signer.
  */
 
 import { base64, hex } from "@scure/base";
@@ -49,6 +50,46 @@ export interface ConnectOptions {
   message?: string;
 }
 
+/**
+ * Trigger the wallet's connect flow and return a `Signing` bound to its
+ * Taproot (P2TR) address. The wallet prompts the user; on approval we read
+ * the P2TR address and its x-only public key — Kontor's identity.
+ */
+export async function connect(opts: ConnectOptions): Promise<Signing> {
+  const result = unwrap(
+    await opts.request("getAccounts", {
+      purposes: ["payment", "ordinals"],
+      message: opts.message ?? "Connect your Kontor account",
+    }),
+    "getAccounts",
+  );
+
+  const entries = asAddressEntries(result);
+  const taproot = pickTaprootAddress(entries);
+  if (taproot == null) {
+    throw new SignerError(
+      "sats-connect: the wallet exposed no Taproot (p2tr) address — " +
+        "Kontor requires a P2TR identity",
+      { docsPath: "/sdk/wallets/sats-connect" },
+    );
+  }
+
+  const hrp = opts.chain.network.bech32;
+  if (!taproot.address.startsWith(`${hrp}1p`)) {
+    throw new SignerError(
+      `sats-connect: wallet returned a "${taproot.address.slice(0, 6)}…" ` +
+        `address, but this session is bound to the "${hrp}" network`,
+      { docsPath: "/sdk/wallets/sats-connect" },
+    );
+  }
+
+  return new SatsConnectSigning(
+    opts.request,
+    normalizeXOnly(taproot.publicKey),
+    taproot.address,
+  );
+}
+
 /** `SighashKind` → the numeric sighash sats-connect's `allowedSignHash` wants.
  *  `default` is absent — a default-sighash call omits `allowedSignHash`. */
 const SIGHASH_NUMBER: Record<Exclude<SighashKind, "default">, number> = {
@@ -63,10 +104,12 @@ interface AddressEntry {
   purpose?: string;
 }
 
-export class WalletAccount implements Signing {
+/** The `Signing` returned by `connect` — delegates each PSBT sign to the
+ *  wallet over the `request` contract. Internal; callers hold a `Signing`. */
+class SatsConnectSigning implements Signing {
   readonly identity: Identity;
 
-  private constructor(
+  constructor(
     private readonly request: WalletRequest,
     xOnlyPubKey: string,
     address: string,
@@ -76,46 +119,6 @@ export class WalletAccount implements Signing {
       address,
       holderRef: HolderRef.xOnlyPubkey(xOnlyPubKey),
     };
-  }
-
-  /**
-   * Trigger the wallet's connect flow and bind to its Taproot (P2TR)
-   * address. The wallet prompts the user; on approval we read the P2TR
-   * address and its x-only public key — Kontor's identity.
-   */
-  static async connect(opts: ConnectOptions): Promise<WalletAccount> {
-    const result = unwrap(
-      await opts.request("getAccounts", {
-        purposes: ["payment", "ordinals"],
-        message: opts.message ?? "Connect your Kontor account",
-      }),
-      "getAccounts",
-    );
-
-    const entries = asAddressEntries(result);
-    const taproot = pickTaprootAddress(entries);
-    if (taproot == null) {
-      throw new SignerError(
-        "WalletAccount.connect: the wallet exposed no Taproot (p2tr) address — " +
-          "Kontor requires a P2TR identity",
-        { docsPath: "/sdk/account/wallet" },
-      );
-    }
-
-    const hrp = opts.chain.network.bech32;
-    if (!taproot.address.startsWith(`${hrp}1p`)) {
-      throw new SignerError(
-        `WalletAccount.connect: wallet returned a "${taproot.address.slice(0, 6)}…" ` +
-          `address, but this session is bound to the "${hrp}" network`,
-        { docsPath: "/sdk/account/wallet" },
-      );
-    }
-
-    return new WalletAccount(
-      opts.request,
-      normalizeXOnly(taproot.publicKey),
-      taproot.address,
-    );
   }
 
   async message(message: string | Uint8Array): Promise<string> {
@@ -128,7 +131,7 @@ export class WalletAccount implements Signing {
       "signMessage",
     ) as { signature?: string };
     if (typeof result.signature !== "string") {
-      throw new SignerError("WalletAccount.message: wallet returned no signature");
+      throw new SignerError("sats-connect: wallet returned no message signature");
     }
     return result.signature;
   }
@@ -139,22 +142,22 @@ export class WalletAccount implements Signing {
       // (sats-connect-style wallets require one), so we never have to walk
       // the PSBT to discover owned inputs.
       throw new SignerError(
-        "WalletAccount.signPsbt requires an explicit `inputs` spec",
-        { docsPath: "/sdk/account/wallet" },
+        "sats-connect.psbt requires an explicit `inputs` spec",
+        { docsPath: "/sdk/wallets/sats-connect" },
       );
     }
 
     if (opts.inputs.length === 0) {
-      // No owned inputs to sign (e.g. signReveal where this account owns none
-      // of the reveal's inputs). Match LocalAccount: no-op, don't prompt the
-      // wallet to sign nothing. Returning the PSBT unchanged.
+      // No owned inputs to sign (e.g. signReveal where this identity owns
+      // none of the reveal's inputs). Match LocalKey: no-op, don't prompt
+      // the wallet to sign nothing. Returning the PSBT unchanged.
       return psbt;
     }
 
     const kind = resolveSighashKind(opts.inputs);
 
-    // Pin the sighash onto the PSBT inputs (like LocalAccount does), not just
-    // on sats-connect's `allowedSignHash`. Some wallets derive the sighash to
+    // Pin the sighash onto the PSBT inputs (like LocalKey does), not just on
+    // sats-connect's `allowedSignHash`. Some wallets derive the sighash to
     // sign with from PSBT_IN_SIGHASH_TYPE, not from allowedSignHash; without
     // the field they'd sign a non-default input (e.g. a SIGHASH_SINGLE|
     // ANYONECANPAY marketplace detach) with the default taproot sighash and
@@ -179,7 +182,7 @@ export class WalletAccount implements Signing {
       "signPsbt",
     ) as { psbt?: string };
     if (typeof result.psbt !== "string") {
-      throw new SignerError("WalletAccount.psbt: wallet returned no signed PSBT");
+      throw new SignerError("sats-connect: wallet returned no signed PSBT");
     }
     return base64.decode(result.psbt);
   }
@@ -189,8 +192,8 @@ export class WalletAccount implements Signing {
 function unwrap(res: WalletRpcResponse, method: string): unknown {
   if (res.status === "success") return res.result;
   const detail = res.error?.message ? `: ${res.error.message}` : "";
-  throw new SignerError(`WalletAccount: wallet rejected "${method}"${detail}`, {
-    docsPath: "/sdk/account/wallet",
+  throw new SignerError(`sats-connect: wallet rejected "${method}"${detail}`, {
+    docsPath: "/sdk/wallets/sats-connect",
   });
 }
 
@@ -218,8 +221,8 @@ function normalizeXOnly(publicKey: string): string {
   if (h.length === 64) return h;
   if (h.length === 66) return h.slice(2); // drop the 02/03 compression prefix byte
   throw new SignerError(
-    `WalletAccount: unexpected public key length (${h.length} hex chars)`,
-    { docsPath: "/sdk/account/wallet" },
+    `sats-connect: unexpected public key length (${h.length} hex chars)`,
+    { docsPath: "/sdk/wallets/sats-connect" },
   );
 }
 
@@ -230,9 +233,9 @@ function resolveSighashKind(inputs: SignInput[]): SighashKind {
   const kinds = new Set(inputs.map((i) => i.sighash ?? "default"));
   if (kinds.size > 1) {
     throw new SignerError(
-      "WalletAccount.signPsbt: one signPsbt call can't mix sighash types — " +
+      "sats-connect.psbt: one signPsbt call can't mix sighash types — " +
         "sats-connect's allowedSignHash is per-request",
-      { docsPath: "/sdk/account/wallet" },
+      { docsPath: "/sdk/wallets/sats-connect" },
     );
   }
   const [kind] = kinds as Set<SighashKind>;

--- a/sdk/test/attach.test.ts
+++ b/sdk/test/attach.test.ts
@@ -37,7 +37,10 @@ const stubSigning: Signing = {
 /** Idle poller: bootstraps, then long-polls with nothing to report. */
 const pollerFetch = (async (url: string) => {
   const body = url.includes("/results")
-    ? { results: [], pagination: { has_more: false, next_offset: null, total_count: 0 } }
+    ? {
+        results: [],
+        pagination: { has_more: false, next_offset: null, total_count: 0 },
+      }
     : { last_result_id: 0, recent_blocks: [], signature: "idle" };
   if (url.includes("?wait=")) await new Promise((r) => setTimeout(r, 5));
   return new Response(JSON.stringify({ result: body }), {

--- a/sdk/test/bitcoin-rpc-proxy.ts
+++ b/sdk/test/bitcoin-rpc-proxy.ts
@@ -41,7 +41,9 @@ export interface StartProxyOptions {
   apiUrl: string;
 }
 
-export async function startRpcProxy(opts: StartProxyOptions): Promise<RpcProxy> {
+export async function startRpcProxy(
+  opts: StartProxyOptions,
+): Promise<RpcProxy> {
   const bitcoinUpstream = new URL(opts.bitcoinRpc);
   const bitcoinOrigin = `${bitcoinUpstream.protocol}//${bitcoinUpstream.host}${bitcoinUpstream.pathname.replace(/\/$/, "")}`;
   const apiUpstream = new URL(opts.apiUrl);

--- a/sdk/test/bulk.test.ts
+++ b/sdk/test/bulk.test.ts
@@ -26,7 +26,10 @@ const stubSigning: Signing = {
 /** Idle poller: bootstraps, then long-polls with nothing to report. */
 const pollerFetch = (async (url: string) => {
   const body = url.includes("/results")
-    ? { results: [], pagination: { has_more: false, next_offset: null, total_count: 0 } }
+    ? {
+        results: [],
+        pagination: { has_more: false, next_offset: null, total_count: 0 },
+      }
     : { last_result_id: 0, recent_blocks: [], signature: "idle" };
   if (url.includes("?wait=")) await new Promise((r) => setTimeout(r, 5));
   return new Response(JSON.stringify({ result: body }), {
@@ -66,8 +69,24 @@ function mockSession(simulate: KontorTransport["simulate"]): KontorSession {
 test("bulk: simulate maps each op to its slot, decoded per-Inst", async () => {
   const session = mockSession(() =>
     Promise.resolve([
-      { status: "Ok", gas: 1n, value: "42", func: "f", contract: "c_0_0", inputIndex: 0, opIndex: 0 },
-      { status: "Ok", gas: 2n, value: "99", func: "g", contract: "c_0_0", inputIndex: 0, opIndex: 1 },
+      {
+        status: "Ok",
+        gas: 1n,
+        value: "42",
+        func: "f",
+        contract: "c_0_0",
+        inputIndex: 0,
+        opIndex: 0,
+      },
+      {
+        status: "Ok",
+        gas: 2n,
+        value: "99",
+        func: "g",
+        contract: "c_0_0",
+        inputIndex: 0,
+        opIndex: 1,
+      },
     ]),
   );
   const addr = new ContractAddress("c", 0n, 0n);
@@ -86,13 +105,32 @@ test("bulk: a wrongly-ordered transport response is realigned by op index", asyn
   // Op 1 listed before op 0 — `mapBundleOutcomes` selects by index.
   const session = mockSession(() =>
     Promise.resolve([
-      { status: "Ok", gas: 2n, value: "b", func: "g", contract: "c_0_0", inputIndex: 0, opIndex: 1 },
-      { status: "Ok", gas: 1n, value: "a", func: "f", contract: "c_0_0", inputIndex: 0, opIndex: 0 },
+      {
+        status: "Ok",
+        gas: 2n,
+        value: "b",
+        func: "g",
+        contract: "c_0_0",
+        inputIndex: 0,
+        opIndex: 1,
+      },
+      {
+        status: "Ok",
+        gas: 1n,
+        value: "a",
+        func: "f",
+        contract: "c_0_0",
+        inputIndex: 0,
+        opIndex: 0,
+      },
     ]),
   );
   const addr = new ContractAddress("c", 0n, 0n);
   const [r1, r2] = await session
-    .bulk(session.call(addr, "f", "f()", (w) => w), session.call(addr, "g", "g()", (w) => w))
+    .bulk(
+      session.call(addr, "f", "f()", (w) => w),
+      session.call(addr, "g", "g()", (w) => w),
+    )
     .simulate();
   expect(r1.value).toBe("a");
   expect(r2.value).toBe("b");

--- a/sdk/test/e2e.test.ts
+++ b/sdk/test/e2e.test.ts
@@ -60,7 +60,10 @@ afterEach(() => {
  */
 const pollerFetch = (async (url: string) => {
   const body = url.includes("/results")
-    ? { results: [], pagination: { has_more: false, next_offset: null, total_count: 0 } }
+    ? {
+        results: [],
+        pagination: { has_more: false, next_offset: null, total_count: 0 },
+      }
     : { last_result_id: 0, recent_blocks: [], signature: "idle" };
   if (url.includes("?wait=")) await new Promise((r) => setTimeout(r, 5));
   return new Response(JSON.stringify({ result: body }), {

--- a/sdk/test/funding.test.ts
+++ b/sdk/test/funding.test.ts
@@ -8,13 +8,22 @@ import { inMemoryFunding, queryFunding } from "../src/funding.js";
 import type { Utxo } from "../src/json-codec.js";
 
 function utxo(tag: string, value: bigint): Utxo {
-  return { txid: tag.repeat(64).slice(0, 64), vout: 0, value, scriptPubKey: "51" };
+  return {
+    txid: tag.repeat(64).slice(0, 64),
+    vout: 0,
+    value,
+    scriptPubKey: "51",
+  };
 }
 
 const values = (us: Utxo[]): bigint[] => us.map((u) => u.value);
 
 test("inMemoryFunding: take() returns the pool smallest-value-first", async () => {
-  const f = inMemoryFunding([utxo("a", 50_000n), utxo("b", 330n), utxo("c", 10_000n)]);
+  const f = inMemoryFunding([
+    utxo("a", 50_000n),
+    utxo("b", 330n),
+    utxo("c", 10_000n),
+  ]);
   expect(values(await f.take())).toEqual([330n, 10_000n, 50_000n]);
 });
 

--- a/sdk/test/local-key.test.ts
+++ b/sdk/test/local-key.test.ts
@@ -12,8 +12,7 @@ import { regtestChain, signet } from "../src/chains.js";
 
 // BIP-39 test vector mnemonic (the "test … junk" phrase). Deriving it at
 // BIP-86 `m/86'/1'/0'/0/0` on a testnet chain is a fixed, known answer.
-const MNEMONIC =
-  "test test test test test test test test test test test junk";
+const MNEMONIC = "test test test test test test test test test test test junk";
 const SIGNET_ADDRESS =
   "tb1pfewlxm8meyyvgjydfu7v8j4ej64symj6ut8sf66h9germp94qgzsgnnjhk";
 const SIGNET_XONLY =
@@ -81,12 +80,18 @@ test("schnorr: signs a 32-byte digest, rejects a wrong-length one", async () => 
   const acct = LocalKey.fromMnemonic({ mnemonic: MNEMONIC, chain: signet });
   const sig = await acct.schnorr(new Uint8Array(32));
   expect(sig.length).toBe(64);
-  await expect(acct.schnorr(new Uint8Array(31))).rejects.toBeInstanceOf(SignerError);
+  await expect(acct.schnorr(new Uint8Array(31))).rejects.toBeInstanceOf(
+    SignerError,
+  );
 });
 
 test("psbt: signs a taproot key-path input", async () => {
   const acct = LocalKey.fromMnemonic({ mnemonic: MNEMONIC, chain: signet });
-  const payment = p2tr(xOnlyBytes(acct.identity.xOnlyPubKey), undefined, signet.network);
+  const payment = p2tr(
+    xOnlyBytes(acct.identity.xOnlyPubKey),
+    undefined,
+    signet.network,
+  );
 
   const tx = new Transaction();
   tx.addInput({
@@ -109,7 +114,11 @@ test("psbt: signs a taproot key-path input", async () => {
 
 test("psbt: signs a chosen input under an explicit sighash", async () => {
   const acct = LocalKey.fromMnemonic({ mnemonic: MNEMONIC, chain: signet });
-  const payment = p2tr(xOnlyBytes(acct.identity.xOnlyPubKey), undefined, signet.network);
+  const payment = p2tr(
+    xOnlyBytes(acct.identity.xOnlyPubKey),
+    undefined,
+    signet.network,
+  );
 
   const tx = new Transaction();
   tx.addInput({
@@ -132,7 +141,7 @@ test("psbt: signs a chosen input under an explicit sighash", async () => {
 
 test("psbt: rejects bytes that aren't a PSBT", async () => {
   const acct = LocalKey.fromMnemonic({ mnemonic: MNEMONIC, chain: signet });
-  await expect(
-    acct.psbt(new Uint8Array([1, 2, 3])),
-  ).rejects.toBeInstanceOf(SignerError);
+  await expect(acct.psbt(new Uint8Array([1, 2, 3]))).rejects.toBeInstanceOf(
+    SignerError,
+  );
 });

--- a/sdk/test/main.test.ts
+++ b/sdk/test/main.test.ts
@@ -237,12 +237,12 @@ test("Wit construction rejects WIT that fails validation", () => {
     export bad-func: async func(val: string) -> string;
 }`;
   const w = new Wit(badWit);
-  expect(() => w.encodeCall("bad-func", '{}')).toThrow(/WIT validation/);
+  expect(() => w.encodeCall("bad-func", "{}")).toThrow(/WIT validation/);
 });
 
 test("Wit construction rejects malformed WIT", () => {
   const w = new Wit("this is not valid wit at all");
-  expect(() => w.encodeCall("anything", '{}')).toThrow(/WIT parse error/);
+  expect(() => w.encodeCall("anything", "{}")).toThrow(/WIT parse error/);
 });
 
 test("Wit.encodeCall errors when function missing", () => {
@@ -364,7 +364,7 @@ test("Wit option<string> round-trips with null for none, value for some", () => 
   const w = new Wit(wit);
 
   // none ↔ null
-  expect(w.encodeCall("echo", '{"x": null}')).toBe('echo(none)');
+  expect(w.encodeCall("echo", '{"x": null}')).toBe("echo(none)");
   expect(w.decodeResult("echo", "none")).toBe("null");
 
   // some ↔ inner value directly (no wrapping)
@@ -386,7 +386,7 @@ test("Wit option<u64> round-trips preserving bigint-quoting", () => {
   expect(JSON.parse(decoded)).toBe(max);
 
   // none still null even for bigint inner
-  expect(w.encodeCall("echo", '{"x": null}')).toBe('echo(none)');
+  expect(w.encodeCall("echo", '{"x": null}')).toBe("echo(none)");
   expect(w.decodeResult("echo", "none")).toBe("null");
 });
 
@@ -411,9 +411,9 @@ test("Wit variant round-trips: unit cases as {kind}, payload cases as {kind,valu
   expect(w.decodeResult("run", "retry")).toBe('{"kind":"retry"}');
 
   // payload case with string
-  expect(w.encodeCall("run", '{"o": {"kind": "success", "value": "done"}}')).toBe(
-    'run(success("done"))',
-  );
+  expect(
+    w.encodeCall("run", '{"o": {"kind": "success", "value": "done"}}'),
+  ).toBe('run(success("done"))');
   expect(w.decodeResult("run", 'success("done")')).toBe(
     '{"kind":"success","value":"done"}',
   );
@@ -453,9 +453,9 @@ test("Wit variant rejects shape mismatches (value on unit case, missing value on
   expect(() =>
     w.encodeCall("run", '{"o": {"kind": "unit", "value": "bad"}}'),
   ).toThrow(/is unit but JSON has 'value'/);
-  expect(() =>
-    w.encodeCall("run", '{"o": {"kind": "with-payload"}}'),
-  ).toThrow(/requires 'value' field/);
+  expect(() => w.encodeCall("run", '{"o": {"kind": "with-payload"}}')).toThrow(
+    /requires 'value' field/,
+  );
 });
 
 // ─── result<T, E> ─────────────────────────────────────────────────────
@@ -627,7 +627,10 @@ test("smoke: decodeResult against real token.wit balance (option<decimal>)", () 
   //   some({r0: 42, r1: 0, r2: 0, r3: 0, sign: plus})
   expect(
     JSON.parse(
-      w.decodeResult("balance", "some({r0: 42, r1: 0, r2: 0, r3: 0, sign: plus})"),
+      w.decodeResult(
+        "balance",
+        "some({r0: 42, r1: 0, r2: 0, r3: 0, sign: plus})",
+      ),
     ),
   ).toEqual({ r0: "42", r1: "0", r2: "0", r3: "0", sign: "plus" });
 
@@ -725,13 +728,14 @@ test("codegen Tier 1: result<T,E> renders as discriminated union", () => {
   const out = generate(tokenWit);
   // hold returns result<transfer, error>; should render as
   // { kind: "ok"; value: ... } | { kind: "err"; value: ... }
-  expect(out).toMatch(/\{ kind: "ok"; value: .+ \} \| \{ kind: "err"; value: .+ \}/);
+  expect(out).toMatch(
+    /\{ kind: "ok"; value: .+ \} \| \{ kind: "err"; value: .+ \}/,
+  );
 });
 
 test("codegen Tier 1: rejects invalid WIT", () => {
   expect(() => generate("garbage")).toThrow(/WIT parse error/);
 });
-
 
 // ─── codegen Tier 2: Contract class end-to-end ────────────────────────
 
@@ -1047,4 +1051,3 @@ test("ContractAddress: fromRaw decodes string-quoted bigints", () => {
 test("ContractAddress: toString gives a human-readable form", () => {
   expect(new ContractAddress("foo", 100n, 3n).toString()).toBe("foo@100.3");
 });
-

--- a/sdk/test/mock-wallet.ts
+++ b/sdk/test/mock-wallet.ts
@@ -12,7 +12,7 @@ import type { SighashKind } from "../src/signing.js";
 import type {
   WalletRequest,
   WalletRpcResponse,
-} from "../src/account/wallet.js";
+} from "../src/wallets/sats-connect.js";
 
 export interface MockWalletOptions {
   /** `addressType` the mock reports for its address (default `"p2tr"`). */

--- a/sdk/test/mock-wallet.ts
+++ b/sdk/test/mock-wallet.ts
@@ -53,7 +53,9 @@ export function mockWalletRequest(
         // deterministic placeholder so the request path stays testable.
         return {
           status: "success",
-          result: { signature: base64.encode(new TextEncoder().encode("mock-sig")) },
+          result: {
+            signature: base64.encode(new TextEncoder().encode("mock-sig")),
+          },
         };
       }
 

--- a/sdk/test/offer.test.ts
+++ b/sdk/test/offer.test.ts
@@ -25,7 +25,10 @@ const stubSigning: Signing = {
 /** Idle poller: bootstraps, then long-polls with nothing to report. */
 const pollerFetch = (async (url: string) => {
   const body = url.includes("/results")
-    ? { results: [], pagination: { has_more: false, next_offset: null, total_count: 0 } }
+    ? {
+        results: [],
+        pagination: { has_more: false, next_offset: null, total_count: 0 },
+      }
     : { last_result_id: 0, recent_blocks: [], signature: "idle" };
   if (url.includes("?wait=")) await new Promise((r) => setTimeout(r, 5));
   return new Response(JSON.stringify({ result: body }), {
@@ -70,9 +73,9 @@ test("openOffer: rejects a blob that isn't JSON", () => {
 });
 
 test("openOffer: rejects an unrecognized blob version", () => {
-  expect(() =>
-    stubSession().openOffer(JSON.stringify({ v: 99 })),
-  ).toThrow(/not a recognized offer/);
+  expect(() => stubSession().openOffer(JSON.stringify({ v: 99 }))).toThrow(
+    /not a recognized offer/,
+  );
 });
 
 test("inspect: flags a malformed offer rather than throwing", async () => {

--- a/sdk/test/poller.test.ts
+++ b/sdk/test/poller.test.ts
@@ -76,7 +76,10 @@ function mockFetch(opts: {
       pollCount += 1;
       result = opts.infos[Math.min(pollCount, opts.infos.length - 1)];
     } else if (path.startsWith("/results")) {
-      result = { results: opts.results ?? [], pagination: { has_more: false, next_offset: null, total_count: 0 } };
+      result = {
+        results: opts.results ?? [],
+        pagination: { has_more: false, next_offset: null, total_count: 0 },
+      };
     } else {
       throw new Error(`unexpected mock path: ${path}`);
     }
@@ -114,8 +117,18 @@ function row(
 test("ResultsPoller: drains results into a per-tx event", async () => {
   const fetch = mockFetch({
     infos: [
-      { height: 1, last_result_id: 0, recent_blocks: [{ height: 1, hash: "a" }], signature: "s0" },
-      { height: 1, last_result_id: 2, recent_blocks: [{ height: 1, hash: "a" }], signature: "s1" },
+      {
+        height: 1,
+        last_result_id: 0,
+        recent_blocks: [{ height: 1, hash: "a" }],
+        signature: "s0",
+      },
+      {
+        height: 1,
+        last_result_id: 2,
+        recent_blocks: [{ height: 1, hash: "a" }],
+        signature: "s1",
+      },
     ],
     // two distinct ops (op_index 0 and 1) of one txid → one `tx` event,
     // two outcomes.
@@ -145,8 +158,18 @@ test("ResultsPoller: collapses one op's rows to its max-result_index result", as
   // — one canonical outcome, mirroring the indexer's `get_op_result`.
   const fetch = mockFetch({
     infos: [
-      { height: 1, last_result_id: 0, recent_blocks: [{ height: 1, hash: "a" }], signature: "s0" },
-      { height: 1, last_result_id: 2, recent_blocks: [{ height: 1, hash: "a" }], signature: "s1" },
+      {
+        height: 1,
+        last_result_id: 0,
+        recent_blocks: [{ height: 1, hash: "a" }],
+        signature: "s0",
+      },
+      {
+        height: 1,
+        last_result_id: 2,
+        recent_blocks: [{ height: 1, hash: "a" }],
+        signature: "s1",
+      },
     ],
     results: [
       { ...row(1, "txGG", 1, 0, 0), func: "release", gas: 5 },
@@ -208,7 +231,12 @@ test("ResultsPoller: a changed recent-block hash yields a reorg event", async ()
 test("ResultsPoller: ready() resolves once the node is reachable", async () => {
   const fetch = mockFetch({
     infos: [
-      { height: 1, last_result_id: 0, recent_blocks: [{ height: 1, hash: "a" }], signature: "s0" },
+      {
+        height: 1,
+        last_result_id: 0,
+        recent_blocks: [{ height: 1, hash: "a" }],
+        signature: "s0",
+      },
     ],
   });
   const poller = new ResultsPoller({ baseUrl: "http://test/api", fetch });

--- a/sdk/test/read-only.test.ts
+++ b/sdk/test/read-only.test.ts
@@ -24,9 +24,9 @@ test("read-only session: registerBls throws a clear read-only error", async () =
     chain: signet,
     identity: Identity.fromXOnly(XONLY, signet),
   });
-  await expect(
-    session.registerBls(undefined as never),
-  ).rejects.toThrow(/read-only/i);
+  await expect(session.registerBls(undefined as never)).rejects.toThrow(
+    /read-only/i,
+  );
   session.close();
 });
 

--- a/sdk/test/read-only.test.ts
+++ b/sdk/test/read-only.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Read-only sessions — built with a bare `identity` (no `signing`), for
+ * server-side / view-only use. Construction is side-effect-free (the poller
+ * is lazy), so these need no network: `view` is available, but any write
+ * path throws a clear error.
+ */
+import { test, expect } from "vitest";
+import { KontorSession, Identity, signet } from "@kontor/sdk";
+
+const XONLY =
+  "8c7fc6552af4384a13791e63bac79ff2bcfeedf143a88d6dc4b6080a8829cdc1";
+
+test("read-only session: identity-only, no signer, no side effects", () => {
+  const identity = Identity.fromXOnly(XONLY, signet);
+  const session = new KontorSession({ chain: signet, identity });
+  expect(session.signing).toBeUndefined();
+  expect(session.identity.xOnlyPubKey).toBe(XONLY);
+  expect(session.identity.address).toBe(identity.address);
+  session.close(); // safe even though the poller never started
+});
+
+test("read-only session: registerBls throws a clear read-only error", async () => {
+  const session = new KontorSession({
+    chain: signet,
+    identity: Identity.fromXOnly(XONLY, signet),
+  });
+  await expect(
+    session.registerBls(undefined as never),
+  ).rejects.toThrow(/read-only/i);
+  session.close();
+});
+
+test("KontorSession: requires either signing or identity", () => {
+  expect(() => new KontorSession({ chain: signet } as never)).toThrow(
+    /signing.*identity/i,
+  );
+});

--- a/sdk/test/read-only.test.ts
+++ b/sdk/test/read-only.test.ts
@@ -30,6 +30,26 @@ test("read-only session: registerBls throws a clear read-only error", async () =
   session.close();
 });
 
+test("read-only session: submit() rejects without starting the poller", async () => {
+  // A fetch that records if it's ever hit — the poller's only I/O. A
+  // read-only submit must reject before the poller starts, so this stays false.
+  let polled = false;
+  const fetchSpy = ((..._args: unknown[]) => {
+    polled = true;
+    return Promise.reject(new Error("poller should not have run"));
+  }) as unknown as typeof fetch;
+
+  const session = new KontorSession({
+    chain: signet,
+    identity: Identity.fromXOnly(XONLY, signet),
+    fetch: fetchSpy,
+  });
+  // `issuance()` is an Inst that needs no bound contract.
+  await expect(session.issuance().submit()).rejects.toThrow(/read-only/i);
+  expect(polled).toBe(false);
+  session.close();
+});
+
 test("KontorSession: requires either signing or identity", () => {
   expect(() => new KontorSession({ chain: signet } as never)).toThrow(
     /signing.*identity/i,

--- a/sdk/test/regtest.test.ts
+++ b/sdk/test/regtest.test.ts
@@ -16,7 +16,8 @@ const INFO = {
     "b02e485eed90477077e90585b3fa3b225f55a5085f0244c17315549afce0e447",
   devPublicKey:
     "3285de1e9b50e8eec053b840fb5c6b886cefcfdb729c37bba2a7e27a066f86fe",
-  devAddress: "bcrt1pfj2vd8zrgmrt2tu75t7kx29ju673v3mc8peqnp676524aayl0tvq0jq7mh",
+  devAddress:
+    "bcrt1pfj2vd8zrgmrt2tu75t7kx29ju673v3mc8peqnp676524aayl0tvq0jq7mh",
   identities: [
     {
       privateKey: "11".repeat(32),
@@ -109,13 +110,13 @@ test("parseRegtestInfo: throws on a complete-but-malformed info line", () => {
     /not valid JSON/,
   );
   const noBitcoinRpc = JSON.stringify({ ...INFO, bitcoinRpc: undefined });
-  expect(() => parseRegtestInfo(`KONTOR_REGTEST_INFO ${noBitcoinRpc}\n`)).toThrow(
-    /missing string field 'bitcoinRpc'/,
-  );
+  expect(() =>
+    parseRegtestInfo(`KONTOR_REGTEST_INFO ${noBitcoinRpc}\n`),
+  ).toThrow(/missing string field 'bitcoinRpc'/);
   const noIdentities = JSON.stringify({ ...INFO, identities: undefined });
-  expect(() => parseRegtestInfo(`KONTOR_REGTEST_INFO ${noIdentities}\n`)).toThrow(
-    /identities/,
-  );
+  expect(() =>
+    parseRegtestInfo(`KONTOR_REGTEST_INFO ${noIdentities}\n`),
+  ).toThrow(/identities/);
 });
 
 test("regtestChain: builds a bcrt chain wired to the parsed endpoints", () => {

--- a/sdk/test/sats-connect.test.ts
+++ b/sdk/test/sats-connect.test.ts
@@ -1,6 +1,6 @@
 /**
- * Tier-1 unit tests for `WalletAccount` (Node, no browser). Drives the
- * account through a `LocalKey`-backed mock provider so signatures are
+ * Tier-1 unit tests for the sats-connect wallet adapter (Node, no browser).
+ * Drives the adapter through a `LocalKey`-backed mock provider so signatures are
  * real: PSBTs go in, valid/finalizable PSBTs come out — exercising all the
  * marshaling (base64, signInputs, sighash→allowedSignHash, the RPC
  * envelope) without a wallet extension or prompts.
@@ -10,8 +10,8 @@ import { base64 } from "@scure/base";
 import { Transaction, p2tr } from "@scure/btc-signer";
 
 import { LocalKey } from "../src/local-key.js";
-import { WalletAccount } from "../src/account/wallet.js";
-import type { WalletRequest } from "../src/account/wallet.js";
+import { connect } from "../src/wallets/sats-connect.js";
+import type { WalletRequest } from "../src/wallets/sats-connect.js";
 import { SignerError } from "../src/errors.js";
 import { regtestChain, signet } from "../src/chains.js";
 import { mockWalletRequest } from "./mock-wallet.js";
@@ -51,7 +51,7 @@ function taprootPsbt(xOnlyHex: string, address: string): Uint8Array {
 
 test("connect: binds to the wallet's P2TR address + x-only key", async () => {
   const { local, request } = fixture();
-  const acct = await WalletAccount.connect({ chain: signet, request });
+  const acct = await connect({ chain: signet, request });
   expect(acct.identity.address).toBe(local.identity.address);
   expect(acct.identity.xOnlyPubKey).toBe(local.identity.xOnlyPubKey);
   expect(acct.identity.holderRef.kind).toBe("x-only-pubkey");
@@ -59,7 +59,7 @@ test("connect: binds to the wallet's P2TR address + x-only key", async () => {
 
 test("connect: normalizes a 33-byte compressed pubkey to x-only", async () => {
   const { local, request } = fixture({ pubkeyForm: "compressed" });
-  const acct = await WalletAccount.connect({ chain: signet, request });
+  const acct = await connect({ chain: signet, request });
   expect(acct.identity.xOnlyPubKey).toBe(local.identity.xOnlyPubKey);
 });
 
@@ -71,7 +71,7 @@ test("connect: rejects an address on the wrong network", async () => {
   });
   const local = LocalKey.fromMnemonic({ mnemonic: MNEMONIC, chain: regtest });
   await expect(
-    WalletAccount.connect({ chain: signet, request: mockWalletRequest(local) }),
+    connect({ chain: signet, request: mockWalletRequest(local) }),
   ).rejects.toBeInstanceOf(SignerError);
 });
 
@@ -86,13 +86,13 @@ test("connect: rejects a wallet with no Taproot address", async () => {
         }
       : { status: "error", error: { message: "unexpected" } };
   await expect(
-    WalletAccount.connect({ chain: signet, request }),
+    connect({ chain: signet, request }),
   ).rejects.toThrow(/no Taproot/);
 });
 
 test("signPsbt: produces a valid, finalizable signed PSBT", async () => {
   const { local, request } = fixture();
-  const acct = await WalletAccount.connect({ chain: signet, request });
+  const acct = await connect({ chain: signet, request });
   const psbt = taprootPsbt(local.identity.xOnlyPubKey, local.identity.address);
 
   const signed = await acct.psbt(psbt, { inputs: [{ index: 0 }] });
@@ -104,7 +104,7 @@ test("signPsbt: produces a valid, finalizable signed PSBT", async () => {
 
 test("signPsbt: maps single-anyonecanpay to allowedSignHash 131", async () => {
   const { local, request, calls } = fixture();
-  const acct = await WalletAccount.connect({ chain: signet, request });
+  const acct = await connect({ chain: signet, request });
   const psbt = taprootPsbt(local.identity.xOnlyPubKey, local.identity.address);
 
   const signed = await acct.psbt(psbt, {
@@ -132,7 +132,7 @@ test("signPsbt: maps single-anyonecanpay to allowedSignHash 131", async () => {
 
 test("signPsbt: default sighash omits allowedSignHash", async () => {
   const { local, request, calls } = fixture();
-  const acct = await WalletAccount.connect({ chain: signet, request });
+  const acct = await connect({ chain: signet, request });
   await acct.psbt(taprootPsbt(local.identity.xOnlyPubKey, local.identity.address), {
     inputs: [{ index: 0 }],
   });
@@ -142,7 +142,7 @@ test("signPsbt: default sighash omits allowedSignHash", async () => {
 
 test("signPsbt: rejects a mixed-sighash request", async () => {
   const { local, request } = fixture();
-  const acct = await WalletAccount.connect({ chain: signet, request });
+  const acct = await connect({ chain: signet, request });
   await expect(
     acct.psbt(taprootPsbt(local.identity.xOnlyPubKey, local.identity.address), {
       inputs: [
@@ -155,7 +155,7 @@ test("signPsbt: rejects a mixed-sighash request", async () => {
 
 test("signPsbt: empty inputs no-ops without calling the wallet", async () => {
   const { local, request, calls } = fixture();
-  const acct = await WalletAccount.connect({ chain: signet, request });
+  const acct = await connect({ chain: signet, request });
   const psbt = taprootPsbt(local.identity.xOnlyPubKey, local.identity.address);
 
   const out = await acct.psbt(psbt, { inputs: [] });
@@ -166,7 +166,7 @@ test("signPsbt: empty inputs no-ops without calling the wallet", async () => {
 
 test("signPsbt: requires an explicit inputs spec", async () => {
   const { local, request } = fixture();
-  const acct = await WalletAccount.connect({ chain: signet, request });
+  const acct = await connect({ chain: signet, request });
   await expect(
     acct.psbt(taprootPsbt(local.identity.xOnlyPubKey, local.identity.address)),
   ).rejects.toThrow(/explicit `inputs`/);
@@ -180,7 +180,7 @@ test("signPsbt: surfaces a wallet rejection as SignerError", async () => {
     method === "signPsbt"
       ? Promise.resolve({ status: "error", error: { message: "user declined" } })
       : base(method, params);
-  const acct = await WalletAccount.connect({ chain: signet, request });
+  const acct = await connect({ chain: signet, request });
   await expect(
     acct.psbt(taprootPsbt(local.identity.xOnlyPubKey, local.identity.address), {
       inputs: [{ index: 0 }],
@@ -190,7 +190,7 @@ test("signPsbt: surfaces a wallet rejection as SignerError", async () => {
 
 test("signMessage: delegates to the wallet and returns its signature", async () => {
   const { request, calls } = fixture();
-  const acct = await WalletAccount.connect({ chain: signet, request });
+  const acct = await connect({ chain: signet, request });
   const sig = await acct.message("hello kontor");
   expect(typeof sig).toBe("string");
   const call = calls.find((c) => c.method === "signMessage")!;

--- a/sdk/test/sats-connect.test.ts
+++ b/sdk/test/sats-connect.test.ts
@@ -16,8 +16,7 @@ import { SignerError } from "../src/errors.js";
 import { regtestChain, signet } from "../src/chains.js";
 import { mockWalletRequest } from "./mock-wallet.js";
 
-const MNEMONIC =
-  "test test test test test test test test test test test junk";
+const MNEMONIC = "test test test test test test test test test test test junk";
 
 function xOnlyBytes(h: string): Uint8Array {
   return Uint8Array.from(h.match(/.{2}/g)!.map((b) => parseInt(b, 16)));
@@ -81,13 +80,18 @@ test("connect: rejects a wallet with no Taproot address", async () => {
       ? {
           status: "success",
           result: [
-            { address: "tb1qexamplepaymentaddrxxxxxxxxxxxxxxxxxxxx", publicKey: "ab".repeat(33), addressType: "p2wpkh", purpose: "payment" },
+            {
+              address: "tb1qexamplepaymentaddrxxxxxxxxxxxxxxxxxxxx",
+              publicKey: "ab".repeat(33),
+              addressType: "p2wpkh",
+              purpose: "payment",
+            },
           ],
         }
       : { status: "error", error: { message: "unexpected" } };
-  await expect(
-    connect({ chain: signet, request }),
-  ).rejects.toThrow(/no Taproot/);
+  await expect(connect({ chain: signet, request })).rejects.toThrow(
+    /no Taproot/,
+  );
 });
 
 test("signPsbt: produces a valid, finalizable signed PSBT", async () => {
@@ -124,7 +128,9 @@ test("signPsbt: maps single-anyonecanpay to allowedSignHash 131", async () => {
 
   // The sighash is ALSO pinned on the PSBT we hand the wallet (not only via
   // allowedSignHash), so wallets that read PSBT_IN_SIGHASH_TYPE sign 0x83.
-  expect(Transaction.fromPSBT(base64.decode(params.psbt)).getInput(0).sighashType).toBe(0x83);
+  expect(
+    Transaction.fromPSBT(base64.decode(params.psbt)).getInput(0).sighashType,
+  ).toBe(0x83);
 
   // And the returned signed input is pinned to 0x83.
   expect(Transaction.fromPSBT(signed).getInput(0).sighashType).toBe(0x83);
@@ -133,9 +139,12 @@ test("signPsbt: maps single-anyonecanpay to allowedSignHash 131", async () => {
 test("signPsbt: default sighash omits allowedSignHash", async () => {
   const { local, request, calls } = fixture();
   const acct = await connect({ chain: signet, request });
-  await acct.psbt(taprootPsbt(local.identity.xOnlyPubKey, local.identity.address), {
-    inputs: [{ index: 0 }],
-  });
+  await acct.psbt(
+    taprootPsbt(local.identity.xOnlyPubKey, local.identity.address),
+    {
+      inputs: [{ index: 0 }],
+    },
+  );
   const call = calls.find((c) => c.method === "signPsbt")!;
   expect("allowedSignHash" in (call.params as object)).toBe(false);
 });
@@ -145,10 +154,7 @@ test("signPsbt: rejects a mixed-sighash request", async () => {
   const acct = await connect({ chain: signet, request });
   await expect(
     acct.psbt(taprootPsbt(local.identity.xOnlyPubKey, local.identity.address), {
-      inputs: [
-        { index: 0 },
-        { index: 1, sighash: "single-anyonecanpay" },
-      ],
+      inputs: [{ index: 0 }, { index: 1, sighash: "single-anyonecanpay" }],
     }),
   ).rejects.toThrow(/can't mix sighash/);
 });
@@ -178,7 +184,10 @@ test("signPsbt: surfaces a wallet rejection as SignerError", async () => {
   const base = mockWalletRequest(local);
   const request: WalletRequest = (method, params) =>
     method === "signPsbt"
-      ? Promise.resolve({ status: "error", error: { message: "user declined" } })
+      ? Promise.resolve({
+          status: "error",
+          error: { message: "user declined" },
+        })
       : base(method, params);
   const acct = await connect({ chain: signet, request });
   await expect(

--- a/sdk/test/sdk.regtest.test.ts
+++ b/sdk/test/sdk.regtest.test.ts
@@ -130,15 +130,25 @@ test("SDK capstone: publish, transfer, bulk, marketplace", async () => {
       expect(sim.value?.kind).toBe("ok");
 
       // Submit 1 — spends the bootstrap UTXO.
-      const first = await token.transfer(recipient.identity.holderRef, Decimal.from("1"));
+      const first = await token.transfer(
+        recipient.identity.holderRef,
+        Decimal.from("1"),
+      );
       expect(Result.unwrap(first).amt.toString()).toBe("1");
-      expect((await token.balance(recipient.identity.holderRef))?.toString()).toBe("1");
+      expect(
+        (await token.balance(recipient.identity.holderRef))?.toString(),
+      ).toBe("1");
 
       // Submit 2 — must chain through submit 1's change. If
       // change-tracking is broken, this errors with no funding.
-      const second = await token.transfer(recipient.identity.holderRef, Decimal.from("1"));
+      const second = await token.transfer(
+        recipient.identity.holderRef,
+        Decimal.from("1"),
+      );
       expect(Result.unwrap(second).amt.toString()).toBe("1");
-      expect((await token.balance(recipient.identity.holderRef))?.toString()).toBe("2");
+      expect(
+        (await token.balance(recipient.identity.holderRef))?.toString(),
+      ).toBe("2");
     } finally {
       session.close();
     }
@@ -172,8 +182,12 @@ test("SDK capstone: publish, transfer, bulk, marketplace", async () => {
       );
       expect(Result.unwrap(resA).amt.toString()).toBe("1");
       expect(Result.unwrap(resB).amt.toString()).toBe("2");
-      expect((await token.balance(recipientA.identity.holderRef))?.toString()).toBe("1");
-      expect((await token.balance(recipientB.identity.holderRef))?.toString()).toBe("2");
+      expect(
+        (await token.balance(recipientA.identity.holderRef))?.toString(),
+      ).toBe("1");
+      expect(
+        (await token.balance(recipientB.identity.holderRef))?.toString(),
+      ).toBe("2");
     } finally {
       session.close();
     }
@@ -181,7 +195,8 @@ test("SDK capstone: publish, transfer, bulk, marketplace", async () => {
 
   // ─── Phase 4 — marketplace: offer + accept ──────────────────────
   {
-    const { signing: seller, fundingUtxo: sellerFunding } = regtest.accounts[3]!;
+    const { signing: seller, fundingUtxo: sellerFunding } =
+      regtest.accounts[3]!;
     const { signing: buyer, fundingUtxo: buyerFunding } = regtest.accounts[4]!;
 
     const sellerSession = new KontorSession({
@@ -201,7 +216,8 @@ test("SDK capstone: publish, transfer, bulk, marketplace", async () => {
       const buyerToken = buyerSession.bind(Token, "token@0.0");
 
       const buyerBaseline =
-        (await buyerToken.balance(buyer.identity.holderRef)) ?? Decimal.from("0");
+        (await buyerToken.balance(buyer.identity.holderRef)) ??
+        Decimal.from("0");
 
       // Seller creates an offer; attach broadcasts immediately.
       const offer = await sellerToken
@@ -338,7 +354,9 @@ test("SDK capstone: publish, transfer, bulk, marketplace", async () => {
     // becomes the source for the next call.
     let chainSource = regtest.accounts[7]!.fundingUtxo;
     const chainSourceAccount = regtest.accounts[7]!.signing;
-    const fund = async (sats: bigint): Promise<{ signing: LocalKey; fundingUtxo: Utxo }> => {
+    const fund = async (
+      sats: bigint,
+    ): Promise<{ signing: LocalKey; fundingUtxo: Utxo }> => {
       const r = await regtest.createAccount({
         sats,
         sourceUtxo: chainSource,
@@ -359,7 +377,10 @@ test("SDK capstone: publish, transfer, bulk, marketplace", async () => {
     /** Set a fresh account up as a contributor: open a session, mint
      *  tokens via Issuance (system-paid), and register a JS-generated
      *  BlsKey so the indexer can verify aggregate signatures. */
-    const setupContributor = async (a: { signing: LocalKey; fundingUtxo: Utxo }) => {
+    const setupContributor = async (a: {
+      signing: LocalKey;
+      fundingUtxo: Utxo;
+    }) => {
       const session = new KontorSession({
         chain,
         signing: a.signing,
@@ -420,8 +441,12 @@ test("SDK capstone: publish, transfer, bulk, marketplace", async () => {
       // through the aggregator's session (any session works — view
       // queries are stateless).
       const aggToken = aggregatorSession.bind(Token, "token@0.0");
-      expect((await aggToken.balance(recipientA.identity.holderRef))?.toString()).toBe("1");
-      expect((await aggToken.balance(recipientB.identity.holderRef))?.toString()).toBe("2");
+      expect(
+        (await aggToken.balance(recipientA.identity.holderRef))?.toString(),
+      ).toBe("1");
+      expect(
+        (await aggToken.balance(recipientB.identity.holderRef))?.toString(),
+      ).toBe("2");
     } finally {
       cA.session.close();
       cB.session.close();

--- a/sdk/test/transport.test.ts
+++ b/sdk/test/transport.test.ts
@@ -50,12 +50,16 @@ test("HttpTransport.view: posts to /contracts/{addr} and returns the Ok value", 
   expect(out).toBe("some(42)");
   expect(seen!.url).toBe("http://test/api/contracts/token_0_0");
   expect(seen!.init.method).toBe("POST");
-  expect(JSON.parse(seen!.init.body as string)).toEqual({ expr: "balance(core)" });
+  expect(JSON.parse(seen!.init.body as string)).toEqual({
+    expr: "balance(core)",
+  });
 });
 
 test("HttpTransport.view: throws ContractError on an Err result", async () => {
   const t = transportWith((async () =>
-    jsonResponse({ result: { type: "Err", message: "no such function" } })) as typeof fetch);
+    jsonResponse({
+      result: { type: "Err", message: "no such function" },
+    })) as typeof fetch);
 
   await expect(t.view(token, "bogus()")).rejects.toBeInstanceOf(ContractError);
   await expect(t.view(token, "bogus()")).rejects.toThrow(/no such function/);
@@ -63,7 +67,10 @@ test("HttpTransport.view: throws ContractError on an Err result", async () => {
 
 test("HttpTransport.view: throws TransportError on a non-2xx response", async () => {
   const t = transportWith((async () =>
-    jsonResponse({ error: "Bad request: invalid address" }, 400)) as typeof fetch);
+    jsonResponse(
+      { error: "Bad request: invalid address" },
+      400,
+    )) as typeof fetch);
 
   await expect(t.view(token, "balance(core)")).rejects.toBeInstanceOf(
     TransportError,
@@ -81,8 +88,12 @@ test("HttpTransport.view: throws TransportError when the node is unreachable", a
 });
 
 test("HttpTransport.view: throws TransportError on a non-JSON body", async () => {
-  const t = transportWith((async () =>
-    new Response("<html>502 Bad Gateway</html>", { status: 200 })) as typeof fetch);
+  const t = transportWith(
+    (async () =>
+      new Response("<html>502 Bad Gateway</html>", {
+        status: 200,
+      })) as typeof fetch,
+  );
 
   await expect(t.view(token, "balance(core)")).rejects.toThrow(/non-JSON/);
 });

--- a/sdk/vite.config.ts
+++ b/sdk/vite.config.ts
@@ -26,7 +26,10 @@ export default defineConfig({
         vite: resolve(__dirname, "src/vite.ts"),
         regtest: resolve(__dirname, "src/regtest.ts"),
         cli: resolve(__dirname, "src/cli.ts"),
-        "wallets/sats-connect": resolve(__dirname, "src/wallets/sats-connect.ts"),
+        "wallets/sats-connect": resolve(
+          __dirname,
+          "src/wallets/sats-connect.ts",
+        ),
       },
       formats: ["es"],
     },
@@ -46,8 +49,7 @@ export default defineConfig({
       output: {
         // Restore the shebang Rollup strips from CLI sources, so the
         // emitted dist/cli.js is directly executable by Node.
-        banner: (chunk) =>
-          chunk.name === "cli" ? "#!/usr/bin/env node" : "",
+        banner: (chunk) => (chunk.name === "cli" ? "#!/usr/bin/env node" : ""),
       },
     },
   },

--- a/sdk/vite.config.ts
+++ b/sdk/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
         vite: resolve(__dirname, "src/vite.ts"),
         regtest: resolve(__dirname, "src/regtest.ts"),
         cli: resolve(__dirname, "src/cli.ts"),
+        "wallets/sats-connect": resolve(__dirname, "src/wallets/sats-connect.ts"),
       },
       formats: ["es"],
     },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Session and wallet import paths change behavior and public API surface (optional `signing`, new subpath); read-only guardrails are well-tested but integrators must adopt the new patterns.
> 
> **Overview**
> This PR reshapes how apps construct **Kontor sessions** and connect **browser wallets**, and adds **Prettier** enforcement for the SDK.
> 
> **Read-only / server-safe sessions:** `KontorSession` can be built with a plain `identity` and no `signing`. `view` stays available; `submit`, `inspect`, `simulate`, `registerBls`, marketplace `offer`, and transport writes go through `assertWritable()` / `requireSigning()` and fail with explicit errors. The results poller **starts lazily** on first `events()` or `ready()` (not in the constructor), so construction alone has no network side effects—`submit()` is rejected before the poller can start.
> 
> **Wallet adapter pattern:** The sats-connect integration moves to `@kontor/sdk/wallets/sats-connect` with a **`connect()`** factory that returns `Signing` (replacing the old `WalletAccount` class). The Vite build and `package.json` exports add that subpath; docs in-module describe how to add more adapters under `src/wallets/<name>.ts`.
> 
> **Tooling:** Prettier config, ignore rules (generated bindings/component, lockfile), `format` / `format:check` scripts, Zed format-on-save, and CI reordering so SDK **format check runs before** the heavy `cargo build`. Most TS diffs are Prettier-driven line wraps; functional edits cluster in `session`, `transport/http`, `inst`/`insts`, `attach`, and wallet tests.
> 
> Package version in the lockfile moves to **`0.3.0-rc.1`** alongside routine devDependency bumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d50c937baf32b36ddc022fa615554e17de6447e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->