### PR TITLE
fix(runtime): harden view-pool recycle to discard stale-snapshot connections

### DIFF
--- a/core/indexer/src/api/client.rs
+++ b/core/indexer/src/api/client.rs
@@ -222,4 +222,19 @@ impl Client {
         )
         .await
     }
+
+    /// Like `signer`, but `None` on 404 (identity genuinely not registered / not yet
+    /// indexed) — so a caller can distinguish "absent" from a transport/5xx failure,
+    /// which still surfaces as an error rather than masquerading as "not registered".
+    pub async fn signer_opt(&self, identifier: &str) -> Result<Option<SignerResponse>> {
+        let res = self
+            .client
+            .get(format!("{}/signers/{}", &self.url, identifier))
+            .send()
+            .await?;
+        if res.status() == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        Self::handle_response(res).await.map(Some)
+    }
 }

--- a/core/indexer/src/reg_tester.rs
+++ b/core/indexer/src/reg_tester.rs
@@ -771,8 +771,7 @@ impl RegTester {
 
     /// `Some` if registered, `None` if genuinely not registered (404). A transport/5xx
     /// failure SURFACES as an error instead of being swallowed as `None` — so a flaky
-    /// node read can't masquerade as "not registered". (For a known-registered identity
-    /// that may just be lagging, use `wait_for_signer_id`, which polls.)
+    /// node read can't masquerade as "not registered".
     pub async fn get_signer_id(&self, xonly: &str) -> Result<Option<u64>> {
         Ok(self
             .kontor_client()
@@ -780,19 +779,6 @@ impl RegTester {
             .signer_opt(xonly)
             .await?
             .map(|entry| entry.signer_id))
-    }
-
-    /// Resolve the signer id of an identity that is KNOWN to be registered (e.g. one
-    /// popped from the registered pool, whose `RegisterBlsKey` was confirmed at setup),
-    /// polling until it's queryable rather than a single shot. A transient miss — the
-    /// queried node briefly behind on indexing the registration, or a 503 under load
-    /// (`require_available`) — means "ask again," not "not registered." Mirrors
-    /// `wait_for_available`'s use of the extended retry budget; surfaces a real error
-    /// only if it never resolves. (Use `get_signer_id` instead when a `None`/absent
-    /// answer is itself the thing under test.)
-    pub async fn wait_for_signer_id(&self, xonly: &str) -> Result<u64> {
-        let client = self.kontor_client().await;
-        retry_extended(async || Ok::<_, anyhow::Error>(client.signer(xonly).await?.signer_id)).await
     }
 
     pub async fn get_bls_pubkey(&self, xonly: &str) -> Result<Option<Vec<u8>>> {

--- a/core/indexer/src/reg_tester.rs
+++ b/core/indexer/src/reg_tester.rs
@@ -776,6 +776,19 @@ impl RegTester {
         }
     }
 
+    /// Resolve the signer id of an identity that is KNOWN to be registered (e.g. one
+    /// popped from the registered pool, whose `RegisterBlsKey` was confirmed at setup),
+    /// polling until it's queryable rather than a single shot. A transient miss — the
+    /// queried node briefly behind on indexing the registration, or a 503 under load
+    /// (`require_available`) — means "ask again," not "not registered." Mirrors
+    /// `wait_for_available`'s use of the extended retry budget; surfaces a real error
+    /// only if it never resolves. (Use `get_signer_id` instead when a `None`/absent
+    /// answer is itself the thing under test.)
+    pub async fn wait_for_signer_id(&self, xonly: &str) -> Result<u64> {
+        let client = self.kontor_client().await;
+        retry_extended(async || Ok::<_, anyhow::Error>(client.signer(xonly).await?.signer_id)).await
+    }
+
     pub async fn get_bls_pubkey(&self, xonly: &str) -> Result<Option<Vec<u8>>> {
         match self.kontor_client().await.signer(xonly).await {
             Ok(entry) => Ok(entry.bls_pubkey),

--- a/core/indexer/src/reg_tester.rs
+++ b/core/indexer/src/reg_tester.rs
@@ -769,11 +769,17 @@ impl RegTester {
         self.inner.lock().await.kontor_client.clone()
     }
 
+    /// `Some` if registered, `None` if genuinely not registered (404). A transport/5xx
+    /// failure SURFACES as an error instead of being swallowed as `None` — so a flaky
+    /// node read can't masquerade as "not registered". (For a known-registered identity
+    /// that may just be lagging, use `wait_for_signer_id`, which polls.)
     pub async fn get_signer_id(&self, xonly: &str) -> Result<Option<u64>> {
-        match self.kontor_client().await.signer(xonly).await {
-            Ok(entry) => Ok(Some(entry.signer_id)),
-            Err(_) => Ok(None),
-        }
+        Ok(self
+            .kontor_client()
+            .await
+            .signer_opt(xonly)
+            .await?
+            .map(|entry| entry.signer_id))
     }
 
     /// Resolve the signer id of an identity that is KNOWN to be registered (e.g. one

--- a/core/indexer/src/runtime/pool.rs
+++ b/core/indexer/src/runtime/pool.rs
@@ -1,8 +1,9 @@
 use std::path::PathBuf;
 
 use anyhow::Context;
-use deadpool::managed::{self, Pool, RecycleResult};
+use deadpool::managed::{self, Pool, RecycleError, RecycleResult};
 use thiserror::Error;
+use tracing::warn;
 use wasmtime::Engine;
 
 use crate::{
@@ -90,12 +91,26 @@ impl managed::Manager for Manager {
         // A view wraps its call in BEGIN…COMMIT; if `execute` returns early without
         // reaching the commit/rollback in `handle_call` (e.g. the spawned call task
         // fails to join), the connection goes back into the pool with an OPEN read
-        // transaction — pinning it to a stale WAL snapshot so every later view on it
-        // reads pre-commit state forever. Best-effort `ROLLBACK` (+ clearing the
-        // savepoint stack) makes every reused connection start from a fresh snapshot.
-        // Errors when no transaction is open, which is the normal case — ignore them.
+        // transaction — pinning it to a stale WAL snapshot so every later view (and
+        // `/signers` lookup, served from this same pool) on it reads pre-commit state.
+        // `ROLLBACK` (+ clearing the savepoint stack) restores a fresh snapshot; it
+        // errors harmlessly when nothing is open (the normal case), so ignore it here
+        // and verify the outcome below instead.
         let _ = obj.storage.rollback_transaction().await;
-        Ok(())
+        // Only hand the connection back if it is provably out of any transaction. If the
+        // rollback could not clear it (e.g. a statement still in progress), it is still
+        // pinned to a stale snapshot — discard it so deadpool builds a fresh connection
+        // rather than serve stale reads. Returning the connection regardless (the prior
+        // behaviour) let one poisoned connection serve stale `/view` / `/signers` reads
+        // indefinitely — the root cause of the floor-view and signer-id cluster flakes.
+        if obj.storage.conn.is_autocommit() {
+            Ok(())
+        } else {
+            warn!("Discarding pooled view connection still in a transaction after rollback");
+            Err(RecycleError::Message(
+                "pooled view connection could not be reset to a fresh snapshot".into(),
+            ))
+        }
     }
 }
 
@@ -156,6 +171,49 @@ mod tests {
             Runtime::new(ComponentCache::new(), Storage::builder().conn(conn).build()).await?;
         assert_eq!(consensus.gas_limit_for_non_procs, DEFAULT_VIEW_GAS_LIMIT);
         assert_eq!(consensus.view_gas_limit, DEFAULT_VIEW_GAS_LIMIT);
+        Ok(())
+    }
+
+    // A view runtime that leaks an open transaction (its task dropped before commit)
+    // must be rolled back to autocommit on recycle so the next checkout reads a fresh
+    // snapshot — never the leaked connection's pinned (stale) snapshot. The clean case
+    // must NOT be discarded.
+    #[tokio::test]
+    async fn recycle_resets_leaked_transaction_before_reuse() -> anyhow::Result<()> {
+        use deadpool::managed::{Manager as _, Metrics};
+
+        let dir = TempDir::new()?;
+        let manager = Manager::new(
+            dir.path().to_path_buf(),
+            "recycle.db".into(),
+            bitcoin::Network::Regtest,
+            DEFAULT_VIEW_GAS_LIMIT,
+        )?;
+
+        // A freshly created connection is clean — recycle keeps it.
+        let mut runtime = manager.create().await.map_err(|e| anyhow::anyhow!("{e}"))?;
+        assert!(runtime.storage.conn.is_autocommit());
+        manager
+            .recycle(&mut runtime, &Metrics::default())
+            .await
+            .map_err(|e| anyhow::anyhow!("clean connection must not be discarded: {e:?}"))?;
+
+        // Simulate a view that opened its BEGIN but never reached commit/rollback.
+        runtime.storage.savepoint().await?;
+        assert!(
+            !runtime.storage.conn.is_autocommit(),
+            "savepoint opens a transaction"
+        );
+
+        // Recycle must restore autocommit (fresh snapshot on next read) and accept it.
+        manager
+            .recycle(&mut runtime, &Metrics::default())
+            .await
+            .map_err(|e| anyhow::anyhow!("recycle should reset, not discard: {e:?}"))?;
+        assert!(
+            runtime.storage.conn.is_autocommit(),
+            "recycle must roll the leaked transaction back to autocommit"
+        );
         Ok(())
     }
 }

--- a/core/testlib/src/lib.rs
+++ b/core/testlib/src/lib.rs
@@ -558,14 +558,11 @@ impl RuntimeRegtest {
 impl RuntimeImpl for RuntimeRegtest {
     async fn identity(&mut self) -> Result<Signer> {
         let identity = self.reg_tester.identity().await?;
-        // The identity comes from the registered pool (its RegisterBlsKey was confirmed
-        // at setup), so poll until the signer is queryable rather than racing a single
-        // query against indexing/availability lag under load — the source of a flaky
-        // "identity must be registered" panic.
         let signer_id = self
             .reg_tester
-            .wait_for_signer_id(&identity.x_only_public_key().to_string())
-            .await?;
+            .get_signer_id(&identity.x_only_public_key().to_string())
+            .await?
+            .expect("identity must be registered");
         let signer = Signer::Id(indexer::database::types::Identity::new(signer_id));
         self.identities.insert(signer.clone(), identity);
         Ok(signer)

--- a/core/testlib/src/lib.rs
+++ b/core/testlib/src/lib.rs
@@ -558,11 +558,14 @@ impl RuntimeRegtest {
 impl RuntimeImpl for RuntimeRegtest {
     async fn identity(&mut self) -> Result<Signer> {
         let identity = self.reg_tester.identity().await?;
+        // The identity comes from the registered pool (its RegisterBlsKey was confirmed
+        // at setup), so poll until the signer is queryable rather than racing a single
+        // query against indexing/availability lag under load — the source of a flaky
+        // "identity must be registered" panic.
         let signer_id = self
             .reg_tester
-            .get_signer_id(&identity.x_only_public_key().to_string())
-            .await?
-            .expect("identity must be registered");
+            .wait_for_signer_id(&identity.x_only_public_key().to_string())
+            .await?;
         let signer = Signer::Id(indexer::database::types::Identity::new(signer_id));
         self.identities.insert(signer.clone(), identity);
         Ok(signer)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes read-path connection lifecycle for all pooled `/view` and `/signers` traffic; incorrect discard logic could increase pool churn, but scope is limited to read-only runtimes and targets a known correctness bug.
> 
> **Overview**
> Addresses **stale read flakes** in cluster regtests where `/view` and `/signers` could keep returning pre-commit state after a pooled connection leaked an open read transaction.
> 
> **View runtime pool (`pool.rs`):** On recycle, the code still best-effort rolls back leaked transactions, but now **refuses to return** a connection unless `is_autocommit()` is true. Connections that stay in a transaction after rollback are **discarded** (with a warning) so deadpool opens a fresh one instead of reusing a WAL-pinned snapshot. A new test simulates a leaked savepoint and asserts recycle restores autocommit without discarding healthy connections.
> 
> **API client / regtest harness:** Adds `signer_opt`, which maps HTTP **404** to `None` while propagating transport and 5xx errors. `RegTester::get_signer_id` uses it so transient API failures are no longer swallowed as “not registered,” which was contributing to signer-id cluster flakes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49382f74328a2d118b8b27ed50515e79e6c8f378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->