### PR TITLE
deps: depend on published kontor-crypto 0.3.0 (drop git-pin)

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -4063,7 +4063,8 @@ dependencies = [
 [[package]]
 name = "kontor-crypto"
 version = "0.3.0"
-source = "git+https://github.com/KontorProtocol/Kontor-Crypto?rev=137bb9ea224bffd43c90f19b8f8918c32646bad8#137bb9ea224bffd43c90f19b8f8918c32646bad8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2626a13dfce013c1d6d09af424212b8f7801943334a6fa8621abe3fa75b2f658"
 dependencies = [
  "bincode",
  "blake2b_simd",
@@ -4089,7 +4090,8 @@ dependencies = [
 [[package]]
 name = "kontor-crypto-core"
 version = "0.2.0"
-source = "git+https://github.com/KontorProtocol/Kontor-Crypto?rev=137bb9ea224bffd43c90f19b8f8918c32646bad8#137bb9ea224bffd43c90f19b8f8918c32646bad8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c69296ba68591d88f4e9339c09e528488d0d8bcb20b2fd4cf75e835091f29d2"
 dependencies = [
  "blake2b_simd",
  "constant_time_eq 0.3.1",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -98,11 +98,6 @@ arc-malachitebft-wal = { git = "https://github.com/KontorProtocol/malachite", re
 # onto specific WIT record fields/types. Drop once upstreamed (rust-lang/wit-bindgen).
 [patch.crates-io]
 wit-bindgen-rust = { git = "https://github.com/wilfreddenton/wit-bindgen", rev = "2a872647adb6adec4dcd7c0504e73d3b26acb241" }
-# Stateless PoR verification (verify_stateless / aggregate_root) for the in-contract
-# file registry. Pinned to the feat/stateless-verify branch rev pending its merge to
-# Kontor-Crypto main; repoint to a main rev (or a release) once that lands.
-kontor-crypto = { git = "https://github.com/KontorProtocol/Kontor-Crypto", rev = "137bb9ea224bffd43c90f19b8f8918c32646bad8" }
-kontor-crypto-core = { git = "https://github.com/KontorProtocol/Kontor-Crypto", rev = "137bb9ea224bffd43c90f19b8f8918c32646bad8" }
 wit-bindgen-rust-macro = { git = "https://github.com/wilfreddenton/wit-bindgen", rev = "2a872647adb6adec4dcd7c0504e73d3b26acb241" }
 
 # Optimize the proof-system crates even in dev/test builds. Proof


### PR DESCRIPTION
Now that kontor-crypto 0.3.0 is published to crates.io, drop the `[patch.crates-io]` git-pin (added before the publish, when #483 needed to build against the unpublished crate) and resolve from the registry instead. No code change — `Cargo.lock` re-sources `kontor-crypto`/`kontor-crypto-core` from crates.io; builds clean. Completes the post-publish cleanup of the constant-size + stateless work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency sourcing-only change with no logic edits; risk is limited to whether the published crate matches the previously pinned git revision.
> 
> **Overview**
> Removes the temporary **`[patch.crates-io]`** git pins for `kontor-crypto` and `kontor-crypto-core` (and their explanatory comment) now that **0.3.0** is on crates.io. **`Cargo.lock`** is updated so those crates resolve from the registry with checksums instead of a pinned Kontor-Crypto git rev.
> 
> **Dev profile** `opt-level = 3` overrides for `kontor-crypto` / `kontor-crypto-core` are unchanged. No application or library source changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 605e0cf873db617d65b0b4f061d9c46a0746f3f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->