### PR TITLE
Split the view/core fuel limits: operator-configurable view cap + uncapped core-signer calls

### DIFF
--- a/core/indexer/src/api/env.rs
+++ b/core/indexer/src/api/env.rs
@@ -67,6 +67,7 @@ impl Env {
                 db_path.to_path_buf(),
                 db_name,
                 bitcoin::Network::Regtest,
+                crate::config::DEFAULT_VIEW_GAS_LIMIT,
             )
             .await?,
             reader,

--- a/core/indexer/src/config.rs
+++ b/core/indexer/src/config.rs
@@ -7,6 +7,10 @@ use serde::{Deserialize, Serialize};
 use crate::consensus::signing::ConsensusMode;
 use crate::logging;
 
+/// Default per-call gas budget for read-only `/view` queries. Matches the runtime's
+/// fixed non-proc default, so the out-of-the-box pool behaves exactly as before.
+pub const DEFAULT_VIEW_GAS_LIMIT: u64 = 100_000;
+
 #[derive(Debug, Clone, Serialize, Deserialize, Parser)]
 pub struct Config {
     #[clap(
@@ -161,6 +165,22 @@ pub struct Config {
         help = "Blocks below tip to retain before pruning (default 144 ≈ 1 day of Bitcoin blocks)"
     )]
     pub prune_retain_blocks: u64,
+
+    // --- Read serving ---
+    /// Per-call gas budget for read-only `/view` queries served by this node's
+    /// runtime pool. NON-consensus: a `/view` read never enters a block, so nodes
+    /// may set different caps without diverging. Lean validators keep the default;
+    /// a read/archive node serving heavy queries (leaderboards, large scans) raises
+    /// it. Applies ONLY to the read-only pool's runtimes — never to a view
+    /// cross-called inside a consensus procedure, which keeps the fixed consensus
+    /// limit (the pool builds separate `Runtime` instances from the reactor's).
+    #[clap(
+        long,
+        env = "VIEW_GAS_LIMIT",
+        default_value_t = DEFAULT_VIEW_GAS_LIMIT,
+        help = "Per-call gas budget for read-only /view queries (default 100000; raise on read/archive nodes)"
+    )]
+    pub view_gas_limit: u64,
 }
 
 impl Config {
@@ -185,6 +205,7 @@ impl Config {
             consensus_propose_timeout_ms: 10000,
             prune: true,
             prune_retain_blocks: 144,
+            view_gas_limit: DEFAULT_VIEW_GAS_LIMIT,
         }
     }
 }

--- a/core/indexer/src/main.rs
+++ b/core/indexer/src/main.rs
@@ -235,6 +235,7 @@ async fn run_daemon(config: Config) -> Result<()> {
                     config.data_dir.clone(),
                     filename.to_string(),
                     config.network,
+                    config.view_gas_limit,
                 )
                 .await?,
                 simulate_tx,

