### PR TITLE
indexer: harden storage ops — meter subtree deletes by size + guard call exprs against parser stack overflow

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2067,7 +2067,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6093,9 +6093,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/core/indexer/src/database/queries/contract_state.rs
+++ b/core/indexer/src/database/queries/contract_state.rs
@@ -34,7 +34,7 @@
 //! Two deliberate EXCEPTIONS, each documented at its call site:
 //!   - [`matching_path`] — enum/option variant resolution. GLOBAL-newest across
 //!     paths (NOT per-path), because it asks "which variant is current?".
-//!   - [`delete_matching_paths`] — a HARD delete at the current height (not a
+//!   - [`hard_delete_matching_paths`] — a HARD delete at the current height (not a
 //!     tombstone, not a liveness read); intra-block `Option` variant cleanup.
 
 use futures_util::{Stream, stream};
@@ -217,14 +217,82 @@ pub async fn get_latest_contract_state_value(
     Ok(None)
 }
 
-/// Remove an entry by tombstoning its WHOLE subtree: the path itself AND every
-/// live descendant (`path/field`, nested struct/map rows, …). A struct value
-/// persists under child paths, so tombstoning only the exact path would leave
-/// live primary rows behind while the caller (`Map`/`IndexedMap` `remove`) has
-/// already cleared the index — a half-removed entry. Height-versioned (one
-/// `deleted = true` row per live path at the current height), so reorg-safe.
-/// Returns true if any live row was tombstoned. The subtree is the byte range
-/// `[path, strinc(path))` (the node + every descendant share `path` as a prefix).
+/// A live row a delete will tombstone: just the `path` and its stored value
+/// `size`. Carries the two quantities the caller needs to METER the delete
+/// (`path.len() + size` = bytes freed) before writing any tombstone, so a delete
+/// is charged in proportion to the subtree it removes — not a flat per-call fee
+/// regardless of size.
+#[derive(Debug, Clone)]
+pub struct DeletableRow {
+    pub path: Vec<u8>,
+    pub size: u64,
+}
+
+/// Every live path at/under `path`: the read half of a subtree delete, split out
+/// so the caller can charge fuel for the rows BEFORE [`tombstone_rows`] writes
+/// them (read → meter → write). `live_latest` skips an already-tombstoned path
+/// (its latest version isn't live), so it isn't re-tombstoned. The subtree is the
+/// byte range `[path, strinc(path))` (the node + every descendant share `path` as
+/// a prefix). `size` is the live row's stored value length.
+pub async fn find_live_subtree(
+    conn: &Connection,
+    contract_id: u64,
+    path: &[u8],
+) -> Result<Vec<DeletableRow>, Error> {
+    let (range, mut params) = subtree_range(">=", path);
+    params.push((
+        ":contract_id".to_string(),
+        Value::Integer(contract_id as i64),
+    ));
+    let query = live_latest("path, size", &format!("contract_id = :contract_id AND {range}"));
+    let mut result = conn.query(&query, params).await?;
+    let mut rows = Vec::new();
+    while let Some(row) = result.next().await? {
+        rows.push(DeletableRow {
+            path: row.get::<Vec<u8>>(0)?,
+            size: row.get::<u64>(1)?,
+        });
+    }
+    Ok(rows)
+}
+
+/// Tombstone a WHOLE subtree: write one `deleted = true` row per live path (from
+/// [`find_live_subtree`]) at the current height. A struct value persists under
+/// child paths, so tombstoning only the exact path would leave live primary rows
+/// behind while the caller (`Map` `remove`) has already cleared the index — a
+/// half-removed entry. Height-versioned, so reorg-safe. Each tombstone is
+/// VALUE-LESS (`value` omitted → empty): nothing reads a tombstone's value
+/// (liveness keys off `deleted = 1`), so a big delete writes N empty marker rows
+/// instead of duplicating N values. Returns `(any row removed, total bytes freed)`
+/// where freed = Σ `path.len() + size` over the live rows.
+pub async fn tombstone_rows(
+    conn: &Connection,
+    contract_id: u64,
+    height: u64,
+    tx_id: Option<u64>,
+    rows: &[DeletableRow],
+) -> Result<(bool, u64), Error> {
+    let removed = !rows.is_empty();
+    let freed: u64 = rows.iter().map(|r| r.path.len() as u64 + r.size).sum();
+    for row in rows {
+        insert_contract_state(
+            conn,
+            ContractStateRow::builder()
+                .contract_id(contract_id)
+                .maybe_tx_id(tx_id)
+                .height(height)
+                .path(row.path.clone())
+                .deleted(true)
+                .build(),
+        )
+        .await?;
+    }
+    Ok((removed, freed))
+}
+
+/// Remove an entry by tombstoning its whole subtree (read → write, no metering).
+/// Returns true if any live row was tombstoned. Callers that meter the delete use
+/// [`find_live_subtree`] + [`tombstone_rows`] directly.
 pub async fn delete_contract_state(
     conn: &Connection,
     height: u64,
@@ -232,34 +300,8 @@ pub async fn delete_contract_state(
     contract_id: u64,
     path: &[u8],
 ) -> Result<bool, Error> {
-    // Every live path at/under `path`, re-inserted as a tombstone below.
-    // `live_latest` skips an already-tombstoned path (its latest version isn't
-    // live), so it's not re-tombstoned.
-    let (range, mut params) = subtree_range(">=", path);
-    params.push((
-        ":contract_id".to_string(),
-        Value::Integer(contract_id as i64),
-    ));
-    let query = live_latest(
-        "contract_id, height, tx_id, path, value, deleted",
-        &format!("contract_id = :contract_id AND {range}"),
-    );
-    let mut result = conn.query(&query, params).await?;
-
-    // Materialise the live rows BEFORE writing tombstones (don't read and write
-    // `contract_state` in the same statement).
-    let mut live: Vec<ContractStateRow> = Vec::new();
-    while let Some(row) = result.next().await? {
-        live.push(from_row(&row)?);
-    }
-
-    let removed = !live.is_empty();
-    for mut row in live {
-        row.deleted = true;
-        row.height = height;
-        row.tx_id = tx_id;
-        insert_contract_state(conn, row).await?;
-    }
+    let rows = find_live_subtree(conn, contract_id, path).await?;
+    let (removed, _freed) = tombstone_rows(conn, contract_id, height, tx_id, &rows).await?;
     Ok(removed)
 }
 
@@ -422,6 +464,60 @@ pub async fn matching_path(
         .map(|i| i as u32))
 }
 
