### PR TITLE
kill the flaky "identity must be registered" regtest cluster panic (poll for signer id; surface non-404 read errors

### DIFF
--- a/core/indexer/src/api/client.rs
+++ b/core/indexer/src/api/client.rs
@@ -222,4 +222,19 @@ impl Client {
         )
         .await
     }
+
+    /// Like `signer`, but `None` on 404 (identity genuinely not registered / not yet
+    /// indexed) — so a caller can distinguish "absent" from a transport/5xx failure,
+    /// which still surfaces as an error rather than masquerading as "not registered".
+    pub async fn signer_opt(&self, identifier: &str) -> Result<Option<SignerResponse>> {
+        let res = self
+            .client
+            .get(format!("{}/signers/{}", &self.url, identifier))
+            .send()
+            .await?;
+        if res.status() == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        Self::handle_response(res).await.map(Some)
+    }
 }

--- a/core/indexer/src/reg_tester.rs
+++ b/core/indexer/src/reg_tester.rs
@@ -776,6 +776,19 @@ impl RegTester {
         }
     }
 
+    /// Resolve the signer id of an identity that is KNOWN to be registered (e.g. one
+    /// popped from the registered pool, whose `RegisterBlsKey` was confirmed at setup),
+    /// polling until it's queryable rather than a single shot. A transient miss — the
+    /// queried node briefly behind on indexing the registration, or a 503 under load
+    /// (`require_available`) — means "ask again," not "not registered." Mirrors
+    /// `wait_for_available`'s use of the extended retry budget; surfaces a real error
+    /// only if it never resolves. (Use `get_signer_id` instead when a `None`/absent
+    /// answer is itself the thing under test.)
+    pub async fn wait_for_signer_id(&self, xonly: &str) -> Result<u64> {
+        let client = self.kontor_client().await;
+        retry_extended(async || Ok::<_, anyhow::Error>(client.signer(xonly).await?.signer_id)).await
+    }
+
     pub async fn get_bls_pubkey(&self, xonly: &str) -> Result<Option<Vec<u8>>> {
         match self.kontor_client().await.signer(xonly).await {
             Ok(entry) => Ok(entry.bls_pubkey),

--- a/core/indexer/src/reg_tester.rs
+++ b/core/indexer/src/reg_tester.rs
@@ -769,11 +769,17 @@ impl RegTester {
         self.inner.lock().await.kontor_client.clone()
     }
 
+    /// `Some` if registered, `None` if genuinely not registered (404). A transport/5xx
+    /// failure SURFACES as an error instead of being swallowed as `None` — so a flaky
+    /// node read can't masquerade as "not registered". (For a known-registered identity
+    /// that may just be lagging, use `wait_for_signer_id`, which polls.)
     pub async fn get_signer_id(&self, xonly: &str) -> Result<Option<u64>> {
-        match self.kontor_client().await.signer(xonly).await {
-            Ok(entry) => Ok(Some(entry.signer_id)),
-            Err(_) => Ok(None),
-        }
+        Ok(self
+            .kontor_client()
+            .await
+            .signer_opt(xonly)
+            .await?
+            .map(|entry| entry.signer_id))
     }
 
     /// Resolve the signer id of an identity that is KNOWN to be registered (e.g. one

--- a/core/testlib/src/lib.rs
+++ b/core/testlib/src/lib.rs
@@ -558,11 +558,14 @@ impl RuntimeRegtest {
 impl RuntimeImpl for RuntimeRegtest {
     async fn identity(&mut self) -> Result<Signer> {
         let identity = self.reg_tester.identity().await?;
+        // The identity comes from the registered pool (its RegisterBlsKey was confirmed
+        // at setup), so poll until the signer is queryable rather than racing a single
+        // query against indexing/availability lag under load — the source of a flaky
+        // "identity must be registered" panic.
         let signer_id = self
             .reg_tester
-            .get_signer_id(&identity.x_only_public_key().to_string())
-            .await?
-            .expect("identity must be registered");
+            .wait_for_signer_id(&identity.x_only_public_key().to_string())
+            .await?;
         let signer = Signer::Id(indexer::database::types::Identity::new(signer_id));
         self.identities.insert(signer.clone(), identity);
         Ok(signer)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to the indexer API client and regtest/testlib harness; production node behavior is unchanged.
> 
> **Overview**
> Fixes flaky regtest **"identity must be registered"** panics when a pool identity’s `RegisterBlsKey` is confirmed but a single `/signers` read races indexing or availability lag under CI load.
> 
> The indexer HTTP client gains **`signer_opt`**, mirroring **`transaction`**: **404 → `None`**, while transport/5xx errors **propagate** instead of being read as absent. **`get_signer_id`** now uses that helper so only a real 404 means “not registered.”
> 
> For identities **known** to be registered (registered pool), **`wait_for_signer_id`** polls with the same **`retry_extended`** budget as **`wait_for_available`**. **`RuntimeRegtest::identity`** calls **`wait_for_signer_id`** instead of **`get_signer_id`** + **`expect`**, so transient misses retry instead of panicking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b898814b76b992b212f7e078496696f8d6d14348. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->