### PR TITLE
sdk: cut 0.3.0-rc.2; fix types export paths

### DIFF
--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontor/sdk",
-  "version": "0.3.0-rc.1",
+  "version": "0.3.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontor/sdk",
-      "version": "0.3.0-rc.1",
+      "version": "0.3.0-rc.2",
       "dependencies": {
         "@scure/base": "^2.2.0",
         "@scure/bip32": "^2.2.0",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontor/sdk",
-  "version": "0.3.0-rc.1",
+  "version": "0.3.0-rc.2",
   "author": "Unspendable Labs <dev@unspendablelabs.com>",
   "repository": {
     "type": "git",
@@ -12,25 +12,25 @@
   },
   "type": "module",
   "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/src/index.d.ts",
   "files": [
     "dist"
   ],
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/src/index.d.ts",
       "import": "./dist/index.js"
     },
     "./vite": {
-      "types": "./dist/vite.d.ts",
+      "types": "./dist/src/vite.d.ts",
       "import": "./dist/vite.js"
     },
     "./regtest": {
-      "types": "./dist/regtest.d.ts",
+      "types": "./dist/src/regtest.d.ts",
       "import": "./dist/regtest.js"
     },
     "./wallets/sats-connect": {
-      "types": "./dist/wallets/sats-connect.d.ts",
+      "types": "./dist/src/wallets/sats-connect.d.ts",
       "import": "./dist/wallets/sats-connect.js"
     }
   },

--- a/sdk/vite.config.ts
+++ b/sdk/vite.config.ts
@@ -59,9 +59,10 @@ export default defineConfig({
       // The CLI is a bin, never imported — no .d.ts needed.
       exclude: ["src/cli.ts"],
       rollupTypes: false,
-      // Emit declarations at the dist/ root (dist/index.d.ts) mirroring
-      // the bundled JS entries. Without this they land under dist/src/
-      // and package.json's `types` path can't resolve them.
+      // vite-plugin-dts emits per-file declarations under `dist/src/`
+      // (mirroring the source tree); the runtime JS is bundled at the
+      // `dist/` root. So package.json's `types` paths point into
+      // `dist/src/**`, while `import` paths point at `dist/*.js`.
       entryRoot: "src",
     }),
     {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Packaging and documentation only; no runtime or API logic changes.
> 
> **Overview**
> Releases **@kontor/sdk** as `0.3.0-rc.2` and aligns published **TypeScript declaration paths** with what the build actually emits.
> 
> `package.json` now points `types` and every subpath `exports` `types` entry at `dist/src/**` (e.g. `dist/src/index.d.ts`) instead of `dist/*.d.ts` at the bundle root. Runtime `import` paths stay on `dist/*.js`. Comments in `vite.config.ts` document that **vite-plugin-dts** mirrors the source tree under `dist/src/` while Vite bundles JS at `dist/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6a12a2042351b8f85af6f6de3a45d8db355df93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->