+/// The current-height subtree `WHERE` fragment + params for one `candidate`:
+/// `contract_id = AND height = AND {byte range of base_path ++ candidate}`. Shared
+/// by the read ([`find_matching_paths`]) and the hard delete
+/// ([`hard_delete_matching_paths`]) so the metered read and the write target the
+/// exact same rows.
+fn matching_paths_clause(
+    contract_id: u64,
+    height: u64,
+    base_path: &[u8],
+    candidate: &[u8],
+) -> (String, Vec<(String, Value)>) {
+    let mut prefix = base_path.to_vec();
+    prefix.extend_from_slice(candidate); // base_path ++ candidate element
+    let (range, mut params) = subtree_range(">=", &prefix);
+    params.push((
+        ":contract_id".to_string(),
+        Value::Integer(contract_id as i64),
+    ));
+    params.push((":height".to_string(), Value::Integer(height as i64)));
+    (
+        format!("contract_id = :contract_id AND height = :height AND {range}"),
+        params,
+    )
+}
+
+/// The rows [`hard_delete_matching_paths`] will delete — read first so the caller
+/// can charge fuel in proportion to what's removed (read → meter → write). Same
+/// current-height, per-candidate ranges; `size` is the stored value length.
+pub async fn find_matching_paths(
+    conn: &Connection,
+    contract_id: u64,
+    height: u64,
+    base_path: &[u8],
+    candidates: &[Vec<u8>],
+) -> Result<Vec<DeletableRow>, Error> {
+    let mut rows = Vec::new();
+    for candidate in candidates {
+        let (clause, params) = matching_paths_clause(contract_id, height, base_path, candidate);
+        let mut result = conn
+            .query(
+                &format!("SELECT path, size FROM contract_state WHERE {clause}"),
+                params,
+            )
+            .await?;
+        while let Some(row) = result.next().await? {
+            rows.push(DeletableRow {
+                path: row.get::<Vec<u8>>(0)?,
+                size: row.get::<u64>(1)?,
+            });
+        }
+    }
+    Ok(rows)
+}
+
 /// EXCEPTION to the liveness model (see module header): a HARD delete of rows at
 /// the CURRENT height under any of `candidates` — not a tombstone, not a
 /// latest-version read. Used only for intra-block `Option`/enum variant cleanup
