### PR TITLE
fix(compose): let Build carry funding prevouts (fixes regtest -5 txindex-lag flake)

### DIFF
--- a/core/indexer-types/src/lib.rs
+++ b/core/indexer-types/src/lib.rs
@@ -69,19 +69,34 @@ pub struct RevealParticipant {
 }
 
 impl CommitSource {
-    /// Construct a `CommitSource::Build` for a commit to be built by
-    /// this call. Accepts any iterable of `OutPoint` for funding — the
-    /// helper formats them into the wire-string shape internally.
+    /// Construct a `CommitSource::Build` whose funding is outpoints only —
+    /// compose resolves each prevout via bitcoind. Accepts any iterable of
+    /// `OutPoint`; the helper formats them into the wire-string shape.
     pub fn build(
         address: &bitcoin::Address,
         funding: impl IntoIterator<Item = bitcoin::OutPoint>,
     ) -> Self {
         Self::Build {
             address: address.to_string(),
-            funding_utxo_ids: funding
-                .into_iter()
-                .map(|op| format!("{}:{}", op.txid, op.vout))
-                .collect(),
+            funding: Funding::Ids(
+                funding
+                    .into_iter()
+                    .map(|op| format!("{}:{}", op.txid, op.vout))
+                    .collect(),
+            ),
+        }
+    }
+
+    /// Construct a `CommitSource::Build` whose funding prevouts the caller
+    /// already holds — compose uses them directly, skipping the bitcoind
+    /// lookup (and its async-`txindex` 404 window).
+    pub fn build_resolved(
+        address: &bitcoin::Address,
+        funding: impl IntoIterator<Item = (bitcoin::OutPoint, bitcoin::TxOut)>,
+    ) -> Self {
+        Self::Build {
+            address: address.to_string(),
+            funding: Funding::Resolved(funding.into_iter().map(Into::into).collect()),
         }
     }
 
@@ -142,10 +157,57 @@ pub enum CommitSource {
     },
     /// The commit needs to be built (by this call or a later one).
     /// Caller supplies funding for the commit tx.
-    Build {
-        address: String,
-        funding_utxo_ids: Vec<String>,
-    },
+    Build { address: String, funding: Funding },
+}
+
+/// Funding UTXOs for a commit that compose must build.
+#[derive(Serialize, Deserialize, Clone, TS)]
+#[ts(export, export_to = "../../../sdk/src/bindings.d.ts")]
+pub enum Funding {
+    /// Outpoints only (`"txid:vout"`). Compose resolves each prevout via
+    /// bitcoind `getrawtransaction`.
+    Ids(Vec<String>),
+    /// Outpoints with prevouts already known. Compose uses them directly,
+    /// skipping the bitcoind lookup (and its async-`txindex` window where a
+    /// just-confirmed UTXO transiently 404s before the index catches up).
+    Resolved(Vec<FundingUtxo>),
+}
+
+impl Funding {
+    /// Number of funding UTXOs, across either variant.
+    pub fn len(&self) -> usize {
+        match self {
+            Funding::Ids(ids) => ids.len(),
+            Funding::Resolved(utxos) => utxos.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// A funding UTXO whose prevout the caller already holds. Mirrors the
+/// `CommitSource::Existing` outpoint+prevout pattern.
+#[derive(Serialize, Deserialize, Clone, TS)]
+#[ts(export, export_to = "../../../sdk/src/bindings.d.ts")]
+pub struct FundingUtxo {
+    #[ts(as = "String")]
+    pub outpoint: bitcoin::OutPoint,
+    #[ts(as = "TxOutSchema")]
+    pub prevout: bitcoin::TxOut,
+}
+
+impl From<(bitcoin::OutPoint, bitcoin::TxOut)> for FundingUtxo {
+    fn from((outpoint, prevout): (bitcoin::OutPoint, bitcoin::TxOut)) -> Self {
+        Self { outpoint, prevout }
+    }
+}
+
+impl From<FundingUtxo> for (bitcoin::OutPoint, bitcoin::TxOut) {
+    fn from(u: FundingUtxo) -> Self {
+        (u.outpoint, u.prevout)
+    }
 }
 
 /// A non-Kontor input (key-path spend) bringing extra value into the

--- a/core/indexer/src/api/compose.rs
+++ b/core/indexer/src/api/compose.rs
@@ -16,7 +16,7 @@ use bitcoin::{
 use bitcoin::Txid;
 use bitcoin::key::constants::SCHNORR_SIGNATURE_SIZE;
 use indexer_types::{
-    CommitSource, Reveal, RevealOutput, RevealOutputInfo, RevealOutputs, RevealParticipant,
+    CommitSource, Funding, Reveal, RevealOutput, RevealOutputInfo, RevealOutputs, RevealParticipant,
     TapLeafScript, serialize,
 };
 use std::{collections::HashSet, str::FromStr};
@@ -693,20 +693,17 @@ pub async fn compose_commit(
     // participant's funding list, or across multiple Build participants.
     // Two inputs spending the same outpoint would make the commit tx
     // double-spend its own input.
-    let mut global_funding: HashSet<&String> = HashSet::new();
+    let mut global_funding: HashSet<String> = HashSet::new();
     for &build_idx in &build_indices {
-        if let CommitSource::Build {
-            funding_utxo_ids, ..
-        } = &reveal.participants[build_idx].commit_source
-        {
-            let mut local_funding: HashSet<&String> = HashSet::new();
-            for op in funding_utxo_ids {
-                if !local_funding.insert(op) {
+        if let CommitSource::Build { funding, .. } = &reveal.participants[build_idx].commit_source {
+            let mut local_funding: HashSet<String> = HashSet::new();
+            for key in funding_outpoint_keys(funding) {
+                if !local_funding.insert(key.clone()) {
                     return Err(anyhow!(
                         "duplicate funding outpoint provided for participant"
                     ));
                 }
-                if !global_funding.insert(op) {
+                if !global_funding.insert(key) {
                     return Err(anyhow!(
                         "duplicate funding outpoint provided across participants"
                     ));
@@ -776,11 +773,8 @@ pub async fn compose_commit(
 
     for (build_order, &build_idx) in build_indices.iter().enumerate() {
         let participant = &reveal.participants[build_idx];
-        let (build_addr_str, funding_utxo_ids) = match &participant.commit_source {
-            CommitSource::Build {
-                address,
-                funding_utxo_ids,
-            } => (address, funding_utxo_ids),
+        let (build_addr_str, funding) = match &participant.commit_source {
+            CommitSource::Build { address, funding } => (address, funding),
             _ => unreachable!(),
         };
 
@@ -806,13 +800,13 @@ pub async fn compose_commit(
         // Bound the funding list before the RPC — a malformed request
         // with thousands of outpoints shouldn't trigger a bitcoind
         // round-trip to bounce.
-        if funding_utxo_ids.len() > MAX_UTXOS_PER_PARTICIPANT {
+        if funding.len() > MAX_UTXOS_PER_PARTICIPANT {
             return Err(anyhow!(
                 "too many utxos for Build participant (max {})",
                 MAX_UTXOS_PER_PARTICIPANT
             ));
         }
-        let funding_utxos = get_utxos(bitcoin_client, funding_utxo_ids.join(",")).await?;
+        let funding_utxos = get_utxos(bitcoin_client, funding).await?;
 
         // Build an empty commit tx with just the tap output.
         // `Psbt::from_unsigned_tx` already initializes `psbt.outputs`
@@ -1143,9 +1137,27 @@ pub fn estimate_participant_commit_fees(
     Ok((fee_with_change, fee_no_change))
 }
 
-async fn get_utxos(bitcoin_client: &Client, utxo_ids: String) -> Result<Vec<(OutPoint, TxOut)>> {
+/// Canonical `"txid:vout"` dedup keys for a participant's funding, uniform
+/// across both `Funding` variants (`OutPoint`'s `Display` is `txid:vout`, the
+/// same shape callers use for `Funding::Ids`).
+fn funding_outpoint_keys(funding: &Funding) -> Vec<String> {
+    match funding {
+        Funding::Ids(ids) => ids.clone(),
+        Funding::Resolved(utxos) => utxos.iter().map(|u| u.outpoint.to_string()).collect(),
+    }
+}
+
+async fn get_utxos(bitcoin_client: &Client, funding: &Funding) -> Result<Vec<(OutPoint, TxOut)>> {
+    // Prevouts already supplied by the caller: use them directly, with no
+    // bitcoind round-trip — avoids the async-`txindex` window where a
+    // just-confirmed funding UTXO transiently 404s before the index catches up.
+    let utxo_ids = match funding {
+        Funding::Resolved(utxos) => return Ok(utxos.iter().cloned().map(Into::into).collect()),
+        Funding::Ids(ids) => ids,
+    };
+
     let outpoints: Vec<OutPoint> = utxo_ids
-        .split(',')
+        .iter()
         .filter_map(|s| {
             let parts = s.split(':').collect::<Vec<&str>>();
             if parts.len() == 2 {

--- a/core/indexer/src/api/compose.rs
+++ b/core/indexer/src/api/compose.rs
@@ -16,8 +16,8 @@ use bitcoin::{
 use bitcoin::Txid;
 use bitcoin::key::constants::SCHNORR_SIGNATURE_SIZE;
 use indexer_types::{
-    CommitSource, Funding, Reveal, RevealOutput, RevealOutputInfo, RevealOutputs, RevealParticipant,
-    TapLeafScript, serialize,
+    CommitSource, Funding, Reveal, RevealOutput, RevealOutputInfo, RevealOutputs,
+    RevealParticipant, TapLeafScript, serialize,
 };
 use std::{collections::HashSet, str::FromStr};
 

--- a/core/indexer/src/reg_tester.rs
+++ b/core/indexer/src/reg_tester.rs
@@ -343,10 +343,6 @@ pub fn derive_taproot_keypair_from_seed(seed: &[u8], path: &str) -> Result<Keypa
     Ok(Keypair::from_secret_key(&secp, &child.private_key))
 }
 
-fn outpoint_to_utxo_id(outpoint: &OutPoint) -> String {
-    format!("{}:{}", outpoint.txid, outpoint.vout)
-}
-
 #[derive(Debug, Clone)]
 pub struct Identity {
     pub address: Address,
@@ -539,10 +535,14 @@ impl RegTesterInner {
                 output: Some(indexer_types::RevealOutput::Change {
                     script_pubkey: hex::encode(ident.address.script_pubkey().as_bytes()),
                 }),
-                commit_source: indexer_types::CommitSource::Build {
-                    address: ident.address.to_string(),
-                    funding_utxo_ids: vec![outpoint_to_utxo_id(&ident.next_funding_utxo.0)],
-                },
+                // Supply the funding prevout we already hold (not just the
+                // outpoint) so compose doesn't re-resolve it via bitcoind
+                // `getrawtransaction` — which transiently 404s in the
+                // async-`txindex` window after the auto-miner confirms it.
+                commit_source: indexer_types::CommitSource::build_resolved(
+                    &ident.address,
+                    [ident.next_funding_utxo.clone()],
+                ),
             }],
             extra_inputs: vec![],
             extra_outputs: vec![],

--- a/sdk/src/attach.ts
+++ b/sdk/src/attach.ts
@@ -103,7 +103,7 @@ export class Attachment<T> {
               commit_source: {
                 Build: {
                   address: identity.address,
-                  funding_utxo_ids: utxos.map((u) => `${u.txid}:${u.vout}`),
+                  funding: { Ids: utxos.map((u) => `${u.txid}:${u.vout}`) },
                 },
               },
             },

--- a/sdk/src/bindings.d.ts
+++ b/sdk/src/bindings.d.ts
@@ -80,7 +80,7 @@ export type CommitOutputs = { commits: Array<CommitTx>; reveal: Reveal };
  */
 export type CommitSource = {
   "Existing": { outpoint: string; prevout: TxOutSchema };
-} | { "Build": { address: string; funding_utxo_ids: Array<string> } };
+} | { "Build": { address: string; funding: Funding } };
 
 /**
  * One commit transaction built by `compose_commit` / `compose`. There's
@@ -208,6 +208,19 @@ export type FootprintResponse = {
 export type Forge = "GitHub" | "GitLab" | "Bitbucket" | "Codeberg" | {
   "Other": string;
 };
+
+/**
+ * Funding UTXOs for a commit that compose must build.
+ */
+export type Funding = { "Ids": Array<string> } | {
+  "Resolved": Array<FundingUtxo>;
+};
+
+/**
+ * A funding UTXO whose prevout the caller already holds. Mirrors the
+ * `CommitSource::Existing` outpoint+prevout pattern.
+ */
+export type FundingUtxo = { outpoint: string; prevout: TxOutSchema };
 
 export type HolderRef =
   | { "XOnlyPubkey": string }

--- a/sdk/src/json-codec.ts
+++ b/sdk/src/json-codec.ts
@@ -55,7 +55,7 @@ export type { WireInst, WireInsts, OpStatus };
 /**
  * A funding UTXO a Build participant can spend in its commit tx. Higher-
  * level flows fetch these via `KontorTransport.utxos()` and feed them
- * into `CommitSource.Build.funding_utxo_ids`.
+ * into `CommitSource.Build.funding` as `Funding.Ids`.
  */
 export interface Utxo {
   txid: string;

--- a/sdk/src/offer.ts
+++ b/sdk/src/offer.ts
@@ -352,7 +352,7 @@ export class IncomingOffer {
             commit_source: {
               Build: {
                 address: identity.address,
-                funding_utxo_ids: buyerUtxos.map((u) => `${u.txid}:${u.vout}`),
+                funding: { Ids: buyerUtxos.map((u) => `${u.txid}:${u.vout}`) },
               },
             },
           },

--- a/sdk/src/transport/http.ts
+++ b/sdk/src/transport/http.ts
@@ -364,7 +364,7 @@ export class HttpTransport implements KontorTransport {
           commit_source: {
             Build: {
               address: identity.address,
-              funding_utxo_ids: utxos.map((u) => `${u.txid}:${u.vout}`),
+              funding: { Ids: utxos.map((u) => `${u.txid}:${u.vout}`) },
             },
           },
         },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes commit-tx funding resolution in compose (bitcoind vs caller-supplied prevouts); wrong prevouts could build invalid commits, but `Ids` preserves prior behavior for SDK paths that only know outpoints.
> 
> **Overview**
> **`CommitSource::Build`** no longer takes a flat `funding_utxo_ids` list. Funding is a **`Funding`** enum: **`Ids`** (outpoints only, same behavior as before via bitcoind `getrawtransaction`) or **`Resolved`** (outpoint + prevout pairs the caller already has).
> 
> Compose **`get_utxos`** skips bitcoind when funding is **`Resolved`**, avoiding transient 404s while **`txindex`** catches up on just-confirmed UTXOs. Duplicate-funding checks use canonical **`txid:vout`** keys for both variants. Rust adds **`CommitSource::build`** / **`build_resolved`** helpers; TypeScript/SDK call sites use **`funding: { Ids: [...] }`**.
> 
> Regtest **`compose_insts`** passes **`build_resolved`** with the identity’s known funding prevout so cluster tests don’t flake on that window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcfc115395c16065863079007158b62f31d3976d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->