### PR TITLE
sdk: add extraOutputs rider outputs to submit/offer/accept

### DIFF
--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontor/sdk",
-  "version": "0.3.0-rc.2",
+  "version": "0.3.0-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontor/sdk",
-      "version": "0.3.0-rc.2",
+      "version": "0.3.0-rc.3",
       "dependencies": {
         "@scure/base": "^2.2.0",
         "@scure/bip32": "^2.2.0",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontor/sdk",
-  "version": "0.3.0-rc.2",
+  "version": "0.3.0-rc.3",
   "author": "Unspendable Labs <dev@unspendablelabs.com>",
   "repository": {
     "type": "git",

--- a/sdk/src/attach.ts
+++ b/sdk/src/attach.ts
@@ -18,6 +18,7 @@ import { hex } from "@scure/base";
 import { p2tr } from "@scure/btc-signer";
 
 import type { Reveal } from "./bindings.js";
+import { toRevealOutputs, type ExtraOutput } from "./outputs.js";
 import { instToWire, type Inst } from "./inst.js";
 import type { WireInsts } from "./json-codec.js";
 import { Offer, buildSellerDetachPsbt, type OfferData } from "./offer.js";
@@ -54,7 +55,13 @@ export class Attachment<T> {
    * asset at listing time): subsequent `revoke()` and `accept()` only
    * need to send the detach / swap tx, not re-broadcast attach.
    */
-  async offer(opts: { price: bigint }): Promise<Offer> {
+  async offer(opts: {
+    price: bigint;
+    /** Rider outputs (e.g. a marketplace listing fee) settled in the
+     *  same attach reveal. Spliced after the escrow output and before
+     *  Change, which must stay last. */
+    extraOutputs?: ExtraOutput[];
+  }): Promise<Offer> {
     const { transport, identity, signing } = this.session;
     if (signing == null) {
       throw new TransportError(
@@ -110,6 +117,8 @@ export class Attachment<T> {
                 internal_key: identity.xOnlyPubKey,
               },
             },
+            ...toRevealOutputs(opts.extraOutputs, this.session.chain.network),
+            // Change MUST stay last — it absorbs leftover sats after fees.
             { Change: { script_pubkey: sellerScriptPubKey } },
           ],
         };

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -38,6 +38,7 @@ export { ContractBase } from "./contract-base";
 export { Attachment } from "./attach";
 export { Offer, IncomingOffer } from "./offer";
 export type { OfferData, OfferInspection } from "./offer";
+export type { ExtraOutput } from "./outputs";
 export { HttpTransport, http } from "./transport/http";
 export type { HttpTransportOptions } from "./transport/http";
 export type { Utxo } from "./json-codec";

--- a/sdk/src/inst.ts
+++ b/sdk/src/inst.ts
@@ -43,6 +43,7 @@ import type {
 import { ContractAddress } from "./canonical/ContractAddress.js";
 import { ContractError, SignerError, TransportError } from "./errors.js";
 import type { ChainEvent } from "./events.js";
+import type { ExtraOutput } from "./outputs.js";
 import type { BroadcastResult, OpResult, OpResultRaw } from "./json-codec.js";
 import type { KontorSession } from "./session.js";
 
@@ -175,7 +176,9 @@ export class Inst<T> implements PromiseLike<T> {
    * immediately, `handle.wait()` resolves the typed `OpResult<T>`
    * once the indexer surfaces the outcome.
    */
-  async submit(): Promise<SubmittedTx<OpResult<T>>> {
+  async submit(opts?: {
+    extraOutputs?: ExtraOutput[];
+  }): Promise<SubmittedTx<OpResult<T>>> {
     // Reject a read-only submit before any side effect (starting the poller).
     this.session.assertWritable();
     const wire: WireInsts = { ops: [instToWire(this)], aggregate: null };
@@ -184,7 +187,7 @@ export class Inst<T> implements PromiseLike<T> {
     const events = this.session.events();
     let broadcast: BroadcastResult;
     try {
-      broadcast = await this.session.transport.submit(wire);
+      broadcast = await this.session.transport.submit(wire, opts);
     } catch (e) {
       await events.return?.();
       throw e;

--- a/sdk/src/insts.ts
+++ b/sdk/src/insts.ts
@@ -28,6 +28,7 @@ import type { AggregateInfo } from "./bindings.js";
 import { ContractError, TransportError } from "./errors.js";
 import { instToWire, rawToOpResult, waitForTxOutcomes } from "./inst.js";
 import type { Inst, SubmittedTx, WaitOptions } from "./inst.js";
+import type { ExtraOutput } from "./outputs.js";
 import type {
   BroadcastResult,
   OpResult,
@@ -87,7 +88,9 @@ export class Insts<T extends readonly unknown[]> implements PromiseLike<T> {
    * immediately, `handle.wait()` resolves the tuple of per-Inst
    * `OpResult`s (`InstsOpResults<T>`) once the indexer surfaces them.
    */
-  async submit(): Promise<SubmittedTx<InstsOpResults<T>>> {
+  async submit(opts?: {
+    extraOutputs?: ExtraOutput[];
+  }): Promise<SubmittedTx<InstsOpResults<T>>> {
     // Reject a read-only submit before any side effect (starting the poller).
     this.session.assertWritable();
     // Attach to the poller before broadcasting — same race-close as
@@ -95,7 +98,7 @@ export class Insts<T extends readonly unknown[]> implements PromiseLike<T> {
     const events = this.session.events();
     let broadcast: BroadcastResult;
     try {
-      broadcast = await this.session.transport.submit(this.toWire());
+      broadcast = await this.session.transport.submit(this.toWire(), opts);
     } catch (e) {
       await events.return?.();
       throw e;

--- a/sdk/src/json-codec.ts
+++ b/sdk/src/json-codec.ts
@@ -38,6 +38,7 @@
 import type { Transaction } from "@scure/btc-signer";
 
 import type { ContractAddress } from "./canonical/ContractAddress.js";
+import type { ExtraOutput } from "./outputs.js";
 import type {
   ComposeOutputs,
   Inst as WireInst,
@@ -148,8 +149,14 @@ export interface KontorTransport {
    * txid. Does NOT wait for inclusion — per-Inst outcomes are
    * resolved later by the session's results poller. This keeps
    * `submit` fast and lets callers see the txid before the tx lands.
+   *
+   * `opts.extraOutputs` appends caller-supplied rider outputs (e.g. a
+   * marketplace fee) to the reveal, after the account's change output.
    */
-  submit(insts: WireInsts): Promise<BroadcastResult>;
+  submit(
+    insts: WireInsts,
+    opts?: { extraOutputs?: ExtraOutput[] },
+  ): Promise<BroadcastResult>;
 
   /**
    * Combined compose: build any commits required by Build participants,

--- a/sdk/src/offer.ts
+++ b/sdk/src/offer.ts
@@ -30,6 +30,7 @@ import {
 
 import type { Signing } from "./signing.js";
 import type { Reveal, TapLeafScript } from "./bindings.js";
+import { toRevealOutputs, type ExtraOutput } from "./outputs.js";
 import type { BitcoinNetwork } from "./chains.js";
 import { SignerError } from "./errors.js";
 import type { BroadcastResult, Utxo, WireInsts } from "./json-codec.js";
@@ -277,7 +278,9 @@ export class IncomingOffer {
    * `ctx.payer()` resolves to the buyer; the asset detaches to the
    * buyer (= signer of this `accept()` call). No OP_RETURN is involved.
    */
-  async accept(): Promise<BroadcastResult> {
+  async accept(opts?: {
+    extraOutputs?: ExtraOutput[];
+  }): Promise<BroadcastResult> {
     const { data } = this;
     const { identity, chain, transport } = this.session;
 
@@ -374,7 +377,9 @@ export class IncomingOffer {
           },
         ],
         extra_inputs: [],
-        extra_outputs: [],
+        // Both participants carry paired outputs (buyer Change, seller
+        // Fixed); these append after them in the layout.
+        extra_outputs: toRevealOutputs(opts?.extraOutputs, chain.network),
       };
       const prepared = await transport.composeAndSign(reveal);
       if (prepared.commitHexes.length !== 1) {

--- a/sdk/src/outputs.ts
+++ b/sdk/src/outputs.ts
@@ -1,0 +1,49 @@
+/**
+ * Caller-supplied "rider" outputs for a reveal tx — a payment (e.g. a
+ * marketplace listing fee) or an OP_RETURN, settled atomically in the
+ * same tx the SDK is already broadcasting.
+ *
+ * Deliberately a safe subset of the wire `RevealOutput`: the
+ * SDK-managed variants (`Change`, the attach `ChainedEnvelope` escrow)
+ * are not expressible here, so a caller can't accidentally displace the
+ * change output or forge an escrow leaf.
+ */
+
+import { hex } from "@scure/base";
+import { Address, OutScript } from "@scure/btc-signer";
+
+import type { RevealOutput } from "./bindings.js";
+import type { BitcoinNetwork } from "./chains.js";
+
+export type ExtraOutput =
+  | { pay: { address: string; value: bigint } }
+  | { data: Uint8Array }; // OP_RETURN
+
+/** Map one `ExtraOutput` to the wire `RevealOutput`. The `pay` address
+ *  is decoded against `network`, so a malformed / wrong-network address
+ *  throws here (surfaced to the caller as a compose-time error). */
+export function toRevealOutput(
+  extra: ExtraOutput,
+  network: BitcoinNetwork,
+): RevealOutput {
+  if ("pay" in extra) {
+    const decoded = Address(network).decode(extra.pay.address);
+    if (decoded === undefined) {
+      throw new Error(`invalid pay-to address: ${extra.pay.address}`);
+    }
+    return {
+      Fixed: {
+        script_pubkey: hex.encode(OutScript.encode(decoded)),
+        value: Number(extra.pay.value),
+      },
+    };
+  }
+  return { OpReturn: { data: Array.from(extra.data) } };
+}
+
+export function toRevealOutputs(
+  extras: ExtraOutput[] | undefined,
+  network: BitcoinNetwork,
+): RevealOutput[] {
+  return (extras ?? []).map((e) => toRevealOutput(e, network));
+}

--- a/sdk/src/transport/http.ts
+++ b/sdk/src/transport/http.ts
@@ -34,6 +34,7 @@ import type { Chain } from "../chains.js";
 import type { ContractAddress } from "../canonical/ContractAddress.js";
 import { ChainError, ContractError, TransportError } from "../errors.js";
 import { signCommit, signReveal } from "./signing.js";
+import { toRevealOutputs, type ExtraOutput } from "../outputs.js";
 import type {
   BroadcastResult,
   KontorTransport,
@@ -276,6 +277,7 @@ export class HttpTransport implements KontorTransport {
   private async buildSimpleReveal(
     insts: WireInsts,
     utxos: Utxo[],
+    extraOutputs?: ExtraOutput[],
   ): Promise<Reveal> {
     const { identity } = this.opts;
     const scriptPubKeyHex = hex.encode(
@@ -298,7 +300,9 @@ export class HttpTransport implements KontorTransport {
         },
       ],
       extra_inputs: [],
-      extra_outputs: [],
+      // Change is the participant's *paired* output above; these append
+      // after it in the layout.
+      extra_outputs: toRevealOutputs(extraOutputs, this.opts.chain.network),
     };
   }
 
@@ -316,9 +320,16 @@ export class HttpTransport implements KontorTransport {
    * in `recentlySpent` (callback mode's filter). On broadcast failure,
    * neither is touched — those UTXOs aren't actually spent.
    */
-  async submit(insts: WireInsts): Promise<BroadcastResult> {
+  async submit(
+    insts: WireInsts,
+    opts?: { extraOutputs?: ExtraOutput[] },
+  ): Promise<BroadcastResult> {
     const { result } = await this.submitReveal(async (utxos) => {
-      const reveal = await this.buildSimpleReveal(insts, utxos);
+      const reveal = await this.buildSimpleReveal(
+        insts,
+        utxos,
+        opts?.extraOutputs,
+      );
       return this.composeAndSign(reveal);
     });
     return result;

--- a/sdk/src/transport/http.ts
+++ b/sdk/src/transport/http.ts
@@ -290,7 +290,13 @@ export class HttpTransport implements KontorTransport {
         {
           x_only_public_key: identity.xOnlyPubKey,
           commit_insts: insts,
-          output: { Change: { script_pubkey: scriptPubKeyHex } },
+          // Change rides as the final extra_output (below), not a paired
+          // output: rider outputs slot in front of it so Change stays
+          // last. The indexer only silently drops sub-dust Change when
+          // it's the final output, so a paired Change at index 0 with
+          // riders appended after would turn a would-be-dropped dust
+          // change into a hard compose error.
+          output: null,
           commit_source: {
             Build: {
               address: identity.address,
@@ -300,9 +306,10 @@ export class HttpTransport implements KontorTransport {
         },
       ],
       extra_inputs: [],
-      // Change is the participant's *paired* output above; these append
-      // after it in the layout.
-      extra_outputs: toRevealOutputs(extraOutputs, this.opts.chain.network),
+      extra_outputs: [
+        ...toRevealOutputs(extraOutputs, this.opts.chain.network),
+        { Change: { script_pubkey: scriptPubKeyHex } },
+      ],
     };
   }
 

--- a/sdk/test/sdk.regtest.test.ts
+++ b/sdk/test/sdk.regtest.test.ts
@@ -44,6 +44,7 @@ import {
   type Utxo,
 } from "@kontor/sdk";
 import { hex, base64 } from "@scure/base";
+import { Transaction, p2tr } from "@scure/btc-signer";
 import { connectRegtest } from "@kontor/sdk/regtest";
 import { Contract as Token } from "./__generated__/token.js";
 import "./regtest-context.js";
@@ -219,11 +220,40 @@ test("SDK capstone: publish, transfer, bulk, marketplace", async () => {
         (await buyerToken.balance(buyer.identity.holderRef)) ??
         Decimal.from("0");
 
-      // Seller creates an offer; attach broadcasts immediately.
-      const offer = await sellerToken
-        .attachment(Decimal.from("2"))
-        .offer({ price: 600n });
+      // Seller creates an offer; attach broadcasts immediately. A
+      // marketplace listing fee rides along as an `extraOutputs`
+      // payment, settled in the same attach reveal rather than a
+      // separate tx — `accounts[0]` stands in as the marketplace.
+      const market = regtest.accounts[0]!.signing.identity;
+      const marketFee = 1_500n;
+      const offer = await sellerToken.attachment(Decimal.from("2")).offer({
+        price: 600n,
+        extraOutputs: [{ pay: { address: market.address, value: marketFee } }],
+      });
       const blob = offer.serialize();
+
+      // The attach reveal carries a fixed output paying the fee to the
+      // market's script — proves the rider output landed in the same tx.
+      const marketScript = hex.encode(
+        p2tr(hex.decode(market.xOnlyPubKey), undefined, chain.network).script,
+      );
+      const attachReveal = Transaction.fromRaw(
+        hex.decode(JSON.parse(blob).attachReveal as string),
+        { disableScriptCheck: true, allowUnknownOutputs: true },
+      );
+      let feePaid = false;
+      for (let i = 0; i < attachReveal.outputsLength; i++) {
+        const o = attachReveal.getOutput(i);
+        if (
+          o.script != null &&
+          hex.encode(o.script) === marketScript &&
+          o.amount === marketFee
+        ) {
+          feePaid = true;
+          break;
+        }
+      }
+      expect(feePaid).toBe(true);
 
       // Buyer opens + inspects.
       const incoming = buyerSession.openOffer(blob);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes reveal output ordering and Change placement in `HttpTransport`, which affects compose and funding settlement; the API is additive and restricts riders to a safe subset of output types.
> 
> **Overview**
> Adds **`extraOutputs`** so callers can attach **rider** payments or OP_RETURN data to the same reveal tx as `submit`, marketplace **offer**, and **accept**, without touching SDK-managed **Change** or escrow outputs.
> 
> New **`ExtraOutput`** (`pay` / `data`) maps to wire reveal outputs via **`outputs.ts`**; **`Inst`**, **`Insts`**, and **`KontorTransport.submit`** forward optional `extraOutputs`. **`Attachment.offer`** splices riders after the **ChainedEnvelope** and before **Change**; **`IncomingOffer.accept`** appends them on the swap reveal. **`HttpTransport.buildSimpleReveal`** moves **Change** off the participant’s paired output into **`extra_outputs`** (riders first, **Change** last) so sub-dust change can still be dropped by the indexer. Package version **0.3.0-rc.3**; regtest asserts a listing fee lands on the attach reveal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fda8c0445e886eaf7ea17816003594aae068fe1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->