--- a/core/indexer/src/runtime/call.rs
+++ b/core/indexer/src/runtime/call.rs
@@ -186,7 +186,26 @@ impl Runtime {
                 {
                     is_proc = true;
                     if self.stack.is_empty().await {
-                        fuel_limit = self.fuel_limit_for_non_procs();
+                        // Core calls are trusted, system-paid consensus block-processing
+                        // (per-block hooks, issuance, etc.) — they MUST complete for the
+                        // block to advance and have no revert-and-continue semantics. So
+                        // they are effectively NOT metered: fuel metering is a DoS/economic
+                        // control for UNTRUSTED user ops, a category error for trusted
+                        // system work, and the old fixed 100k cap would eventually
+                        // false-halt a healthy network on legitimate growth. (Safe: a core
+                        // call runs in the block savepoint and commits-or-rolls-back, so an
+                        // over-budget hang can only stall a node a height behind — never
+                        // fork committed state — and core fuel never enters the checkpoint
+                        // hash. `gas_consumed` is a start−end difference, so it still
+                        // records true usage.)
+                        //
+                        // NOT u64::MAX: the remaining fuel is bound into the storage read
+                        // path as a SQL i64 size-budget (`CASE WHEN size <= :fuel`,
+                        // contract_state.rs), so it must fit in i64. CORE_CALL_FUEL_CEILING
+                        // is i64-safe and ~10^7× the old limit — unreachable by any
+                        // legitimate per-block work, so it only ever fires as a clean
+                        // deterministic halt on a genuine non-terminating bug.
+                        fuel_limit = CORE_CALL_FUEL_CEILING;
                         store
                             .set_fuel(fuel_limit)
                             .expect("Failed to set fuel for core context procedure");
@@ -750,6 +769,17 @@ const MAX_STRING_LITERAL_BYTES: usize = 16 * 1024;
 /// overflows at a few thousand levels. 64 is far beyond any real call and far
 /// below the overflow depth. CONSENSUS-LOAD-BEARING — see `MAX_STRING_LITERAL_BYTES`.
 const MAX_EXPR_DEPTH: usize = 64;
+
+/// Effective "unmetered" fuel budget for trusted, must-complete CORE calls (per-block
+/// hooks, issuance, genesis) — see the top-of-stack core branch in `prepare_call`.
+/// ~10^7× the old 100k-gas non-proc cap, so it's unreachable by any legitimate
+/// per-block work (it only ever fires as a clean deterministic halt on a genuine
+/// non-terminating bug). NOT `u64::MAX`: remaining fuel is bound into the storage read
+/// path as a SQL i64 size-budget, so this MUST stay within i64 range (with headroom for
+/// any `× gas_to_fuel_multiplier`). CONSENSUS-LOAD-BEARING — all nodes must share the
+/// value (a node with a lower budget would stall on a block others commit); change only
+/// behind a coordinated upgrade.
+const CORE_CALL_FUEL_CEILING: u64 = 1_000_000_000_000_000; // 1e15 fuel = 1e12 gas
 
 /// Deterministically reject a call expression that would overflow the recursive
 /// WAVE parser — along its two recursion axes: an over-long string literal, or

--- a/core/indexer/src/runtime/call.rs
+++ b/core/indexer/src/runtime/call.rs
@@ -93,7 +93,10 @@ impl Runtime {
             Some(f) => f,
             None => match payment {
                 Some(p) => p.gas_limit * self.gas_to_fuel_multiplier,
-                None => self.fuel_limit_for_non_procs(),
+                // payment-`None` is a read-only `/view` call → the operator-configurable
+                // view cap, NOT the consensus core-call budget (the Core-context
+                // procedure path keeps `fuel_limit_for_non_procs`).
+                None => self.fuel_limit_for_view(),
             },
         };
         let mut store = self

--- a/core/indexer/src/runtime/mod.rs
+++ b/core/indexer/src/runtime/mod.rs
@@ -223,7 +223,17 @@ pub struct Runtime {
     /// start, drained at the settle boundary to compute the execution burn
     /// (`burn = gas - charge`).
     pub deposit: DepositMeter,
+    /// Fuel budget for non-procedure work that IS consensus-relevant: top-level
+    /// core-signer/system procedures (`call.rs` Core-context path) and native-api
+    /// (`execute_api`/`core_payment`) calls. FIXED — never operator-configurable, so
+    /// all nodes meter core calls identically.
     pub gas_limit_for_non_procs: u64,
+    /// Fuel budget for read-only `/view` calls (the payment-`None` path) ONLY.
+    /// Operator-configurable per node (set from `Config::view_gas_limit` on the
+    /// read-only pool runtime; left at the default on the reactor's consensus runtime,
+    /// where views don't run). DELIBERATELY SEPARATE from `gas_limit_for_non_procs` so
+    /// an operator's view cap can NEVER starve consensus core calls.
+    pub view_gas_limit: u64,
     pub gas_to_fuel_multiplier: u64,
     pub gas_to_token_multiplier: Decimal,
     pub previous_output: Option<bitcoin::OutPoint>,
@@ -303,6 +313,9 @@ impl Runtime {
             gauge: Some(FuelGauge::new()),
             deposit: DepositMeter::new(),
             gas_limit_for_non_procs: 100_000,
+            // Default matches gas_limit_for_non_procs (preserves prior /view behavior);
+            // the pool overrides this from node config, the reactor leaves it as-is.
+            view_gas_limit: 100_000,
             gas_to_fuel_multiplier: 1_000,
             gas_to_token_multiplier: Decimal::from("1e-9"),
             previous_output: None,
@@ -372,6 +385,12 @@ impl Runtime {
 
     pub fn fuel_limit_for_non_procs(&self) -> u64 {
         self.gas_limit_for_non_procs * self.gas_to_fuel_multiplier
+    }
+
+    /// Fuel budget for a read-only `/view` call (the operator-configurable cap),
+    /// distinct from the fixed consensus core-call budget above.
+    pub fn fuel_limit_for_view(&self) -> u64 {
+        self.view_gas_limit * self.gas_to_fuel_multiplier
     }
 
     /// Build a Payment for system (Core-paid) operations.

--- a/core/indexer/src/runtime/pool.rs
+++ b/core/indexer/src/runtime/pool.rs
@@ -73,11 +73,11 @@ impl managed::Manager for Manager {
         .map_err(|e| RuntimeError::CreationFailed(e.to_string()))?;
         // Chain-identity constant, surfaced to contracts via `network()`.
         runtime.network = self.network;
-        // Operator-set `/view` budget. This is the ONLY place the view cap is applied,
-        // and only to pooled (read-only) runtimes — the reactor's consensus runtime is
-        // built separately and keeps the fixed `gas_limit_for_non_procs` default, so a
-        // view cross-called inside a consensus procedure stays deterministic.
-        runtime.gas_limit_for_non_procs = self.view_gas_limit;
+        // Operator-set `/view` budget. Sets ONLY `view_gas_limit` (the read-only view
+        // path), never `gas_limit_for_non_procs` (the consensus core-call budget) — so
+        // an operator can't starve core calls no matter how low they set this, and it
+        // only ever applies to pooled read-only runtimes anyway.
+        runtime.view_gas_limit = self.view_gas_limit;
         Ok(runtime)
     }
 
@@ -119,12 +119,12 @@ mod tests {
     use deadpool::managed::Manager as _; // brings the `create` trait method into scope
     use tempfile::TempDir;
 
-    // The operator's view gas cap applies to POOLED (read-only) runtimes only; the
-    // consensus runtime (built directly, not via the pool) keeps the fixed non-proc
-    // limit — so a view cross-called inside a procedure stays deterministic no matter
-    // what an operator sets for /view.
+    // The operator's view cap sets ONLY `view_gas_limit`, and only on pooled
+    // (read-only) runtimes. It must NEVER touch `gas_limit_for_non_procs` — the
+    // consensus core-call budget — so a too-low view cap can only break views, never
+    // starve core calls / affect consensus.
     #[tokio::test]
-    async fn view_gas_limit_applies_to_pool_runtime_not_consensus() -> anyhow::Result<()> {
+    async fn view_cap_is_decoupled_from_core_call_budget() -> anyhow::Result<()> {
         let dir = TempDir::new()?;
         let custom = 9_000_000u64;
         assert_ne!(
@@ -139,20 +139,23 @@ mod tests {
             custom,
         )?;
         let pooled = pool.create().await.map_err(|e| anyhow::anyhow!("{e}"))?;
+        // The view cap moved...
         assert_eq!(
-            pooled.gas_limit_for_non_procs, custom,
-            "pooled /view runtime must use the operator-configured cap"
+            pooled.view_gas_limit, custom,
+            "pooled /view runtime must use the operator-configured view cap"
+        );
+        // ...but the consensus core-call budget did NOT, even on the pool runtime.
+        assert_eq!(
+            pooled.gas_limit_for_non_procs, DEFAULT_VIEW_GAS_LIMIT,
+            "the view cap must not touch the core-call budget"
         );
 
-        // Consensus path: a Runtime built directly is untouched by the view cap.
+        // Consensus path: a directly-built Runtime is untouched on both fields.
         let conn = new_connection(dir.path(), "consensus.db").await?;
         let consensus =
             Runtime::new(ComponentCache::new(), Storage::builder().conn(conn).build()).await?;
-        assert_eq!(
-            consensus.gas_limit_for_non_procs, DEFAULT_VIEW_GAS_LIMIT,
-            "consensus runtime must keep the fixed non-proc limit, not the view cap"
-        );
-        assert_ne!(consensus.gas_limit_for_non_procs, custom);
+        assert_eq!(consensus.gas_limit_for_non_procs, DEFAULT_VIEW_GAS_LIMIT);
+        assert_eq!(consensus.view_gas_limit, DEFAULT_VIEW_GAS_LIMIT);
         Ok(())
     }
 }

--- a/core/indexer/src/runtime/pool.rs
+++ b/core/indexer/src/runtime/pool.rs
@@ -25,6 +25,10 @@ pub struct Manager {
     linkers: Linkers,
     component_cache: ComponentCache,
     network: bitcoin::Network,
+    /// Operator-set per-call gas budget for `/view` reads served by this pool.
+    /// Applied to each pooled runtime in `create`; the reactor's consensus runtime
+    /// is a separate instance and keeps the fixed consensus limit.
+    view_gas_limit: u64,
 }
 
 impl Manager {
@@ -32,6 +36,7 @@ impl Manager {
         data_dir: PathBuf,
         filename: String,
         network: bitcoin::Network,
+        view_gas_limit: u64,
     ) -> anyhow::Result<Self> {
         let engine = Runtime::new_engine()?;
         let linkers = Runtime::new_linkers(&engine)?;
@@ -42,6 +47,7 @@ impl Manager {
             linkers,
             component_cache: ComponentCache::new(),
             network,
+            view_gas_limit,
         })
     }
 }
@@ -67,6 +73,11 @@ impl managed::Manager for Manager {
         .map_err(|e| RuntimeError::CreationFailed(e.to_string()))?;
         // Chain-identity constant, surfaced to contracts via `network()`.
         runtime.network = self.network;
+        // Operator-set `/view` budget. This is the ONLY place the view cap is applied,
+        // and only to pooled (read-only) runtimes — the reactor's consensus runtime is
+        // built separately and keeps the fixed `gas_limit_for_non_procs` default, so a
+        // view cross-called inside a consensus procedure stays deterministic.
+        runtime.gas_limit_for_non_procs = self.view_gas_limit;
         Ok(runtime)
     }
 
@@ -92,9 +103,56 @@ pub async fn new(
     data_dir: PathBuf,
     filename: String,
     network: bitcoin::Network,
+    view_gas_limit: u64,
 ) -> anyhow::Result<Pool<Manager>> {
-    Pool::builder(Manager::new(data_dir, filename, network)?)
+    Pool::builder(Manager::new(data_dir, filename, network, view_gas_limit)?)
         .max_size(std::thread::available_parallelism()?.into())
         .build()
         .context("Failed to build runtime pool")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::DEFAULT_VIEW_GAS_LIMIT;
+    use crate::runtime::Storage;
+    use deadpool::managed::Manager as _; // brings the `create` trait method into scope
+    use tempfile::TempDir;
+
+    // The operator's view gas cap applies to POOLED (read-only) runtimes only; the
+    // consensus runtime (built directly, not via the pool) keeps the fixed non-proc
+    // limit — so a view cross-called inside a procedure stays deterministic no matter
+    // what an operator sets for /view.
+    #[tokio::test]
+    async fn view_gas_limit_applies_to_pool_runtime_not_consensus() -> anyhow::Result<()> {
+        let dir = TempDir::new()?;
+        let custom = 9_000_000u64;
+        assert_ne!(
+            custom, DEFAULT_VIEW_GAS_LIMIT,
+            "test needs a non-default cap"
+        );
+
+        let pool = Manager::new(
+            dir.path().to_path_buf(),
+            "view_cap.db".into(),
+            bitcoin::Network::Regtest,
+            custom,
+        )?;
+        let pooled = pool.create().await.map_err(|e| anyhow::anyhow!("{e}"))?;
+        assert_eq!(
+            pooled.gas_limit_for_non_procs, custom,
+            "pooled /view runtime must use the operator-configured cap"
+        );
+
+        // Consensus path: a Runtime built directly is untouched by the view cap.
+        let conn = new_connection(dir.path(), "consensus.db").await?;
+        let consensus =
+            Runtime::new(ComponentCache::new(), Storage::builder().conn(conn).build()).await?;
+        assert_eq!(
+            consensus.gas_limit_for_non_procs, DEFAULT_VIEW_GAS_LIMIT,
+            "consensus runtime must keep the fixed non-proc limit, not the view cap"
+        );
+        assert_ne!(consensus.gas_limit_for_non_procs, custom);
+        Ok(())
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Introduces a consensus-load-bearing `CORE_CALL_FUEL_CEILING` for trusted core block work; all validators must agree on that constant or nodes could diverge on block processing.
> 
> **Overview**
> **Read path:** `/view` calls with no payment now meter against a separate **`view_gas_limit`** (CLI/env `VIEW_GAS_LIMIT`, default 100k), applied only on the **read-only runtime pool**—not on the reactor’s consensus runtime. **`gas_limit_for_non_procs`** stays fixed for consensus-relevant native/core API metering.
> 
> **Consensus path:** Top-level **Core-context** procedures (per-block hooks, issuance, etc.) no longer reuse the 100k non-proc cap; they get **`CORE_CALL_FUEL_CEILING`** (~1e15 fuel, i64-safe for storage SQL budgets). Nested core calls still inherit parent fuel.
> 
> A pool unit test asserts a high view cap updates **`view_gas_limit`** only and does not change **`gas_limit_for_non_procs`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aada50b862ff21a940f99faf6c9adbe4d14574f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->