@@ -429,7 +525,7 @@ pub async fn matching_path(
 /// it deliberately does NOT touch earlier-height rows. Each `candidate` is an
 /// already-encoded discriminant element, so the subtree is `base_path ++ candidate`
 /// — a per-candidate current-height range delete.
-pub async fn delete_matching_paths(
+pub async fn hard_delete_matching_paths(
     conn: &Connection,
     contract_id: u64,
     height: u64,
@@ -438,20 +534,10 @@ pub async fn delete_matching_paths(
 ) -> Result<u64, Error> {
     let mut deleted = 0;
     for candidate in candidates {
-        let mut prefix = base_path.to_vec();
-        prefix.extend_from_slice(candidate); // base_path ++ candidate element
-        let (range, mut params) = subtree_range(">=", &prefix);
-        params.push((
-            ":contract_id".to_string(),
-            Value::Integer(contract_id as i64),
-        ));
-        params.push((":height".to_string(), Value::Integer(height as i64)));
+        let (clause, params) = matching_paths_clause(contract_id, height, base_path, candidate);
         deleted += conn
             .execute(
-                &format!(
-                    "DELETE FROM contract_state \
-                     WHERE contract_id = :contract_id AND height = :height AND {range}"
-                ),
+                &format!("DELETE FROM contract_state WHERE {clause}"),
                 params,
             )
             .await?;

--- a/core/indexer/src/database/queries/contract_state.rs
+++ b/core/indexer/src/database/queries/contract_state.rs
@@ -245,7 +245,10 @@ pub async fn find_live_subtree(
         ":contract_id".to_string(),
         Value::Integer(contract_id as i64),
     ));
-    let query = live_latest("path, size", &format!("contract_id = :contract_id AND {range}"));
+    let query = live_latest(
+        "path, size",
+        &format!("contract_id = :contract_id AND {range}"),
+    );
     let mut result = conn.query(&query, params).await?;
     let mut rows = Vec::new();
     while let Some(row) = result.next().await? {

--- a/core/indexer/src/database/queries/contract_state.rs
+++ b/core/indexer/src/database/queries/contract_state.rs
@@ -39,6 +39,7 @@
 
 use futures_util::{Stream, stream};
 use libsql::{Connection, Value, de::from_row, params};
+use serde::Deserialize;
 use stdlib::{next_element, strinc};
 
 use super::Error;
@@ -222,7 +223,7 @@ pub async fn get_latest_contract_state_value(
 /// (`path.len() + size` = bytes freed) before writing any tombstone, so a delete
 /// is charged in proportion to the subtree it removes — not a flat per-call fee
 /// regardless of size.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct DeletableRow {
     pub path: Vec<u8>,
     pub size: u64,
@@ -248,10 +249,7 @@ pub async fn find_live_subtree(
     let mut result = conn.query(&query, params).await?;
     let mut rows = Vec::new();
     while let Some(row) = result.next().await? {
-        rows.push(DeletableRow {
-            path: row.get::<Vec<u8>>(0)?,
-            size: row.get::<u64>(1)?,
-        });
+        rows.push(from_row(&row)?);
     }
     Ok(rows)
 }
@@ -509,10 +507,7 @@ pub async fn find_matching_paths(
             )
             .await?;
         while let Some(row) = result.next().await? {
-            rows.push(DeletableRow {
-                path: row.get::<Vec<u8>>(0)?,
-                size: row.get::<u64>(1)?,
-            });
+            rows.push(from_row(&row)?);
         }
     }
     Ok(rows)

--- a/core/indexer/src/database/queries/tests.rs
+++ b/core/indexer/src/database/queries/tests.rs
@@ -58,7 +58,7 @@ fn cs_path_dotted(path: &str) -> Vec<u8> {
     cs_path(&path.split('.').collect::<Vec<_>>())
 }
 
-/// Candidate discriminant elements for `matching_path`/`delete_matching_paths`,
+/// Candidate discriminant elements for `matching_path`/`hard_delete_matching_paths`,
 /// from string variant names — these host tests use string-element discriminants
 /// (the byte-compare is encoding-agnostic, so a string element is a fine stand-in).
 fn cands(names: &[&str]) -> Vec<Vec<u8>> {
@@ -1119,7 +1119,7 @@ async fn test_map_keys() -> Result<()> {
     assert_eq!(paths[1], cs_path(&["key1"]));
     assert_eq!(paths[2], cs_path(&["key2"]));
 
-    let result = delete_matching_paths(
+    let result = hard_delete_matching_paths(
         &conn,
         contract_id,
         height,

--- a/core/indexer/src/runtime/call.rs
+++ b/core/indexer/src/runtime/call.rs
@@ -70,6 +70,11 @@ impl Runtime {
         ),
         ExecutionError,
     > {
+        // Reject an oversized/over-nested call expression BEFORE it reaches the
+        // recursive WAVE parser (`parse_raw_func_call` below), which would
+        // otherwise overflow the host stack and abort the node — a deterministic
+        // rejection here keeps that a normal failed op instead.
+        validate_expr(expr)?;
         let contract_id = self
             .storage
             .contract_id(contract_address)
@@ -126,6 +131,9 @@ impl Runtime {
         let (call, func) = if let Some(func) = instance.get_func(&mut store, call.name()) {
             (call, func)
         } else if let Some(func) = instance.get_func(&mut store, fallback_name) {
+            // The fallback wraps the whole expr as one string arg (~2× after
+            // escaping), so it too must clear the limit before being parsed.
+            validate_expr(&fallback_expr)?;
             (
                 WaveParser::new(&fallback_expr)
                     .parse_raw_func_call()
@@ -675,5 +683,125 @@ fn classify_result(result: &Result<String, ExecutionError>) -> OpStatus {
             }
         }
         Err(ExecutionError::NonDeterministic(_)) => OpStatus::Other,
+    }
+}
+
+/// Max bytes for a single STRING LITERAL in a call expression. The WAVE parser
+/// (`parse_raw_func_call`) recurses ~per character through a string literal,
+/// overflowing the host stack (~32k chars on the default ~2MB thread stack —
+/// measured). Bound well under that. This is NOT a cap on total expr size: a
+/// long `list<u8>` (binary args, e.g. a filestorage proof) parses *iteratively*
+/// and is safe at any size — only string literals recurse. Total size stays
+/// bounded by the tx/witness limits at consensus.
+///
+/// CONSENSUS-LOAD-BEARING: this deterministically rejects ops, so changing it is a
+/// consensus change — nodes on different values would disagree on op validity and
+/// fork. Treat like the checkpoint format; only change behind a coordinated upgrade.
+const MAX_STRING_LITERAL_BYTES: usize = 16 * 1024;
+
+/// Max structural nesting (`(`/`[`/`{`) of a call expression. The other recursion
+/// axis: a short but deeply nested expr recurses per level (bigger frames) and
+/// overflows at a few thousand levels. 64 is far beyond any real call and far
+/// below the overflow depth. CONSENSUS-LOAD-BEARING — see `MAX_STRING_LITERAL_BYTES`.
+const MAX_EXPR_DEPTH: usize = 64;
+
+/// Deterministically reject a call expression that would overflow the recursive
+/// WAVE parser — along its two recursion axes: an over-long string literal, or
+/// over-deep structural nesting. One O(n) non-recursive pass; bracket/quote bytes
+/// inside a string literal are data, not structure. Deterministic (pure function
+/// of the bytes) → a uniform failed op on every node, never a host-stack abort.
+fn validate_expr(expr: &str) -> Result<(), ExecutionError> {
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut str_len = 0usize;
+    for &b in expr.as_bytes() {
+        if in_string {
+            if escaped {
+                escaped = false;
+                str_len += 1;
+            } else if b == b'\\' {
+                escaped = true;
+                str_len += 1;
+            } else if b == b'"' {
+                in_string = false; // closing quote
+            } else {
+                str_len += 1;
+            }
+            if in_string && str_len > MAX_STRING_LITERAL_BYTES {
+                return Err(ExecutionError::Deterministic(anyhow!(
+                    "call expression string literal too large (max {MAX_STRING_LITERAL_BYTES} bytes)"
+                )));
+            }
+        } else {
+            match b {
+                b'"' => {
+                    in_string = true;
+                    str_len = 0;
+                }
+                b'(' | b'[' | b'{' => {
+                    depth += 1;
+                    if depth > MAX_EXPR_DEPTH {
+                        return Err(ExecutionError::Deterministic(anyhow!(
+                            "call expression nested too deeply (max {MAX_EXPR_DEPTH})"
+                        )));
+                    }
+                }
+                b')' | b']' | b'}' => depth = depth.saturating_sub(1),
+                _ => {}
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod expr_limit_tests {
+    use super::{MAX_EXPR_DEPTH, MAX_STRING_LITERAL_BYTES, validate_expr};
+
+    #[test]
+    fn accepts_normal_expr() {
+        assert!(validate_expr("transfer(signer-id(2), 100)").is_ok());
+        assert!(validate_expr("noop()").is_ok());
+    }
+
+    #[test]
+    fn accepts_long_list_arg() {
+        // A big binary arg (e.g. a filestorage proof) is a `list<u8>` — parsed
+        // iteratively, safe at any size. Must NOT be rejected.
+        let elems = (0..60_000).map(|_| "1").collect::<Vec<_>>().join(", ");
+        assert!(validate_expr(&format!("f([{elems}])")).is_ok());
+    }
+
+    #[test]
+    fn rejects_oversized_string_arg() {
+        // The exact shape that overflows the parser today.
+        let big = format!("f(\"{}\")", "a".repeat(MAX_STRING_LITERAL_BYTES + 1));
+        assert!(validate_expr(&big).is_err());
+    }
+
+    #[test]
+    fn rejects_deep_nesting() {
+        let deep = format!(
+            "f({}{})",
+            "[".repeat(MAX_EXPR_DEPTH + 1),
+            "]".repeat(MAX_EXPR_DEPTH + 1)
+        );
+        assert!(validate_expr(&deep).is_err());
+    }
+
+    #[test]
+    fn brackets_inside_strings_are_data_not_depth() {
+        // A string packed with brackets is content, not structure — must pass.
+        let s = format!("f(\"{}\")", "[".repeat(1000));
+        assert!(validate_expr(&s).is_ok());
+    }
+
+    #[test]
+    fn escaped_quote_does_not_end_string() {
+        // The escaped quote must not be read as the closer (else the trailing
+        // brackets would be miscounted as real nesting).
+        let s = format!("f(\"a\\\"{}\")", "[".repeat(1000));
+        assert!(validate_expr(&s).is_ok());
     }
 }

--- a/core/indexer/src/runtime/fuel.rs
+++ b/core/indexer/src/runtime/fuel.rs
@@ -27,7 +27,11 @@ pub enum Fuel {
     Exists,
     Get(usize),
     Set(u64),
-    DeleteMatchingPaths(u64),
+    /// A subtree delete (tombstone or hard delete), metered by what it removes:
+    /// `(rows, bytes)`. A flat per-call fee would let a cheap call tombstone an
+    /// arbitrarily large subtree on every node, so the cost scales with both the
+    /// row count and the bytes freed (`path.len() + value size`).
+    Delete(u64, u64),
     ContractAddress,
     ProcSigner,
     ProcPayer,
@@ -80,7 +84,7 @@ pub enum Fuel {
     Result(u64),
     // TODO: recalibrate with the rest of the Fuel table against measured
     // benchmarks. Currently sized to match other non-zk "non-trivial"
-    // operations (DeleteMatchingPaths, ProofFromBytes base cost).
+    // operations (Delete, ProofFromBytes base cost).
     RegisterBlsKey,
 }
 
@@ -118,7 +122,7 @@ impl Fuel {
             Self::Exists => 50,
             Self::ExtendPathWithMatch(regexp_len) => 500 + 10 * regexp_len,
             Self::Set(value_len) | Self::Result(value_len) => 200 + 10 * value_len,
-            Self::DeleteMatchingPaths(regexp_len) => 1000 + 10 * regexp_len,
+            Self::Delete(rows, bytes) => 200 + 200 * rows + 10 * bytes,
             Self::ContractAddress => 100,
             Self::ProcSigner | Self::ProcContractSigner | Self::ProcTransaction => 500,
             Self::ProcPayer | Self::ProcContract => 500,

--- a/core/indexer/src/runtime/host_storage.rs
+++ b/core/indexer/src/runtime/host_storage.rs
@@ -123,12 +123,19 @@ impl Runtime {
         candidates: Vec<Vec<u8>>,
     ) -> Result<u64> {
         validate_path(&base_path)?;
-        Fuel::DeleteMatchingPaths(candidates.len() as u64)
+        let contract_id = self.table.lock().await.get(&self_)?.get_contract_id();
+        // Read → meter → write: charge in proportion to the rows actually removed,
+        // not a flat per-candidate fee.
+        let rows = self
+            .storage
+            .find_matching_paths(contract_id, &base_path, &candidates)
+            .await?;
+        let bytes: u64 = rows.iter().map(|r| r.path.len() as u64 + r.size).sum();
+        Fuel::Delete(rows.len() as u64, bytes)
             .consume(accessor, self.gauge.as_ref())
             .await?;
-        let contract_id = self.table.lock().await.get(&self_)?.get_contract_id();
         self.storage
-            .delete_matching_paths(contract_id, &base_path, &candidates)
+            .hard_delete_matching_paths(contract_id, &base_path, &candidates)
             .await
     }
 
@@ -141,9 +148,16 @@ impl Runtime {
         path: Vec<u8>,
     ) -> Result<bool> {
         validate_path(&path)?;
-        Fuel::Set(0).consume(accessor, self.gauge.as_ref()).await?;
         let contract_id = self.table.lock().await.get(&self_)?.get_contract_id();
-        self.storage.delete(contract_id, &path).await
+        // Read → meter → write. A flat `Set(0)` charged the same whether the
+        // subtree held one row or thousands; meter by the rows/bytes tombstoned.
+        let rows = self.storage.find_live_subtree(contract_id, &path).await?;
+        let bytes: u64 = rows.iter().map(|r| r.path.len() as u64 + r.size).sum();
+        Fuel::Delete(rows.len() as u64, bytes)
+            .consume(accessor, self.gauge.as_ref())
+            .await?;
+        let (removed, _freed) = self.storage.tombstone_rows(contract_id, &rows).await?;
+        Ok(removed)
     }
 
     pub(crate) async fn _set_primitive<S, T: HasContractId, V: Serialize>(

--- a/core/indexer/src/runtime/storage.rs
+++ b/core/indexer/src/runtime/storage.rs
@@ -11,11 +11,12 @@ use wit_component::{ComponentEncoder, WitPrinter};
 use crate::{
     database::{
         queries::{
-            create_contract_signer, delete_contract_state, delete_matching_paths,
-            exists_contract_state, get_contract_address_from_id, get_contract_bytes_by_id,
-            get_contract_id_from_address, get_latest_contract_state_value, insert_contract,
-            insert_contract_result, insert_contract_state, matching_path,
-            path_prefix_filter_contract_state, prune_contract_state, select_block_at_height,
+            DeletableRow, create_contract_signer, exists_contract_state, find_live_subtree,
+            find_matching_paths, get_contract_address_from_id, get_contract_bytes_by_id,
+            get_contract_id_from_address, get_latest_contract_state_value,
+            hard_delete_matching_paths, insert_contract, insert_contract_result,
+            insert_contract_state, matching_path, path_prefix_filter_contract_state,
+            prune_contract_state, select_block_at_height, tombstone_rows,
         },
         types::{ContractResultRow, ContractRow, ContractStateRow},
     },
@@ -90,13 +91,27 @@ impl Storage {
         Ok(())
     }
 
-    pub async fn delete(&self, contract_id: u64, path: &[u8]) -> Result<bool> {
-        Ok(delete_contract_state(
+    /// The live subtree a [`Self::tombstone_rows`] would remove — read first so
+    /// the caller can charge fuel for the rows before writing tombstones.
+    pub async fn find_live_subtree(
+        &self,
+        contract_id: u64,
+        path: &[u8],
+    ) -> Result<Vec<DeletableRow>> {
+        Ok(find_live_subtree(&self.conn, contract_id, path).await?)
+    }
+
+    pub async fn tombstone_rows(
+        &self,
+        contract_id: u64,
+        rows: &[DeletableRow],
+    ) -> Result<(bool, u64)> {
+        Ok(tombstone_rows(
             &self.conn,
+            contract_id,
             self.height,
             self.effective_tx_id(),
-            contract_id,
-            path,
+            rows,
         )
         .await?)
     }
@@ -117,14 +132,25 @@ impl Storage {
         Ok(matching_path(&self.conn, contract_id, base_path, candidates).await?)
     }
 
-    pub async fn delete_matching_paths(
+    /// The current-height rows a [`Self::hard_delete_matching_paths`] would
+    /// remove — read first so the caller can meter the delete.
+    pub async fn find_matching_paths(
+        &self,
+        contract_id: u64,
+        base_path: &[u8],
+        candidates: &[Vec<u8>],
+    ) -> Result<Vec<DeletableRow>> {
+        Ok(find_matching_paths(&self.conn, contract_id, self.height, base_path, candidates).await?)
+    }
+
+    pub async fn hard_delete_matching_paths(
         &self,
         contract_id: u64,
         base_path: &[u8],
         candidates: &[Vec<u8>],
     ) -> Result<u64> {
         Ok(
-            delete_matching_paths(&self.conn, contract_id, self.height, base_path, candidates)
+            hard_delete_matching_paths(&self.conn, contract_id, self.height, base_path, candidates)
                 .await?,
         )
     }

--- a/core/indexer/src/runtime/storage.rs
+++ b/core/indexer/src/runtime/storage.rs
@@ -140,7 +140,10 @@ impl Storage {
         base_path: &[u8],
         candidates: &[Vec<u8>],
     ) -> Result<Vec<DeletableRow>> {
-        Ok(find_matching_paths(&self.conn, contract_id, self.height, base_path, candidates).await?)
+        Ok(
+            find_matching_paths(&self.conn, contract_id, self.height, base_path, candidates)
+                .await?,
+        )
     }
 
     pub async fn hard_delete_matching_paths(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Consensus-load-bearing expr limits and fuel metering for deletes change which ops succeed and how much gas they cost; nodes must agree on both.
> 
> **Overview**
> **Subtree deletes** are split into read → meter → write so fuel scales with rows removed and bytes freed (`path.len() + value size`), instead of flat per-call fees. Tombstone writes are **value-less** marker rows; variant cleanup uses **`hard_delete_matching_paths`** with a shared clause so metering and deletes target the same rows.
> 
> **Call expressions** are validated before the recursive WAVE parser: caps on string literal size (16 KiB) and structural depth (64). Oversized or over-nested exprs fail as deterministic ops rather than host stack overflow. Limits are **consensus-load-bearing**.
> 
> Minor lockfile updates (`quinn-proto` 0.11.15).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b824b8ed115e01cd9b0dea05795e82593122fa07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->