### PR TITLE
reactor: libp2p peer discovery + dynamic-port consensus bootstrap to fix flaky cluster tests

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -219,7 +219,7 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 [[package]]
 name = "arc-malachitebft-app"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite?rev=8ee5d998545087e73710c37e457cc03cb56b1463#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/KontorProtocol/malachite?rev=e600da33cee22fd9d848fefc4d33bcf77b204fc8#e600da33cee22fd9d848fefc4d33bcf77b204fc8"
 dependencies = [
  "arc-malachitebft-codec",
  "arc-malachitebft-config",
@@ -247,7 +247,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-app-channel"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite?rev=8ee5d998545087e73710c37e457cc03cb56b1463#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/KontorProtocol/malachite?rev=e600da33cee22fd9d848fefc4d33bcf77b204fc8#e600da33cee22fd9d848fefc4d33bcf77b204fc8"
 dependencies = [
  "arc-malachitebft-app",
  "arc-malachitebft-config",
@@ -265,7 +265,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-codec"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite?rev=8ee5d998545087e73710c37e457cc03cb56b1463#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/KontorProtocol/malachite?rev=e600da33cee22fd9d848fefc4d33bcf77b204fc8#e600da33cee22fd9d848fefc4d33bcf77b204fc8"
 dependencies = [
  "bytes",
 ]
@@ -273,7 +273,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-config"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite?rev=8ee5d998545087e73710c37e457cc03cb56b1463#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/KontorProtocol/malachite?rev=e600da33cee22fd9d848fefc4d33bcf77b204fc8#e600da33cee22fd9d848fefc4d33bcf77b204fc8"
 dependencies = [
  "arc-malachitebft-core-types",
  "bytesize",
@@ -287,7 +287,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-core-consensus"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite?rev=8ee5d998545087e73710c37e457cc03cb56b1463#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/KontorProtocol/malachite?rev=e600da33cee22fd9d848fefc4d33bcf77b204fc8#e600da33cee22fd9d848fefc4d33bcf77b204fc8"
 dependencies = [
  "arc-malachitebft-core-driver",
  "arc-malachitebft-core-types",
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-core-driver"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite?rev=8ee5d998545087e73710c37e457cc03cb56b1463#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/KontorProtocol/malachite?rev=e600da33cee22fd9d848fefc4d33bcf77b204fc8#e600da33cee22fd9d848fefc4d33bcf77b204fc8"
 dependencies = [
  "arc-malachitebft-core-state-machine",
  "arc-malachitebft-core-types",
@@ -320,7 +320,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-core-state-machine"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite?rev=8ee5d998545087e73710c37e457cc03cb56b1463#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/KontorProtocol/malachite?rev=e600da33cee22fd9d848fefc4d33bcf77b204fc8#e600da33cee22fd9d848fefc4d33bcf77b204fc8"
 dependencies = [
  "arc-malachitebft-core-types",
  "derive-where",
@@ -330,7 +330,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-core-types"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite?rev=8ee5d998545087e73710c37e457cc03cb56b1463#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/KontorProtocol/malachite?rev=e600da33cee22fd9d848fefc4d33bcf77b204fc8#e600da33cee22fd9d848fefc4d33bcf77b204fc8"
 dependencies = [
  "arc-malachitebft-peer",
  "async-trait",
@@ -343,7 +343,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-core-votekeeper"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite?rev=8ee5d998545087e73710c37e457cc03cb56b1463#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/KontorProtocol/malachite?rev=e600da33cee22fd9d848fefc4d33bcf77b204fc8#e600da33cee22fd9d848fefc4d33bcf77b204fc8"
 dependencies = [
  "arc-malachitebft-core-types",
  "derive-where",
@@ -354,7 +354,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-discovery"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite?rev=8ee5d998545087e73710c37e457cc03cb56b1463#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/KontorProtocol/malachite?rev=e600da33cee22fd9d848fefc4d33bcf77b204fc8#e600da33cee22fd9d848fefc4d33bcf77b204fc8"
 dependencies = [
  "arc-malachitebft-metrics",
  "either",
@@ -369,7 +369,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-engine"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite?rev=8ee5d998545087e73710c37e457cc03cb56b1463#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/KontorProtocol/malachite?rev=e600da33cee22fd9d848fefc4d33bcf77b204fc8#e600da33cee22fd9d848fefc4d33bcf77b204fc8"
 dependencies = [
  "arc-malachitebft-codec",
  "arc-malachitebft-config",
@@ -402,7 +402,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-metrics"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite?rev=8ee5d998545087e73710c37e457cc03cb56b1463#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/KontorProtocol/malachite?rev=e600da33cee22fd9d848fefc4d33bcf77b204fc8#e600da33cee22fd9d848fefc4d33bcf77b204fc8"
 dependencies = [
  "arc-malachitebft-core-state-machine",
  "prometheus-client",
@@ -411,7 +411,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-network"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite?rev=8ee5d998545087e73710c37e457cc03cb56b1463#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/KontorProtocol/malachite?rev=e600da33cee22fd9d848fefc4d33bcf77b204fc8#e600da33cee22fd9d848fefc4d33bcf77b204fc8"
 dependencies = [
  "arc-malachitebft-discovery",
  "arc-malachitebft-metrics",
@@ -440,7 +440,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-peer"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite?rev=8ee5d998545087e73710c37e457cc03cb56b1463#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/KontorProtocol/malachite?rev=e600da33cee22fd9d848fefc4d33bcf77b204fc8#e600da33cee22fd9d848fefc4d33bcf77b204fc8"
 dependencies = [
  "bs58",
  "multihash",
@@ -450,7 +450,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-proto"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite?rev=8ee5d998545087e73710c37e457cc03cb56b1463#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/KontorProtocol/malachite?rev=e600da33cee22fd9d848fefc4d33bcf77b204fc8#e600da33cee22fd9d848fefc4d33bcf77b204fc8"
 dependencies = [
  "prost 0.13.5",
  "prost-types",
@@ -460,7 +460,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-signing"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite?rev=8ee5d998545087e73710c37e457cc03cb56b1463#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/KontorProtocol/malachite?rev=e600da33cee22fd9d848fefc4d33bcf77b204fc8#e600da33cee22fd9d848fefc4d33bcf77b204fc8"
 dependencies = [
  "arc-malachitebft-core-types",
  "async-trait",
@@ -470,7 +470,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-signing-ed25519"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite?rev=8ee5d998545087e73710c37e457cc03cb56b1463#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/KontorProtocol/malachite?rev=e600da33cee22fd9d848fefc4d33bcf77b204fc8#e600da33cee22fd9d848fefc4d33bcf77b204fc8"
 dependencies = [
  "arc-malachitebft-core-types",
  "base64 0.22.1",
@@ -483,7 +483,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-sync"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite?rev=8ee5d998545087e73710c37e457cc03cb56b1463#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/KontorProtocol/malachite?rev=e600da33cee22fd9d848fefc4d33bcf77b204fc8#e600da33cee22fd9d848fefc4d33bcf77b204fc8"
 dependencies = [
  "arc-malachitebft-core-types",
  "arc-malachitebft-metrics",
@@ -505,7 +505,7 @@ dependencies = [
 [[package]]
 name = "arc-malachitebft-wal"
 version = "0.7.0-pre"
-source = "git+https://github.com/circlefin/malachite?rev=8ee5d998545087e73710c37e457cc03cb56b1463#8ee5d998545087e73710c37e457cc03cb56b1463"
+source = "git+https://github.com/KontorProtocol/malachite?rev=e600da33cee22fd9d848fefc4d33bcf77b204fc8#e600da33cee22fd9d848fefc4d33bcf77b204fc8"
 dependencies = [
  "advisory-lock",
  "bytes",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -67,3 +67,28 @@ ts-rs = { version = "=12.0.1", features = ["format"] }
 
 # Malachite BFT consensus
 malachitebft-app-channel = { git = "https://github.com/circlefin/malachite", rev = "8ee5d998545087e73710c37e457cc03cb56b1463", package = "arc-malachitebft-app-channel" }
+
+# Pin malachite to the KontorProtocol fork (branch listen-addr-event): stores the
+# resolved consensus listen address in network state so it's readable via
+# dump_state — used to bring up clusters on `/tcp/0` (no fixed-port allocation).
+# Drop this [patch] block once the change lands upstream in circlefin.
+[patch."https://github.com/circlefin/malachite"]
+arc-malachitebft-app = { git = "https://github.com/KontorProtocol/malachite", rev = "e600da33cee22fd9d848fefc4d33bcf77b204fc8" }
+arc-malachitebft-app-channel = { git = "https://github.com/KontorProtocol/malachite", rev = "e600da33cee22fd9d848fefc4d33bcf77b204fc8" }
+arc-malachitebft-codec = { git = "https://github.com/KontorProtocol/malachite", rev = "e600da33cee22fd9d848fefc4d33bcf77b204fc8" }
+arc-malachitebft-config = { git = "https://github.com/KontorProtocol/malachite", rev = "e600da33cee22fd9d848fefc4d33bcf77b204fc8" }
+arc-malachitebft-core-consensus = { git = "https://github.com/KontorProtocol/malachite", rev = "e600da33cee22fd9d848fefc4d33bcf77b204fc8" }
+arc-malachitebft-core-driver = { git = "https://github.com/KontorProtocol/malachite", rev = "e600da33cee22fd9d848fefc4d33bcf77b204fc8" }
+arc-malachitebft-core-state-machine = { git = "https://github.com/KontorProtocol/malachite", rev = "e600da33cee22fd9d848fefc4d33bcf77b204fc8" }
+arc-malachitebft-core-types = { git = "https://github.com/KontorProtocol/malachite", rev = "e600da33cee22fd9d848fefc4d33bcf77b204fc8" }
+arc-malachitebft-core-votekeeper = { git = "https://github.com/KontorProtocol/malachite", rev = "e600da33cee22fd9d848fefc4d33bcf77b204fc8" }
+arc-malachitebft-discovery = { git = "https://github.com/KontorProtocol/malachite", rev = "e600da33cee22fd9d848fefc4d33bcf77b204fc8" }
+arc-malachitebft-engine = { git = "https://github.com/KontorProtocol/malachite", rev = "e600da33cee22fd9d848fefc4d33bcf77b204fc8" }
+arc-malachitebft-metrics = { git = "https://github.com/KontorProtocol/malachite", rev = "e600da33cee22fd9d848fefc4d33bcf77b204fc8" }
+arc-malachitebft-network = { git = "https://github.com/KontorProtocol/malachite", rev = "e600da33cee22fd9d848fefc4d33bcf77b204fc8" }
+arc-malachitebft-peer = { git = "https://github.com/KontorProtocol/malachite", rev = "e600da33cee22fd9d848fefc4d33bcf77b204fc8" }
+arc-malachitebft-proto = { git = "https://github.com/KontorProtocol/malachite", rev = "e600da33cee22fd9d848fefc4d33bcf77b204fc8" }
+arc-malachitebft-signing = { git = "https://github.com/KontorProtocol/malachite", rev = "e600da33cee22fd9d848fefc4d33bcf77b204fc8" }
+arc-malachitebft-signing-ed25519 = { git = "https://github.com/KontorProtocol/malachite", rev = "e600da33cee22fd9d848fefc4d33bcf77b204fc8" }
+arc-malachitebft-sync = { git = "https://github.com/KontorProtocol/malachite", rev = "e600da33cee22fd9d848fefc4d33bcf77b204fc8" }
+arc-malachitebft-wal = { git = "https://github.com/KontorProtocol/malachite", rev = "e600da33cee22fd9d848fefc4d33bcf77b204fc8" }

--- a/core/indexer/src/api/client.rs
+++ b/core/indexer/src/api/client.rs
@@ -8,6 +8,7 @@ use reqwest::{Client as HttpClient, ClientBuilder, Response, StatusCode};
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
+use crate::api::handlers::NodeStatus;
 use crate::{config::Config, database::types::OpResultId, runtime::ContractAddress};
 
 #[derive(Clone, Debug)]
@@ -45,6 +46,19 @@ impl Client {
 
     pub async fn index(&self) -> Result<Info> {
         Self::handle_response(self.client.get(&self.url).send().await?).await
+    }
+
+    /// Node status. Unlike `index`, this is not gated by availability, so it
+    /// answers during bootstrap (before quorum exists) — used to read back a
+    /// node's resolved `consensus_listen_addr`.
+    pub async fn status(&self) -> Result<NodeStatus> {
+        Ok(self
+            .client
+            .get(format!("{}/status", &self.url))
+            .send()
+            .await?
+            .json::<NodeStatus>()
+            .await?)
     }
 
     /// Long-poll variant of `index`: the server holds the request until

--- a/core/indexer/src/api/env.rs
+++ b/core/indexer/src/api/env.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
+use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, RwLock};
 
 use anyhow::Result;
 use deadpool::managed::Pool;
@@ -29,10 +29,12 @@ pub struct Env {
     /// exists from disk before the reactor has populated `fees_rx`) still
     /// 503s until the reactor catches up.
     pub reactor_ready: Arc<AtomicBool>,
-    /// This node's resolved consensus listen address, written by the reactor on
+    /// This node's resolved consensus listen address, sent by the reactor on
     /// the first `Listening` (before consensus is available) and surfaced by the
-    /// ungated `GET /api/status`. `None` until bound / for non-consensus nodes.
-    pub consensus_listen_addr: Arc<RwLock<Option<String>>>,
+    /// ungated `GET /api/status`. A watch so in-process cluster tests can await
+    /// the bind event-driven rather than poll. `None` until bound / for
+    /// non-consensus nodes.
+    pub consensus_listen_addr: watch::Receiver<Option<String>>,
     /// Latest fee tier snapshot published by the reactor. `borrow()` is
     /// non-blocking and returns the most recent value.
     pub fees_rx: watch::Receiver<Fees>,
@@ -59,7 +61,7 @@ impl Env {
             // Unit-test env skips the reactor; flip ready so handlers that
             // get mounted directly into a test router aren't perma-503'd.
             reactor_ready: Arc::new(AtomicBool::new(true)),
-            consensus_listen_addr: Arc::new(RwLock::new(None)),
+            consensus_listen_addr: watch::channel(None).1,
             event_subscriber: EventSubscriber::new(),
             runtime_pool: runtime::pool::new(db_path.to_path_buf(), db_name).await?,
             reader,

--- a/core/indexer/src/api/env.rs
+++ b/core/indexer/src/api/env.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
-use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, RwLock};
 
 use anyhow::Result;
 use deadpool::managed::Pool;
@@ -29,6 +29,10 @@ pub struct Env {
     /// exists from disk before the reactor has populated `fees_rx`) still
     /// 503s until the reactor catches up.
     pub reactor_ready: Arc<AtomicBool>,
+    /// This node's resolved consensus listen address, written by the reactor on
+    /// the first `Listening` (before consensus is available) and surfaced by the
+    /// ungated `GET /api/status`. `None` until bound / for non-consensus nodes.
+    pub consensus_listen_addr: Arc<RwLock<Option<String>>>,
     /// Latest fee tier snapshot published by the reactor. `borrow()` is
     /// non-blocking and returns the most recent value.
     pub fees_rx: watch::Receiver<Fees>,
@@ -55,6 +59,7 @@ impl Env {
             // Unit-test env skips the reactor; flip ready so handlers that
             // get mounted directly into a test router aren't perma-503'd.
             reactor_ready: Arc::new(AtomicBool::new(true)),
+            consensus_listen_addr: Arc::new(RwLock::new(None)),
             event_subscriber: EventSubscriber::new(),
             runtime_pool: runtime::pool::new(db_path.to_path_buf(), db_name).await?,
             reader,

--- a/core/indexer/src/api/handlers/info.rs
+++ b/core/indexer/src/api/handlers/info.rs
@@ -99,6 +99,6 @@ pub async fn get_status(State(env): State<Env>) -> Json<NodeStatus> {
         network: env.config.network.to_string(),
         consensus_mode: env.config.consensus_mode,
         reactor_ready: env.reactor_ready.load(Ordering::Relaxed),
-        consensus_listen_addr: env.consensus_listen_addr.read().unwrap().clone(),
+        consensus_listen_addr: env.consensus_listen_addr.borrow().clone(),
     })
 }

--- a/core/indexer/src/api/handlers/info.rs
+++ b/core/indexer/src/api/handlers/info.rs
@@ -1,8 +1,10 @@
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
+use axum::Json;
 use axum::extract::{Query, State};
-use indexer_types::Info;
-use serde::Deserialize;
+use indexer_types::{ConsensusMode, Info};
+use serde::{Deserialize, Serialize};
 use tokio::time::timeout;
 
 use crate::api::{API_REQUEST_TIMEOUT_MS, Env, result::Result};
@@ -70,4 +72,33 @@ pub async fn get_index(Query(query): Query<InfoQuery>, State(env): State<Env>) -
         }
     }
     Ok(current_info(&env).into())
+}
+
+/// Node status available *before* the node is "available" — static identity
+/// plus the pre-consensus signals (`reactor_ready`, the resolved consensus
+/// listen address). Deliberately served outside the `require_available` gate:
+/// a cluster bootstrapping from a seed must read the seed's listen address
+/// before quorum (and thus availability) exists.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NodeStatus {
+    pub version: String,
+    pub target: String,
+    pub network: String,
+    pub consensus_mode: ConsensusMode,
+    pub reactor_ready: bool,
+    /// Resolved consensus listen multiaddr, or `null` until bound / for
+    /// non-consensus nodes.
+    pub consensus_listen_addr: Option<String>,
+}
+
+/// `GET /api/status` — ungated node status (see [`NodeStatus`]).
+pub async fn get_status(State(env): State<Env>) -> Json<NodeStatus> {
+    Json(NodeStatus {
+        version: built_info::PKG_VERSION.to_string(),
+        target: built_info::TARGET.to_string(),
+        network: env.config.network.to_string(),
+        consensus_mode: env.config.consensus_mode,
+        reactor_ready: env.reactor_ready.load(Ordering::Relaxed),
+        consensus_listen_addr: env.consensus_listen_addr.read().unwrap().clone(),
+    })
 }

--- a/core/indexer/src/api/mod.rs
+++ b/core/indexer/src/api/mod.rs
@@ -35,9 +35,21 @@ pub async fn run(env: Env, prom_handle: PrometheusHandle) -> Result<JoinHandle<(
         }
     });
 
+    // Log the *resolved* bound address once the listener is up. With
+    // `api_port = 0` (OS-assigned — used by the regtest harness to bind without
+    // a probe/release port race) the configured `addr` reads `:0`, so the real
+    // port is only knowable after bind; `Handle::listening()` surfaces it.
+    tokio::spawn({
+        let handle = handle.clone();
+        async move {
+            if let Some(bound) = handle.listening().await {
+                info!("HTTP server running @ http://{}", bound);
+            }
+        }
+    });
+
     let router = router::new(env, prom_handle);
 
-    info!("HTTP server running @ http://{}", addr);
     Ok(tokio::spawn(async move {
         if axum_server::bind(addr)
             .handle(handle)

--- a/core/indexer/src/api/router.rs
+++ b/core/indexer/src/api/router.rs
@@ -23,10 +23,9 @@ use tracing::{Level, Span, error, field, info, span};
 
 use crate::api::handlers::{
     get_block_transactions, get_blocks, get_contract, get_contracts, get_fees, get_index,
-    get_status,
-    get_metrics, get_result, get_results, get_signer, get_transaction, get_transaction_inspect,
-    get_transactions, post_compose, post_contract, post_simulate, post_transaction_broadcast,
-    post_transaction_hex_inspect,
+    get_metrics, get_result, get_results, get_signer, get_status, get_transaction,
+    get_transaction_inspect, get_transactions, post_compose, post_contract, post_simulate,
+    post_transaction_broadcast, post_transaction_hex_inspect,
 };
 
 use super::{

--- a/core/indexer/src/api/router.rs
+++ b/core/indexer/src/api/router.rs
@@ -23,6 +23,7 @@ use tracing::{Level, Span, error, field, info, span};
 
 use crate::api::handlers::{
     get_block_transactions, get_blocks, get_contract, get_contracts, get_fees, get_index,
+    get_status,
     get_metrics, get_result, get_results, get_signer, get_transaction, get_transaction_inspect,
     get_transactions, post_compose, post_contract, post_simulate, post_transaction_broadcast,
     post_transaction_hex_inspect,
@@ -170,8 +171,14 @@ pub fn new(context: Env, prom_handle: PrometheusHandle) -> Router {
         .route("/signers/{identifier}", get(get_signer))
         .layer(from_fn_with_state(context.clone(), require_available));
 
+    // Endpoints that must answer even before the node is "available" — merged
+    // outside the `require_available` layer above. `/status` carries the
+    // consensus listen addr (resolved at swarm-bind time), needed to bootstrap a
+    // cluster before quorum (and thus availability) exists.
+    let always_available = Router::new().route("/status", get(get_status));
+
     Router::new()
-        .nest("/api", chain_routes)
+        .nest("/api", chain_routes.merge(always_available))
         .layer(
             ServiceBuilder::new()
                 .layer(SetRequestIdLayer::new(

--- a/core/indexer/src/logging.rs
+++ b/core/indexer/src/logging.rs
@@ -40,9 +40,9 @@ pub fn setup_with_format(log_format: Format) {
                     .with_default_directive(LevelFilter::INFO.into())
                     .from_env_lossy()
                     .add_directive("arc_malachitebft=warn".parse().unwrap());
-                // Emit ANSI colour codes only when stdout is a real
-                // terminal; otherwise (redirected to a file or piped)
-                // they land in the output as escape-sequence garbage.
+                // Emit ANSI colour codes only when stdout is a real terminal;
+                // otherwise (redirected to a file or piped) they land in the
+                // output as escape-sequence garbage.
                 let _ = tracing_subscriber::fmt()
                     .with_env_filter(env_filter)
                     .with_ansi(std::io::stdout().is_terminal())

--- a/core/indexer/src/main.rs
+++ b/core/indexer/src/main.rs
@@ -276,6 +276,7 @@ async fn run_daemon(config: Config) -> Result<()> {
         persistent_peers: config.consensus_peers.clone(),
         data_dir: config.data_dir.clone(),
         consensus_enabled,
+        discovery_enabled: true,
     };
 
     let (ready_tx, ready_rx) = oneshot::channel();

--- a/core/indexer/src/main.rs
+++ b/core/indexer/src/main.rs
@@ -200,7 +200,7 @@ async fn run_daemon(config: Config) -> Result<()> {
     let reader = database::Reader::new(&config.data_dir, filename).await?;
     let writer = database::Writer::new(&config.data_dir, filename).await?;
     let reactor_ready = Arc::new(AtomicBool::new(false));
-    let consensus_listen_addr = Arc::new(std::sync::RwLock::new(None));
+    let (consensus_listen_addr_tx, consensus_listen_addr_rx) = tokio::sync::watch::channel(None);
     let (event_tx, event_rx) = mpsc::channel(10);
     let event_subscriber = EventSubscriber::new();
     // Seed the info snapshot from current DB state; the reactor republishes
@@ -227,7 +227,7 @@ async fn run_daemon(config: Config) -> Result<()> {
                 config: config.clone(),
                 cancel_token: cancel_token.clone(),
                 reactor_ready: reactor_ready.clone(),
-                consensus_listen_addr: consensus_listen_addr.clone(),
+                consensus_listen_addr: consensus_listen_addr_rx.clone(),
                 reader: reader.clone(),
                 event_subscriber: event_subscriber.clone(),
                 bitcoin: bitcoin.clone(),
@@ -298,7 +298,7 @@ async fn run_daemon(config: Config) -> Result<()> {
         None,
         config.consensus_propose_timeout_ms,
         Some(fees_tx),
-        consensus_listen_addr,
+        consensus_listen_addr_tx,
     ));
     ready_rx.await?;
     reactor_ready.store(true, std::sync::atomic::Ordering::Relaxed);

--- a/core/indexer/src/main.rs
+++ b/core/indexer/src/main.rs
@@ -200,6 +200,7 @@ async fn run_daemon(config: Config) -> Result<()> {
     let reader = database::Reader::new(&config.data_dir, filename).await?;
     let writer = database::Writer::new(&config.data_dir, filename).await?;
     let reactor_ready = Arc::new(AtomicBool::new(false));
+    let consensus_listen_addr = Arc::new(std::sync::RwLock::new(None));
     let (event_tx, event_rx) = mpsc::channel(10);
     let event_subscriber = EventSubscriber::new();
     // Seed the info snapshot from current DB state; the reactor republishes
@@ -226,6 +227,7 @@ async fn run_daemon(config: Config) -> Result<()> {
                 config: config.clone(),
                 cancel_token: cancel_token.clone(),
                 reactor_ready: reactor_ready.clone(),
+                consensus_listen_addr: consensus_listen_addr.clone(),
                 reader: reader.clone(),
                 event_subscriber: event_subscriber.clone(),
                 bitcoin: bitcoin.clone(),
@@ -296,6 +298,7 @@ async fn run_daemon(config: Config) -> Result<()> {
         None,
         config.consensus_propose_timeout_ms,
         Some(fees_tx),
+        consensus_listen_addr,
     ));
     ready_rx.await?;
     reactor_ready.store(true, std::sync::atomic::Ordering::Relaxed);

--- a/core/indexer/src/reactor/engine.rs
+++ b/core/indexer/src/reactor/engine.rs
@@ -20,6 +20,10 @@ pub struct EngineConfig {
     pub persistent_peers: Vec<String>,
     pub data_dir: PathBuf,
     pub consensus_enabled: bool,
+    /// Enable libp2p peer discovery so nodes learn peers beyond the configured
+    /// set (which then act as bootstrap seeds). Off in cluster tests, which wire
+    /// every peer explicitly and don't want discovery's churn perturbing bring-up.
+    pub discovery_enabled: bool,
 }
 
 /// NodeConfig implementation for Malachite engine.
@@ -81,6 +85,20 @@ pub async fn start(config: EngineConfig) -> Result<EngineOutput> {
             p2p: P2pConfig {
                 listen_addr,
                 persistent_peers,
+                discovery: DiscoveryConfig {
+                    enabled: config.discovery_enabled,
+                    bootstrap_protocol: BootstrapProtocol::Full,
+                    selector: Selector::Random,
+                    ..Default::default()
+                },
+                // Validator-aware gossipsub scoring is always on: it prioritizes
+                // validators (then persistent peers) in the consensus mesh, fed by
+                // the live on-chain set, and explicit peering keeps persistent peers
+                // in the message flow regardless of mesh churn. Off by default in
+                // malachite; a no-op in fully-connected test clusters.
+                protocol: PubSubProtocol::GossipSub(GossipSubConfig::new(
+                    6, 12, 4, 2, true, true, true,
+                )),
                 ..Default::default()
             },
             ..Default::default()

--- a/core/indexer/src/reactor/handlers.rs
+++ b/core/indexer/src/reactor/handlers.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use malachitebft_app_channel::AppMsg;
+use malachitebft_app_channel::{AppMsg, NetworkRequest};
 use malachitebft_app_channel::app::streaming::{StreamContent, StreamMessage};
 use malachitebft_app_channel::app::types::codec::Codec;
 use malachitebft_app_channel::app::types::sync::RawDecidedValue;
@@ -190,6 +190,16 @@ impl<E: Executor> Reactor<E> {
                 reply
                     .send((start_height, self.consensus.height_params()))
                     .map_err(|_| anyhow::anyhow!("Failed to send ConsensusReady reply"))?;
+
+                // This fires on the first `Listening`, so the swarm has bound and
+                // the resolved consensus listen address is now in network state.
+                // Read it once (surfaced on `/api/status`).
+                if let Ok(Some(dump)) =
+                    NetworkRequest::dump_state(&self.consensus.channels.net_requests).await
+                {
+                    *self.consensus_listen_addr.write().unwrap() =
+                        Some(dump.local_node.listen_addr.to_string());
+                }
             }
 
             AppMsg::StartedRound {

--- a/core/indexer/src/reactor/handlers.rs
+++ b/core/indexer/src/reactor/handlers.rs
@@ -193,12 +193,14 @@ impl<E: Executor> Reactor<E> {
 
                 // This fires on the first `Listening`, so the swarm has bound and
                 // the resolved consensus listen address is now in network state.
-                // Read it once (surfaced on `/api/status`).
+                // Read it once and publish on the watch (surfaced on `/api/status`;
+                // in-process cluster tests await it to bootstrap followers).
                 if let Ok(Some(dump)) =
                     NetworkRequest::dump_state(&self.consensus.channels.net_requests).await
                 {
-                    *self.consensus_listen_addr.write().unwrap() =
-                        Some(dump.local_node.listen_addr.to_string());
+                    let _ = self
+                        .consensus_listen_addr
+                        .send(Some(dump.local_node.listen_addr.to_string()));
                 }
             }
 

--- a/core/indexer/src/reactor/handlers.rs
+++ b/core/indexer/src/reactor/handlers.rs
@@ -1,9 +1,9 @@
 use anyhow::{Context, Result};
-use malachitebft_app_channel::{AppMsg, NetworkRequest};
 use malachitebft_app_channel::app::streaming::{StreamContent, StreamMessage};
 use malachitebft_app_channel::app::types::codec::Codec;
 use malachitebft_app_channel::app::types::sync::RawDecidedValue;
 use malachitebft_app_channel::app::types::{LocallyProposedValue, ProposedValue};
+use malachitebft_app_channel::{AppMsg, NetworkRequest};
 use malachitebft_core_consensus::Role;
 use malachitebft_core_types::{Round, Validity};
 use tracing::info;

--- a/core/indexer/src/reactor/handlers.rs
+++ b/core/indexer/src/reactor/handlers.rs
@@ -6,7 +6,7 @@ use malachitebft_app_channel::app::types::{LocallyProposedValue, ProposedValue};
 use malachitebft_app_channel::{AppMsg, NetworkRequest};
 use malachitebft_core_consensus::Role;
 use malachitebft_core_types::{Round, Validity};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::consensus::codec::ProtobufCodec;
 use crate::consensus::{Address, Ctx, Height, ProposalPart, ValueId};
@@ -191,16 +191,28 @@ impl<E: Executor> Reactor<E> {
                     .send((start_height, self.consensus.height_params()))
                     .map_err(|_| anyhow::anyhow!("Failed to send ConsensusReady reply"))?;
 
-                // This fires on the first `Listening`, so the swarm has bound and
-                // the resolved consensus listen address is now in network state.
-                // Read it once and publish on the watch (surfaced on `/api/status`;
-                // in-process cluster tests await it to bootstrap followers).
-                if let Ok(Some(dump)) =
-                    NetworkRequest::dump_state(&self.consensus.channels.net_requests).await
-                {
-                    let _ = self
-                        .consensus_listen_addr
-                        .send(Some(dump.local_node.listen_addr.to_string()));
+                // `ConsensusReady` is emitted only from the network `Listening`
+                // event, and the swarm records its resolved address *before*
+                // emitting `Listening` — so by here the address is bound and
+                // recorded, and this read is race-free (never the unresolved
+                // `/tcp/0`). Publish it once on the watch (surfaced on
+                // `/api/status`; in-process cluster tests await it to bootstrap
+                // followers). The address is observability-only, so on the
+                // unexpected failure paths we just warn and leave it unset rather
+                // than block or crash — a genuinely dead swarm surfaces through
+                // consensus liveness, not here.
+                match NetworkRequest::dump_state(&self.consensus.channels.net_requests).await {
+                    Ok(Some(dump)) => {
+                        let _ = self
+                            .consensus_listen_addr
+                            .send(Some(dump.local_node.listen_addr.to_string()));
+                    }
+                    Ok(None) => {
+                        warn!("Network state dump empty; consensus listen address left unset");
+                    }
+                    Err(e) => {
+                        warn!(%e, "Failed to read network state for consensus listen address");
+                    }
                 }
             }
 

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -12,6 +12,7 @@ pub mod mock_bitcoin;
 mod reactor_cluster_tests;
 pub mod types;
 
+use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
 use anyhow::{Context, Result, bail};
@@ -33,6 +34,7 @@ use malachitebft_app_channel::app::types::LocallyProposedValue;
 use malachitebft_app_channel::app::types::core::VotingPower;
 use malachitebft_core_types::{LinearTimeouts, Round};
 use tracing::{debug, error, info, warn};
+
 
 use crate::consensus::finality_types::StateEvent;
 use crate::consensus::{BatchTx, Ctx};
@@ -72,6 +74,9 @@ pub struct Reactor<E: Executor> {
 
     last_height: u64,
     last_hash: Option<BlockHash>,
+    /// Shared with the API (`Env.consensus_listen_addr`); written on the first
+    /// `Listening` (see `handle_consensus_msg`'s `ConsensusReady` arm).
+    consensus_listen_addr: Arc<RwLock<Option<String>>>,
 }
 
 impl<E: Executor> Reactor<E> {
@@ -88,6 +93,7 @@ impl<E: Executor> Reactor<E> {
         consensus: consensus_state::ConsensusState,
         last_height: u64,
         last_hash: Option<BlockHash>,
+        consensus_listen_addr: Arc<RwLock<Option<String>>>,
     ) -> Self {
         let mut runtime = runtime;
         runtime.node_label = consensus
@@ -106,6 +112,7 @@ impl<E: Executor> Reactor<E> {
             ready_tx,
             event_tx,
             consensus,
+            consensus_listen_addr,
         }
     }
 
@@ -643,6 +650,7 @@ pub fn run(
     observation_channels: Option<consensus_state::ObservationChannels>,
     consensus_propose_timeout_ms: u64,
     fee_tx: Option<tokio::sync::watch::Sender<Fees>>,
+    consensus_listen_addr: Arc<RwLock<Option<String>>>,
 ) -> JoinHandle<()> {
     tokio::spawn({
         async move {
@@ -757,6 +765,7 @@ pub fn run(
                     consensus,
                     last_height,
                     last_hash,
+                    consensus_listen_addr,
                 );
 
                 reactor.run().await

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -12,7 +12,6 @@ pub mod mock_bitcoin;
 mod reactor_cluster_tests;
 pub mod types;
 
-use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
 use anyhow::{Context, Result, bail};
@@ -76,7 +75,7 @@ pub struct Reactor<E: Executor> {
     last_hash: Option<BlockHash>,
     /// Shared with the API (`Env.consensus_listen_addr`); written on the first
     /// `Listening` (see `handle_consensus_msg`'s `ConsensusReady` arm).
-    consensus_listen_addr: Arc<RwLock<Option<String>>>,
+    consensus_listen_addr: tokio::sync::watch::Sender<Option<String>>,
 }
 
 impl<E: Executor> Reactor<E> {
@@ -93,7 +92,7 @@ impl<E: Executor> Reactor<E> {
         consensus: consensus_state::ConsensusState,
         last_height: u64,
         last_hash: Option<BlockHash>,
-        consensus_listen_addr: Arc<RwLock<Option<String>>>,
+        consensus_listen_addr: tokio::sync::watch::Sender<Option<String>>,
     ) -> Self {
         let mut runtime = runtime;
         runtime.node_label = consensus
@@ -650,7 +649,7 @@ pub fn run(
     observation_channels: Option<consensus_state::ObservationChannels>,
     consensus_propose_timeout_ms: u64,
     fee_tx: Option<tokio::sync::watch::Sender<Fees>>,
-    consensus_listen_addr: Arc<RwLock<Option<String>>>,
+    consensus_listen_addr: tokio::sync::watch::Sender<Option<String>>,
 ) -> JoinHandle<()> {
     tokio::spawn({
         async move {

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -34,7 +34,6 @@ use malachitebft_app_channel::app::types::core::VotingPower;
 use malachitebft_core_types::{LinearTimeouts, Round};
 use tracing::{debug, error, info, warn};
 
-
 use crate::consensus::finality_types::StateEvent;
 use crate::consensus::{BatchTx, Ctx};
 use crate::{

--- a/core/indexer/src/reactor/reactor_cluster_tests.rs
+++ b/core/indexer/src/reactor/reactor_cluster_tests.rs
@@ -3,8 +3,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::Result;
-use malachitebft_app_channel::NetworkRequest;
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::{broadcast, mpsc, watch};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
@@ -68,10 +67,9 @@ struct ReactorCluster {
     private_keys: Vec<PrivateKey>,
     /// Node 0's resolved consensus listen multiaddr — the bootstrap seed every
     /// other node (including late joiners via `add_node`) discovers the cluster
-    /// through. No fixed ports: each node binds `/tcp/0` and reports its
-    /// resolved address back over `addr_tx`.
+    /// through. No fixed ports: each node binds `/tcp/0` and publishes its
+    /// resolved address on a per-node watch the reactor writes on bind.
     seed_addr: String,
-    addr_tx: mpsc::Sender<(usize, String)>,
     shared_pubkey: String,
     engine: wasmtime::Engine,
     component_cache: crate::runtime::ComponentCache,
@@ -148,8 +146,6 @@ impl ReactorCluster {
         let (state_tx, state_rx) = mpsc::channel(1024);
         let (ready_tx, ready_rx) = mpsc::channel(total);
         let (event_tx, event_rx) = mpsc::channel(1024);
-        // Each node binds `/tcp/0` and reports its resolved listen address here.
-        let (addr_tx, mut addr_rx) = mpsc::channel::<(usize, String)>(total);
 
         let mut join_set = JoinSet::new();
         let mut started_nodes = vec![false; total];
@@ -173,13 +169,18 @@ impl ReactorCluster {
                 vec![seed_addr.clone()]
             };
 
+            // Per-node watch: the reactor publishes the resolved `/tcp/0` address
+            // here on bind. Only the seed's receiver is read back (to bootstrap
+            // the followers); the rest are dropped after spawn.
+            let (addr_tx, addr_rx) = watch::channel(None);
+
             Self::spawn_node(
                 i,
                 private_keys[i].clone(),
                 &genesis,
                 &genesis_validators,
                 peers,
-                addr_tx.clone(),
+                addr_tx,
                 node_block_tx,
                 node_block_rx,
                 node_mempool_rx,
@@ -199,10 +200,7 @@ impl ReactorCluster {
             started_nodes[i] = true;
 
             if i == 0 {
-                seed_addr = match addr_rx.recv().await {
-                    Some((0, addr)) => addr,
-                    _ => return Err(anyhow::anyhow!("seed never reported a listen address")),
-                };
+                seed_addr = Self::await_listen_addr(addr_rx).await?;
             }
         }
 
@@ -221,7 +219,6 @@ impl ReactorCluster {
             genesis_validators,
             private_keys,
             seed_addr,
-            addr_tx,
             shared_pubkey,
             engine,
             component_cache,
@@ -263,6 +260,17 @@ impl ReactorCluster {
         rx
     }
 
+    /// Await a node's resolved consensus listen address on its watch. The
+    /// reactor publishes it from its `ConsensusReady` handler once the swarm
+    /// binds — event-driven, no polling.
+    async fn await_listen_addr(mut rx: watch::Receiver<Option<String>>) -> Result<String> {
+        rx.wait_for(Option::is_some)
+            .await
+            .map_err(|_| anyhow::anyhow!("node reactor dropped before reporting a listen address"))?
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("listen address watch resolved to None"))
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn spawn_node(
         i: usize,
@@ -270,7 +278,7 @@ impl ReactorCluster {
         genesis: &Genesis,
         genesis_validators: &[GenesisValidator],
         peers: Vec<String>,
-        addr_tx: mpsc::Sender<(usize, String)>,
+        consensus_listen_addr: watch::Sender<Option<String>>,
         node_block_tx: mpsc::Sender<BlockEvent>,
         node_block_rx: mpsc::Receiver<BlockEvent>,
         node_mempool_rx: mpsc::Receiver<MempoolEvent>,
@@ -323,24 +331,6 @@ impl ReactorCluster {
                 }
             };
 
-            // Report this node's resolved listen address by polling the network
-            // state (the patched engine stores it on bind). Race-free: a stored
-            // snapshot, unlike a fleeting event. The seed's address is what
-            // `start_with`/`add_node` use to bootstrap the followers.
-            {
-                let net_requests = engine_output.channels.net_requests.clone();
-                let listen_addr = loop {
-                    if let Ok(Some(dump)) = NetworkRequest::dump_state(&net_requests).await {
-                        let addr = dump.local_node.listen_addr.to_string();
-                        if !addr.ends_with("/tcp/0") {
-                            break addr;
-                        }
-                    }
-                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-                };
-                let _ = addr_tx.send((i, listen_addr)).await;
-            }
-
             info!(node = i, address = %engine_output.address, "Engine started");
 
             let validator_index = genesis
@@ -379,10 +369,10 @@ impl ReactorCluster {
                 state,
                 0,
                 None,
-                // The in-process test reads each engine's address directly via
-                // dump_state (reported over addr_tx); this Env-shared slot is
-                // unused here.
-                std::sync::Arc::new(std::sync::RwLock::new(None)),
+                // Same path as production: the reactor's `ConsensusReady` handler
+                // reads the resolved address and publishes it here. `start_with`
+                // awaits the seed's receiver to bootstrap the followers.
+                consensus_listen_addr,
             );
 
             let _ = rtx.send(i).await;
@@ -407,13 +397,16 @@ impl ReactorCluster {
         let (sim_tx, sim_rx) = mpsc::channel(1);
         self.simulate_txs.push(sim_tx);
 
+        // Late joiner bootstraps from the seed; its own address isn't read back.
+        let (addr_tx, _addr_rx) = watch::channel(None);
+
         Self::spawn_node(
             i,
             self.private_keys[i].clone(),
             &self.genesis,
             &self.genesis_validators,
             vec![self.seed_addr.clone()],
-            self.addr_tx.clone(),
+            addr_tx,
             node_block_tx,
             node_block_rx,
             node_mempool_rx,

--- a/core/indexer/src/reactor/reactor_cluster_tests.rs
+++ b/core/indexer/src/reactor/reactor_cluster_tests.rs
@@ -307,6 +307,7 @@ impl ReactorCluster {
                     .collect(),
                 data_dir: executor.data_dir(),
                 consensus_enabled: true,
+                discovery_enabled: false,
             };
 
             let conn = runtime.get_storage_conn();

--- a/core/indexer/src/reactor/reactor_cluster_tests.rs
+++ b/core/indexer/src/reactor/reactor_cluster_tests.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::Result;
+use malachitebft_app_channel::NetworkRequest;
 use tokio::sync::{broadcast, mpsc};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
@@ -24,26 +25,6 @@ use bitcoin::hashes::Hash;
 use indexer_types::Event;
 use indexer_types::OpWithResult;
 use malachitebft_app_channel::app::types::core::VotingPower;
-
-/// Allocate `n` distinct ephemeral ports by briefly binding each to
-/// `127.0.0.1:0`, mirroring `reg_tester::allocate_ports`. Every listener is held
-/// until all are bound so the ports are guaranteed distinct; dropping them hands
-/// the ports to the consensus engine. The previous fixed-base allocator
-/// (`19000 + counter`) did not check availability, so a port could collide with
-/// another listener or a lingering `TIME_WAIT` socket — which surfaced as libp2p
-/// "failed to negotiate transport protocol" hangs on macOS CI loopback.
-fn allocate_ports(n: usize) -> Vec<u16> {
-    let mut ports = Vec::with_capacity(n);
-    let mut listeners = Vec::with_capacity(n);
-    for _ in 0..n {
-        let listener =
-            std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port for test node");
-        ports.push(listener.local_addr().expect("read local_addr").port());
-        listeners.push(listener);
-    }
-    drop(listeners);
-    ports
-}
 
 async fn wait_matching<T>(
     rx: &mut mpsc::Receiver<T>,
@@ -85,7 +66,12 @@ struct ReactorCluster {
     genesis: Genesis,
     genesis_validators: Vec<GenesisValidator>,
     private_keys: Vec<PrivateKey>,
-    ports: Vec<u16>,
+    /// Node 0's resolved consensus listen multiaddr — the bootstrap seed every
+    /// other node (including late joiners via `add_node`) discovers the cluster
+    /// through. No fixed ports: each node binds `/tcp/0` and reports its
+    /// resolved address back over `addr_tx`.
+    seed_addr: String,
+    addr_tx: mpsc::Sender<(usize, String)>,
     shared_pubkey: String,
     engine: wasmtime::Engine,
     component_cache: crate::runtime::ComponentCache,
@@ -150,8 +136,6 @@ impl ReactorCluster {
         let validator_set = ValidatorSet::new(validators);
         let genesis = Genesis { validator_set };
 
-        let ports: Vec<u16> = allocate_ports(total);
-
         let (mempool_tx, _) = broadcast::channel::<MempoolEvent>(256);
         let cancel = CancellationToken::new();
         let mut block_txs = Vec::new();
@@ -164,11 +148,17 @@ impl ReactorCluster {
         let (state_tx, state_rx) = mpsc::channel(1024);
         let (ready_tx, ready_rx) = mpsc::channel(total);
         let (event_tx, event_rx) = mpsc::channel(1024);
+        // Each node binds `/tcp/0` and reports its resolved listen address here.
+        let (addr_tx, mut addr_rx) = mpsc::channel::<(usize, String)>(total);
 
         let mut join_set = JoinSet::new();
         let mut started_nodes = vec![false; total];
         let mut simulate_txs = Vec::new();
 
+        // Seed-first bring-up, no fixed ports. Node 0 boots with no peers; we
+        // wait only for it to report its resolved listen address, then point
+        // the rest at it. libp2p discovery meshes the cluster from there.
+        let mut seed_addr = String::new();
         for i in 0..initial {
             let (node_block_tx, node_block_rx) = mpsc::channel(256);
             block_txs.push(node_block_tx.clone());
@@ -177,12 +167,19 @@ impl ReactorCluster {
             let (sim_tx, sim_rx) = mpsc::channel(1);
             simulate_txs.push(sim_tx);
 
+            let peers = if i == 0 {
+                vec![]
+            } else {
+                vec![seed_addr.clone()]
+            };
+
             Self::spawn_node(
                 i,
                 private_keys[i].clone(),
                 &genesis,
                 &genesis_validators,
-                &ports,
+                peers,
+                addr_tx.clone(),
                 node_block_tx,
                 node_block_rx,
                 node_mempool_rx,
@@ -200,6 +197,13 @@ impl ReactorCluster {
                 &mut join_set,
             );
             started_nodes[i] = true;
+
+            if i == 0 {
+                seed_addr = match addr_rx.recv().await {
+                    Some((0, addr)) => addr,
+                    _ => return Err(anyhow::anyhow!("seed never reported a listen address")),
+                };
+            }
         }
 
         Ok(Self {
@@ -216,7 +220,8 @@ impl ReactorCluster {
             genesis,
             genesis_validators,
             private_keys,
-            ports,
+            seed_addr,
+            addr_tx,
             shared_pubkey,
             engine,
             component_cache,
@@ -264,7 +269,8 @@ impl ReactorCluster {
         private_key: PrivateKey,
         genesis: &Genesis,
         genesis_validators: &[GenesisValidator],
-        ports: &[u16],
+        peers: Vec<String>,
+        addr_tx: mpsc::Sender<(usize, String)>,
         node_block_tx: mpsc::Sender<BlockEvent>,
         node_block_rx: mpsc::Receiver<BlockEvent>,
         node_mempool_rx: mpsc::Receiver<MempoolEvent>,
@@ -283,7 +289,6 @@ impl ReactorCluster {
     ) {
         let genesis = genesis.clone();
         let genesis_vals = genesis_validators.to_vec();
-        let ports = ports.to_vec();
         join_set.spawn(async move {
             let (executor, runtime) = LiteExecutor::new(
                 mock_btc,
@@ -298,16 +303,14 @@ impl ReactorCluster {
 
             let engine_config = EngineConfig {
                 private_key,
-                listen_addr: format!("/ip4/127.0.0.1/tcp/{}", ports[i]),
-                persistent_peers: ports
-                    .iter()
-                    .enumerate()
-                    .filter(|(j, _)| *j != i)
-                    .map(|(_, &port)| format!("/ip4/127.0.0.1/tcp/{port}"))
-                    .collect(),
+                // OS-assigned port (no probe/release race). The seed boots with
+                // no peers; everyone else bootstraps from the seed's reported
+                // address and discovers the rest of the cluster.
+                listen_addr: "/ip4/127.0.0.1/tcp/0".to_string(),
+                persistent_peers: peers,
                 data_dir: executor.data_dir(),
                 consensus_enabled: true,
-                discovery_enabled: false,
+                discovery_enabled: true,
             };
 
             let conn = runtime.get_storage_conn();
@@ -319,6 +322,24 @@ impl ReactorCluster {
                     return;
                 }
             };
+
+            // Report this node's resolved listen address by polling the network
+            // state (the patched engine stores it on bind). Race-free: a stored
+            // snapshot, unlike a fleeting event. The seed's address is what
+            // `start_with`/`add_node` use to bootstrap the followers.
+            {
+                let net_requests = engine_output.channels.net_requests.clone();
+                let listen_addr = loop {
+                    if let Ok(Some(dump)) = NetworkRequest::dump_state(&net_requests).await {
+                        let addr = dump.local_node.listen_addr.to_string();
+                        if !addr.ends_with("/tcp/0") {
+                            break addr;
+                        }
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                };
+                let _ = addr_tx.send((i, listen_addr)).await;
+            }
 
             info!(node = i, address = %engine_output.address, "Engine started");
 
@@ -358,6 +379,10 @@ impl ReactorCluster {
                 state,
                 0,
                 None,
+                // The in-process test reads each engine's address directly via
+                // dump_state (reported over addr_tx); this Env-shared slot is
+                // unused here.
+                std::sync::Arc::new(std::sync::RwLock::new(None)),
             );
 
             let _ = rtx.send(i).await;
@@ -387,7 +412,8 @@ impl ReactorCluster {
             self.private_keys[i].clone(),
             &self.genesis,
             &self.genesis_validators,
-            &self.ports,
+            vec![self.seed_addr.clone()],
+            self.addr_tx.clone(),
             node_block_tx,
             node_block_rx,
             node_mempool_rx,

--- a/core/indexer/src/reg_tester.rs
+++ b/core/indexer/src/reg_tester.rs
@@ -24,7 +24,7 @@ use crate::{
     consensus::signing::PrivateKey as Ed25519PrivateKey,
     database::types::OpResultId,
     keygen,
-    retry::{retry_extended, retry_simple},
+    retry::retry_extended,
     runtime::ContractAddress,
     test_utils,
 };
@@ -35,7 +35,7 @@ use bitcoin::{
     absolute::LockTime,
     bip32::{DerivationPath, Xpriv},
     consensus::serialize as serialize_tx,
-    key::rand::RngCore,
+    key::rand::{Rng, RngCore},
     key::{Keypair, PrivateKey, Secp256k1, rand},
     taproot::TaprootBuilder,
     transaction::Version,
@@ -46,8 +46,8 @@ use indexer_types::{
 use tempfile::TempDir;
 use tokio::{
     fs,
-    io::AsyncWriteExt,
-    process::{Child, Command},
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    process::{Child, ChildStdout, Command},
     sync::Mutex,
 };
 
@@ -89,15 +89,30 @@ async fn create_bitcoin_conf(data_dir: &Path, rpc_port: u16, zmq_port: u16) -> R
     Ok(())
 }
 
-/// Returns (child, client, rpc_url, zmq_port)
-async fn run_bitcoin(data_dir: &Path) -> Result<(Child, bitcoin_client::Client, String, u16)> {
-    let rpc_port = allocate_ports(1)?[0];
-    let zmq_port = allocate_ports(1)?[0];
-    create_bitcoin_conf(data_dir, rpc_port, zmq_port).await?;
+/// A consensus/test port drawn from a band *below* the OS ephemeral range
+/// (Linux `32768+`, macOS `49152+`) and above the privileged range. Ports the
+/// kernel hands out for `:0` binds — the indexer's API, bitcoind's outbound
+/// sockets, anything — all come from the ephemeral range, so a port from this
+/// band can never collide with a `:0` allocation. Non-privileged and portable
+/// across CI runners.
+fn random_low_port() -> u16 {
+    rand::thread_rng().gen_range(10_000..32_000)
+}
 
+/// Number of (rpc, zmq) port draws to try before giving up on bitcoind bind-up.
+const BITCOIND_BIND_ATTEMPTS: usize = 8;
+
+/// Returns (child, client, rpc_url, zmq_port)
+///
+/// bitcoind can't self-assign its RPC port (it rejects both `-rpcport=0` and
+/// `-rpcbind=…:0`), so we pick candidate ports ourselves. Rather than probe and
+/// release a listener (the old `allocate_ports` TOCTOU race), we let bitcoind's
+/// own bind be the source of truth: pick ports from a collision-resistant band,
+/// start bitcoind, and if it exits during start-up (a taken port makes it fail
+/// fast and loud) re-pick and respawn. Bounded; effectively never exhausts.
+async fn run_bitcoin(data_dir: &Path) -> Result<(Child, bitcoin_client::Client, String, u16)> {
     // Check if bitcoind is in PATH
     let bitcoind_check = Command::new("which").arg("bitcoind").output().await;
-
     if bitcoind_check.is_err() || !bitcoind_check.unwrap().status.success() {
         bail!(
             "bitcoind not found in PATH. Regtest tests require Bitcoin Core.\n\
@@ -105,29 +120,66 @@ async fn run_bitcoin(data_dir: &Path) -> Result<(Child, bitcoin_client::Client, 
         );
     }
 
-    // Drop bitcoind's stdout — it inherits the parent's pipe and its
-    // startup writes interleave with kontor's own `println!`s, splitting
-    // long single-line outputs (notably the regtest `KONTOR_REGTEST_INFO`
-    // payload) at noise newlines. stderr is left inherited for debug.
-    let process = Command::new("bitcoind")
-        .arg(format!("-datadir={}", data_dir.to_string_lossy()))
-        .stdout(std::process::Stdio::null())
-        .spawn()?;
-    let config = RegtestConfig {
-        bitcoin_rpc_url: format!("http://127.0.0.1:{rpc_port}"),
-        ..RegtestConfig::default()
-    };
-    let client = bitcoin_client::Client::new_from_config(&config)?;
-    retry_simple(async || {
-        let i = client.get_blockchain_info().await?;
-        if i.chain != Network::Regtest {
-            bail!("Network not regtest");
+    let mut last_err = None;
+    for _ in 0..BITCOIND_BIND_ATTEMPTS {
+        let rpc_port = random_low_port();
+        let mut zmq_port = random_low_port();
+        while zmq_port == rpc_port {
+            zmq_port = random_low_port();
         }
-        Ok(())
-    })
-    .await?;
-    let rpc_url = config.bitcoin_rpc_url;
-    Ok((process, client, rpc_url, zmq_port))
+        create_bitcoin_conf(data_dir, rpc_port, zmq_port).await?;
+
+        // Drop bitcoind's stdout — it inherits the parent's pipe and its
+        // startup writes interleave with kontor's own `println!`s, splitting
+        // long single-line outputs (notably the regtest `KONTOR_REGTEST_INFO`
+        // payload) at noise newlines. stderr is left inherited for debug.
+        let mut process = Command::new("bitcoind")
+            .arg(format!("-datadir={}", data_dir.to_string_lossy()))
+            .stdout(std::process::Stdio::null())
+            .spawn()?;
+        let config = RegtestConfig {
+            bitcoin_rpc_url: format!("http://127.0.0.1:{rpc_port}"),
+            ..RegtestConfig::default()
+        };
+        let client = bitcoin_client::Client::new_from_config(&config)?;
+
+        match wait_bitcoind_ready(&mut process, &client).await {
+            Ok(()) => return Ok((process, client, config.bitcoin_rpc_url, zmq_port)),
+            Err(e) => {
+                // Likely a port collision: bitcoind exited during start-up.
+                // Make sure it's gone, then retry with a fresh port pair.
+                let _ = process.start_kill();
+                let _ = process.wait().await;
+                last_err = Some(e);
+            }
+        }
+    }
+    bail!(
+        "bitcoind failed to bind after {BITCOIND_BIND_ATTEMPTS} attempts: {}",
+        last_err.map_or_else(|| "unknown".to_string(), |e| format!("{e:#}"))
+    )
+}
+
+/// Wait for a freshly-spawned bitcoind to answer RPC on regtest. Distinguishes
+/// "not up yet" (keep waiting) from "process exited" (a bind collision — caller
+/// retries with new ports).
+async fn wait_bitcoind_ready(process: &mut Child, client: &bitcoin_client::Client) -> Result<()> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        if let Some(status) = process.try_wait()? {
+            bail!("bitcoind exited during start-up ({status}) — likely a port bind collision");
+        }
+        if let Ok(i) = client.get_blockchain_info().await {
+            if i.chain != Network::Regtest {
+                bail!("Network not regtest");
+            }
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            bail!("bitcoind did not become ready within 30s");
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
 }
 
 struct ConsensusNodeConfig {
@@ -147,24 +199,25 @@ pub fn default_kontor_bin() -> PathBuf {
     ))
 }
 
-/// Spawn a `kontor` node process and return a handle + API client. Returns as
-/// soon as the process is launched — it does *not* wait for the node to become
-/// available. Callers decide what to wait for: a seed waits only for its listen
-/// address ([`RegTesterCluster::wait_for_listen_addr`]), while nodes that will
-/// reach quorum wait for availability ([`RegTesterCluster::wait_for_available`]).
+/// Spawn a `kontor` node process and return a handle, API client, and the
+/// node's resolved API port. Binds the API on `--api-port 0` (OS-assigned, no
+/// probe/release race) and reads the real port back from the node's logs.
+/// Returns as soon as the API port is known — it does *not* wait for the node
+/// to become available. Callers decide what to wait for: a seed waits only for
+/// its listen address ([`RegTesterCluster::wait_for_listen_addr`]), while nodes
+/// that reach quorum wait for availability ([`RegTesterCluster::wait_for_available`]).
 async fn run_kontor(
     data_dir: &Path,
-    api_port: u16,
     bitcoin_rpc_url: &str,
     zmq_port: u16,
     consensus: Option<&ConsensusNodeConfig>,
     kontor_bin: &Path,
-) -> Result<(Child, KontorClient)> {
+) -> Result<(Child, KontorClient, u16)> {
     let config = RegtestConfig::default();
     let mut cmd = Command::new(kontor_bin);
     cmd.arg("run")
         .arg("--api-port")
-        .arg(api_port.to_string())
+        .arg("0")
         .arg("--data-dir")
         .arg(data_dir.to_string_lossy().into_owned())
         .arg("--network")
@@ -194,9 +247,58 @@ async fn run_kontor(
         }
     }
 
-    let process = cmd.spawn()?;
+    let mut process = cmd.stdout(std::process::Stdio::piped()).spawn()?;
+    let stdout = process
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow!("kontor child has no piped stdout"))?;
+    let api_port = read_api_port_from_logs(stdout, Duration::from_secs(30)).await?;
     let client = KontorClient::new(format!("http://localhost:{api_port}/api"))?;
-    Ok((process, client))
+    Ok((process, client, api_port))
+}
+
+/// Read a `kontor run` child's resolved API port from its stdout. The node
+/// binds `--api-port 0` and logs the resolved address ("HTTP server running @
+/// http://0.0.0.0:PORT"); we scan for that line, then detach a task that keeps
+/// draining (and re-emitting) the rest so the child never blocks on a full
+/// stdout pipe and its logs stay visible in test output.
+async fn read_api_port_from_logs(stdout: ChildStdout, timeout: Duration) -> Result<u16> {
+    let mut lines = BufReader::new(stdout).lines();
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        match tokio::time::timeout_at(deadline, lines.next_line()).await {
+            Ok(Ok(Some(line))) => {
+                let port = parse_http_server_port(&line);
+                println!("{line}");
+                if let Some(port) = port {
+                    tokio::spawn(async move {
+                        while let Ok(Some(line)) = lines.next_line().await {
+                            println!("{line}");
+                        }
+                    });
+                    return Ok(port);
+                }
+            }
+            Ok(Ok(None)) => bail!("kontor exited before reporting its API port"),
+            Ok(Err(e)) => return Err(e.into()),
+            Err(_) => bail!("kontor did not report its API port within {timeout:?}"),
+        }
+    }
+}
+
+/// Extract the port from the indexer's "HTTP server running @ http://<addr>:<port>"
+/// log line (matches both plain and JSON log formats). `None` for any other line.
+fn parse_http_server_port(line: &str) -> Option<u16> {
+    if !line.contains("HTTP server running") {
+        return None;
+    }
+    let after_scheme = line.split("http://").nth(1)?;
+    let port_part = after_scheme.rsplit(':').next()?;
+    let digits: String = port_part
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    digits.parse().ok()
 }
 
 /// Generate a random x-only public key string (for test signers that don't need a full identity).
@@ -885,18 +987,6 @@ pub struct ClusterNode {
     child: Child,
 }
 
-fn allocate_ports(n: usize) -> std::io::Result<Vec<u16>> {
-    let mut ports = Vec::with_capacity(n);
-    let mut listeners = Vec::with_capacity(n);
-    for _ in 0..n {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
-        ports.push(listener.local_addr()?.port());
-        listeners.push(listener);
-    }
-    drop(listeners);
-    Ok(ports)
-}
-
 enum MinerCmd {
     Pause(tokio::sync::oneshot::Sender<()>),
     Resume(tokio::sync::oneshot::Sender<()>),
@@ -1030,17 +1120,16 @@ impl RegTesterCluster {
         let genesis_path = genesis_dir.path().join("genesis.json");
         std::fs::write(&genesis_path, serde_json::to_string(&genesis_config)?)?;
 
-        // Allocate API ports up front (the harness connects to each node's
-        // HTTP API by port). Consensus nodes bind `:0` instead — the OS
-        // assigns the port atomically at bind time, so there is no
-        // probe-then-release window for a parallel test to race into. The
-        // resolved port is read back from node 0 (the seed) and discovered by
-        // everyone else via libp2p.
-        let api_ports = allocate_ports(total)?;
-
+        // No port pre-allocation anywhere: each node binds both its HTTP API
+        // (`--api-port 0`) and its consensus listener (`/tcp/0`) on OS-assigned
+        // ports, atomically at bind time, so there is no probe-then-release
+        // window for a parallel test to race into. The resolved API port is read
+        // back from each node's logs (`api_port` is filled in after spawn); the
+        // consensus address is read from node 0 and discovered by everyone else
+        // via libp2p.
         let mut node_configs: Vec<NodeConfig> = (0..total)
             .map(|i| NodeConfig {
-                api_port: api_ports[i],
+                api_port: 0,
                 ed25519_key: ed25519_keys[i].clone(),
                 data_dir: TempDir::new().expect("Failed to create temp dir"),
                 running: None,
@@ -1057,7 +1146,7 @@ impl RegTesterCluster {
             active >= 1,
             "cluster needs at least the seed node (index 0)"
         );
-        let (seed_child, seed_client) = Self::spawn_node(
+        let (seed_child, seed_client, seed_api_port) = Self::spawn_node(
             &node_configs[0],
             &[],
             &genesis_path,
@@ -1066,6 +1155,7 @@ impl RegTesterCluster {
             kontor_bin,
         )
         .await?;
+        node_configs[0].api_port = seed_api_port;
         let seed_addr = Self::wait_for_listen_addr(&seed_client, Duration::from_secs(30)).await?;
         node_configs[0].running = Some(ClusterNode {
             client: seed_client,
@@ -1091,7 +1181,8 @@ impl RegTesterCluster {
             .into_iter()
             .enumerate()
         {
-            let (child, client) = result?;
+            let (child, client, api_port) = result?;
+            node_configs[offset + 1].api_port = api_port;
             node_configs[offset + 1].running = Some(ClusterNode { client, child });
         }
 
@@ -1236,7 +1327,7 @@ impl RegTesterCluster {
         bitcoin_rpc_url: &str,
         zmq_port: u16,
         kontor_bin: &Path,
-    ) -> Result<(Child, KontorClient)> {
+    ) -> Result<(Child, KontorClient, u16)> {
         let consensus_config = ConsensusNodeConfig {
             private_key_hex: hex::encode(nc.ed25519_key.inner().to_bytes()),
             listen_addr: "/ip4/127.0.0.1/tcp/0".to_string(),
@@ -1245,7 +1336,6 @@ impl RegTesterCluster {
         };
         run_kontor(
             nc.data_dir.path(),
-            nc.api_port,
             bitcoin_rpc_url,
             zmq_port,
             Some(&consensus_config),
@@ -1303,7 +1393,7 @@ impl RegTesterCluster {
     /// is never restarted (see [`Self::seed_addr`]).
     pub async fn start_node(&mut self, index: usize) -> Result<()> {
         let nc = &self.node_configs[index];
-        let (child, client) = Self::spawn_node(
+        let (child, client, api_port) = Self::spawn_node(
             nc,
             std::slice::from_ref(&self.seed_addr),
             &self.genesis_path,
@@ -1315,6 +1405,7 @@ impl RegTesterCluster {
         // A restart/late-joiner joins an existing quorum, so it does become
         // available.
         Self::wait_for_available(&client).await?;
+        self.node_configs[index].api_port = api_port;
         self.node_configs[index].running = Some(ClusterNode { client, child });
         Ok(())
     }

--- a/core/indexer/src/reg_tester.rs
+++ b/core/indexer/src/reg_tester.rs
@@ -6,6 +6,7 @@ use std::{
         Arc,
         atomic::{AtomicUsize, Ordering},
     },
+    time::Duration,
 };
 
 use backon::BackoffBuilder;
@@ -146,6 +147,11 @@ pub fn default_kontor_bin() -> PathBuf {
     ))
 }
 
+/// Spawn a `kontor` node process and return a handle + API client. Returns as
+/// soon as the process is launched — it does *not* wait for the node to become
+/// available. Callers decide what to wait for: a seed waits only for its listen
+/// address ([`RegTesterCluster::wait_for_listen_addr`]), while nodes that will
+/// reach quorum wait for availability ([`RegTesterCluster::wait_for_available`]).
 async fn run_kontor(
     data_dir: &Path,
     api_port: u16,
@@ -190,18 +196,6 @@ async fn run_kontor(
 
     let process = cmd.spawn()?;
     let client = KontorClient::new(format!("http://localhost:{api_port}/api"))?;
-    // Extended budget: cluster tests run 5 indexer processes in
-    // parallel; under heavy CI load, the standard ~25s budget isn't
-    // always enough for DB init + mempool sync + initial fee
-    // projection + consensus startup to complete on each one.
-    // `client.index()` itself returns an error when the indexer 503s
-    // (`require_available` middleware), so a successful response is
-    // the availability signal — no separate flag to inspect.
-    retry_extended(async || {
-        let _ = client.index().await?;
-        Ok::<_, anyhow::Error>(())
-    })
-    .await?;
     Ok((process, client))
 }
 
@@ -881,7 +875,6 @@ macro_rules! poll_nodes {
 
 pub struct NodeConfig {
     pub api_port: u16,
-    pub consensus_port: u16,
     pub ed25519_key: Ed25519PrivateKey,
     pub data_dir: TempDir,
     pub running: Option<ClusterNode>,
@@ -925,6 +918,11 @@ pub struct RegTesterCluster {
     /// Node binary spawned for each validator; retained so `start_node`
     /// restarts with the same binary `setup_with` was given.
     kontor_bin: PathBuf,
+    /// Node 0's resolved consensus listen multiaddr — the bootstrap seed every
+    /// other node discovers the cluster through. Read back from node 0 after it
+    /// binds its `:0` port. Node 0 is never restarted (tests only cycle higher
+    /// indices), so this stays valid for the cluster's lifetime.
+    seed_addr: String,
     miner_cmd_tx: tokio::sync::mpsc::Sender<MinerCmd>,
     _miner_handle: tokio::task::JoinHandle<()>,
     _bitcoin_child: Child,
@@ -1032,44 +1030,71 @@ impl RegTesterCluster {
         let genesis_path = genesis_dir.path().join("genesis.json");
         std::fs::write(&genesis_path, serde_json::to_string(&genesis_config)?)?;
 
-        // Allocate ports and build NodeConfigs
+        // Allocate API ports up front (the harness connects to each node's
+        // HTTP API by port). Consensus nodes bind `:0` instead — the OS
+        // assigns the port atomically at bind time, so there is no
+        // probe-then-release window for a parallel test to race into. The
+        // resolved port is read back from node 0 (the seed) and discovered by
+        // everyone else via libp2p.
         let api_ports = allocate_ports(total)?;
-        let consensus_ports = allocate_ports(total)?;
 
         let mut node_configs: Vec<NodeConfig> = (0..total)
             .map(|i| NodeConfig {
                 api_port: api_ports[i],
-                consensus_port: consensus_ports[i],
                 ed25519_key: ed25519_keys[i].clone(),
                 data_dir: TempDir::new().expect("Failed to create temp dir"),
                 running: None,
             })
             .collect();
 
-        // Start active nodes
-        let all_consensus_ports: Vec<u16> =
-            node_configs.iter().map(|nc| nc.consensus_port).collect();
-        let launch_futures: Vec<_> = node_configs
-            .iter()
+        // Seed-first bring-up, no fixed ports. The seed (node 0) boots with no
+        // peers; we wait only for its *listen address* — a lone node can't
+        // decide a block (no quorum) so it never becomes "available", and
+        // waiting for that here would deadlock against the very followers it's
+        // meant to seed. The address is read from the ungated
+        // `/consensus/listen-addr` endpoint (answers before availability).
+        assert!(active >= 1, "cluster needs at least the seed node (index 0)");
+        let (seed_child, seed_client) = Self::spawn_node(
+            &node_configs[0],
+            &[],
+            &genesis_path,
+            &bitcoin_rpc_url,
+            zmq_port,
+            kontor_bin,
+        )
+        .await?;
+        let seed_addr = Self::wait_for_listen_addr(&seed_client, Duration::from_secs(30)).await?;
+        node_configs[0].running = Some(ClusterNode {
+            client: seed_client,
+            child: seed_child,
+        });
+
+        // Spawn the remaining active nodes, all bootstrapping from the seed and
+        // discovering each other. Spawn first, then wait for availability: with
+        // the seed already participating they reach quorum together, so each
+        // does become available (unlike the lone seed).
+        let spawns = node_configs.iter().skip(1).take(active - 1).map(|nc| {
+            Self::spawn_node(
+                nc,
+                std::slice::from_ref(&seed_addr),
+                &genesis_path,
+                &bitcoin_rpc_url,
+                zmq_port,
+                kontor_bin,
+            )
+        });
+        let mut follower_clients = Vec::new();
+        for (offset, result) in futures_util::future::join_all(spawns)
+            .await
+            .into_iter()
             .enumerate()
-            .take(active)
-            .map(|(i, nc)| {
-                Self::launch_node(
-                    nc,
-                    i,
-                    &all_consensus_ports,
-                    &genesis_path,
-                    &bitcoin_rpc_url,
-                    zmq_port,
-                    kontor_bin,
-                )
-            })
-            .collect();
-        let results = futures_util::future::join_all(launch_futures).await;
-        for (i, result) in results.into_iter().enumerate() {
+        {
             let (child, client) = result?;
-            node_configs[i].running = Some(ClusterNode { client, child });
+            follower_clients.push(client.clone());
+            node_configs[offset + 1].running = Some(ClusterNode { client, child });
         }
+        futures_util::future::try_join_all(follower_clients.iter().map(Self::wait_for_available))
+            .await?;
 
         // Mine a block so we can verify all nodes process it (proves peer connectivity).
         bitcoin_client
@@ -1138,6 +1163,7 @@ impl RegTesterCluster {
             node_counter: AtomicUsize::new(0),
             genesis_path,
             kontor_bin: kontor_bin.to_path_buf(),
+            seed_addr,
             miner_cmd_tx,
             _miner_handle: miner_handle,
             _bitcoin_child: bitcoin_child,
@@ -1161,10 +1187,35 @@ impl RegTesterCluster {
         Ok(cluster)
     }
 
-    async fn launch_node(
+    /// Poll a node's `GET /api/status` until it reports a bound consensus listen
+    /// address (the libp2p bind is async, so it lands shortly after the API
+    /// comes up). Used to read back the seed's OS-assigned `:0` port.
+    async fn wait_for_listen_addr(client: &KontorClient, timeout: Duration) -> Result<String> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            // Ungated endpoint — answers as soon as the swarm binds, well before
+            // the node is "available" (which needs quorum, hence the followers
+            // we're about to bootstrap from this very address).
+            if let Ok(status) = client.status().await
+                && let Some(addr) = status.consensus_listen_addr
+            {
+                return Ok(addr);
+            }
+            if tokio::time::Instant::now() >= deadline {
+                bail!("seed node never reported a bound consensus listen address within {timeout:?}");
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+
+    /// Spawn a validator node, binding an OS-assigned consensus port
+    /// (`/tcp/0`, no probe/release race). `peers` is the bootstrap seed set —
+    /// empty for the seed itself, `[seed_addr]` for everyone else, who learn
+    /// the rest of the cluster via discovery. Returns immediately; the caller
+    /// waits for whatever it needs.
+    async fn spawn_node(
         nc: &NodeConfig,
-        index: usize,
-        all_consensus_ports: &[u16],
+        peers: &[String],
         genesis_path: &std::path::Path,
         bitcoin_rpc_url: &str,
         zmq_port: u16,
@@ -1172,13 +1223,8 @@ impl RegTesterCluster {
     ) -> Result<(Child, KontorClient)> {
         let consensus_config = ConsensusNodeConfig {
             private_key_hex: hex::encode(nc.ed25519_key.inner().to_bytes()),
-            listen_addr: format!("/ip4/127.0.0.1/tcp/{}", nc.consensus_port),
-            peers: all_consensus_ports
-                .iter()
-                .enumerate()
-                .filter(|(j, _)| *j != index)
-                .map(|(_, &port)| format!("/ip4/127.0.0.1/tcp/{port}"))
-                .collect(),
+            listen_addr: "/ip4/127.0.0.1/tcp/0".to_string(),
+            peers: peers.to_vec(),
             genesis_file: genesis_path.to_string_lossy().into_owned(),
         };
         run_kontor(
@@ -1189,6 +1235,21 @@ impl RegTesterCluster {
             Some(&consensus_config),
             kontor_bin,
         )
+        .await
+    }
+
+    /// Wait until a node's `/api/` reports available — i.e. consensus has
+    /// decided a block. Only meaningful once quorum can form (the seed can't
+    /// satisfy this alone). Extended budget: cluster tests run several indexer
+    /// processes in parallel, so DB init + mempool sync + initial fee
+    /// projection + consensus startup can exceed the standard ~25s budget.
+    /// `client.index()` errors while the indexer 503s (`require_available`),
+    /// so a successful response is the availability signal.
+    async fn wait_for_available(client: &KontorClient) -> Result<()> {
+        retry_extended(async || {
+            let _ = client.index().await?;
+            Ok::<_, anyhow::Error>(())
+        })
         .await
     }
 
@@ -1221,44 +1282,25 @@ impl RegTesterCluster {
         Ok(())
     }
 
-    /// Start or restart a node.
+    /// Start or restart a node. Restarted/late-joining nodes bootstrap from
+    /// the seed (node 0) and rediscover the rest of the cluster; node 0 itself
+    /// is never restarted (see [`Self::seed_addr`]).
     pub async fn start_node(&mut self, index: usize) -> Result<()> {
-        let all_consensus_ports: Vec<u16> = self
-            .node_configs
-            .iter()
-            .map(|nc| nc.consensus_port)
-            .collect();
         let nc = &self.node_configs[index];
-        let (child, client) = Self::launch_node(
+        let (child, client) = Self::spawn_node(
             nc,
-            index,
-            &all_consensus_ports,
+            std::slice::from_ref(&self.seed_addr),
             &self.genesis_path,
             &self.bitcoin_rpc_url,
             self.zmq_port,
             &self.kontor_bin,
         )
         .await?;
+        // A restart/late-joiner joins an existing quorum, so it does become
+        // available.
+        Self::wait_for_available(&client).await?;
         self.node_configs[index].running = Some(ClusterNode { client, child });
-
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
-        loop {
-            if self.node_configs[index]
-                .running
-                .as_ref()
-                .unwrap()
-                .client
-                .index()
-                .await
-                .is_ok()
-            {
-                return Ok(());
-            }
-            if tokio::time::Instant::now() >= deadline {
-                bail!("Node {index} failed to become available within 30s");
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-        }
+        Ok(())
     }
 
     /// Get a `RegTester` for the cluster. Returns a clone of the shared

--- a/core/indexer/src/reg_tester.rs
+++ b/core/indexer/src/reg_tester.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    io::Write,
     path::{Path, PathBuf},
     str::FromStr,
     sync::{
@@ -120,7 +121,7 @@ async fn run_bitcoin(data_dir: &Path) -> Result<(Child, bitcoin_client::Client, 
         );
     }
 
-    let mut last_err = None;
+    let mut last_exit = None;
     for _ in 0..BITCOIND_BIND_ATTEMPTS {
         let rpc_port = random_low_port();
         let mut zmq_port = random_low_port();
@@ -143,40 +144,58 @@ async fn run_bitcoin(data_dir: &Path) -> Result<(Child, bitcoin_client::Client, 
         };
         let client = bitcoin_client::Client::new_from_config(&config)?;
 
-        match wait_bitcoind_ready(&mut process, &client).await {
-            Ok(()) => return Ok((process, client, config.bitcoin_rpc_url, zmq_port)),
-            Err(e) => {
-                // Likely a port collision: bitcoind exited during start-up.
-                // Make sure it's gone, then retry with a fresh port pair.
-                let _ = process.start_kill();
-                let _ = process.wait().await;
-                last_err = Some(e);
+        // Only a process *exit* means a port collision (or other fatal start-up
+        // error) — that's the one outcome worth retrying with fresh ports. A
+        // slow-but-alive bitcoind, a wrong network, or an I/O error propagate
+        // straight out: respawning on new ports wouldn't fix any of them.
+        match wait_bitcoind_ready(&mut process, &client).await? {
+            BitcoindStartup::Ready => {
+                return Ok((process, client, config.bitcoin_rpc_url, zmq_port));
+            }
+            BitcoindStartup::Exited(status) => {
+                // `try_wait` already reaped it; just record and re-pick ports.
+                last_exit = Some(status);
             }
         }
     }
     bail!(
-        "bitcoind failed to bind after {BITCOIND_BIND_ATTEMPTS} attempts: {}",
-        last_err.map_or_else(|| "unknown".to_string(), |e| format!("{e:#}"))
+        "bitcoind exited on every one of {BITCOIND_BIND_ATTEMPTS} port attempts \
+         (last exit: {last_exit:?}) — likely sustained port pressure"
     )
 }
 
-/// Wait for a freshly-spawned bitcoind to answer RPC on regtest. Distinguishes
-/// "not up yet" (keep waiting) from "process exited" (a bind collision — caller
-/// retries with new ports).
-async fn wait_bitcoind_ready(process: &mut Child, client: &bitcoin_client::Client) -> Result<()> {
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+/// Outcome of waiting on a freshly-spawned bitcoind.
+enum BitcoindStartup {
+    /// RPC answered on regtest — bitcoind is up.
+    Ready,
+    /// The process exited during start-up — almost always a port bind
+    /// collision. The caller retries with a fresh port pair.
+    Exited(std::process::ExitStatus),
+}
+
+/// Wait for a freshly-spawned bitcoind to either answer RPC on regtest
+/// ([`BitcoindStartup::Ready`]) or exit ([`BitcoindStartup::Exited`], the
+/// retryable port-collision case). A readiness *timeout while the process is
+/// still alive* is **not** a collision — new ports wouldn't help — so it
+/// surfaces as a hard error instead. The budget matches `retry_extended`
+/// (~65s): under parallel CI load a healthy bitcoind can be slow to answer RPC.
+async fn wait_bitcoind_ready(
+    process: &mut Child,
+    client: &bitcoin_client::Client,
+) -> Result<BitcoindStartup> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(65);
     loop {
         if let Some(status) = process.try_wait()? {
-            bail!("bitcoind exited during start-up ({status}) — likely a port bind collision");
+            return Ok(BitcoindStartup::Exited(status));
         }
         if let Ok(i) = client.get_blockchain_info().await {
             if i.chain != Network::Regtest {
-                bail!("Network not regtest");
+                bail!("bitcoind came up on {:?}, expected regtest", i.chain);
             }
-            return Ok(());
+            return Ok(BitcoindStartup::Ready);
         }
         if tokio::time::Instant::now() >= deadline {
-            bail!("bitcoind did not become ready within 30s");
+            bail!("bitcoind alive but did not answer RPC within 65s (not a port collision)");
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
@@ -269,11 +288,16 @@ async fn read_api_port_from_logs(stdout: ChildStdout, timeout: Duration) -> Resu
         match tokio::time::timeout_at(deadline, lines.next_line()).await {
             Ok(Ok(Some(line))) => {
                 let port = parse_http_server_port(&line);
-                println!("{line}");
+                let _ = writeln!(std::io::stdout(), "{line}");
                 if let Some(port) = port {
+                    // Keep draining the child's stdout for its whole life so it
+                    // never blocks on a full pipe; forward best-effort and ignore
+                    // write errors (e.g. the test's captured stdout closing) so a
+                    // broken parent pipe can't kill the drain and leave the child
+                    // spewing into a closed pipe.
                     tokio::spawn(async move {
                         while let Ok(Some(line)) = lines.next_line().await {
-                            println!("{line}");
+                            let _ = writeln!(std::io::stdout(), "{line}");
                         }
                     });
                     return Ok(port);
@@ -1156,7 +1180,10 @@ impl RegTesterCluster {
         )
         .await?;
         node_configs[0].api_port = seed_api_port;
-        let seed_addr = Self::wait_for_listen_addr(&seed_client, Duration::from_secs(30)).await?;
+        // ≥ the `retry_extended` budget `wait_for_available` uses: the seed only
+        // publishes its listen address after initial mempool sync + consensus
+        // start-up, which under parallel CI load can run well past 30s.
+        let seed_addr = Self::wait_for_listen_addr(&seed_client, Duration::from_secs(90)).await?;
         node_configs[0].running = Some(ClusterNode {
             client: seed_client,
             child: seed_child,

--- a/core/indexer/src/reg_tester.rs
+++ b/core/indexer/src/reg_tester.rs
@@ -1052,8 +1052,11 @@ impl RegTesterCluster {
         // decide a block (no quorum) so it never becomes "available", and
         // waiting for that here would deadlock against the very followers it's
         // meant to seed. The address is read from the ungated
-        // `/consensus/listen-addr` endpoint (answers before availability).
-        assert!(active >= 1, "cluster needs at least the seed node (index 0)");
+        // `/api/status` endpoint (answers before availability).
+        assert!(
+            active >= 1,
+            "cluster needs at least the seed node (index 0)"
+        );
         let (seed_child, seed_client) = Self::spawn_node(
             &node_configs[0],
             &[],
@@ -1202,7 +1205,9 @@ impl RegTesterCluster {
                 return Ok(addr);
             }
             if tokio::time::Instant::now() >= deadline {
-                bail!("seed node never reported a bound consensus listen address within {timeout:?}");
+                bail!(
+                    "seed node never reported a bound consensus listen address within {timeout:?}"
+                );
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
         }

--- a/core/indexer/src/reg_tester.rs
+++ b/core/indexer/src/reg_tester.rs
@@ -1086,17 +1086,28 @@ impl RegTesterCluster {
                 kontor_bin,
             )
         });
-        let mut follower_clients = Vec::new();
         for (offset, result) in futures_util::future::join_all(spawns)
             .await
             .into_iter()
             .enumerate()
         {
             let (child, client) = result?;
-            follower_clients.push(client.clone());
             node_configs[offset + 1].running = Some(ClusterNode { client, child });
         }
-        futures_util::future::try_join_all(follower_clients.iter().map(Self::wait_for_available))
+
+        // Now wait for *every* active node — seed included — to become available.
+        // The seed was only waited for its listen address above (so its bootstrap
+        // address could be handed to the followers before they existed); now that
+        // the full active set is running it reaches quorum and they all go
+        // available together. For a single-node devnet (no followers) this is the
+        // only availability barrier — without it, bring-up races ahead of the lone
+        // seed and the first `/api` poll 503s.
+        let active_clients: Vec<KontorClient> = node_configs
+            .iter()
+            .take(active)
+            .filter_map(|nc| nc.running.as_ref().map(|cn| cn.client.clone()))
+            .collect();
+        futures_util::future::try_join_all(active_clients.iter().map(Self::wait_for_available))
             .await?;
 
         // Mine a block so we can verify all nodes process it (proves peer connectivity).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Patches consensus to a fork and changes P2P discovery/gossipsub defaults; bootstrap and networking behavior differ from fixed-port setups, though listen-addr publishing is observability-only on failure paths.
> 
> **Overview**
> Eliminates **probe-then-release port allocation** for consensus and HTTP in tests/regtest by binding **`/tcp/0`** and **`--api-port 0`**, then reading back the real addresses (Malachite **`dump_state`** + **`GET /api/status`**, API log line parsing).
> 
> Adds an **ungated `GET /api/status`** and a reactor watch channel that publishes **`consensus_listen_addr`** on **`ConsensusReady`**, so a seed can be discovered before quorum/availability. **`Cargo.toml`** patches Malachite to the **KontorProtocol** fork until listen-addr support is upstream.
> 
> **Production reactor** turns on **libp2p discovery** and **validator-aware gossipsub** mesh settings. **Regtest/cluster harness** uses seed-first bring-up (listen addr → followers → availability), **bitcoind** port retry from a low band, and in-process cluster tests mirror the same **`/tcp/0`** + watch bootstrap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fd8a454fd6118f0e5bd4c0359f661df41b00b98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->