### PR TITLE
fix(runtime-pool): clear resource table on recycle to release leaked-cursor WAL snapshot pin

### DIFF
--- a/core/indexer/src/runtime/pool.rs
+++ b/core/indexer/src/runtime/pool.rs
@@ -87,22 +87,25 @@ impl managed::Manager for Manager {
         obj: &mut Self::Type,
         _metrics: &deadpool::managed::Metrics,
     ) -> RecycleResult<Self::Error> {
-        // Reset any transaction left open on this connection before it is reused.
-        // A view wraps its call in BEGIN…COMMIT; if `execute` returns early without
-        // reaching the commit/rollback in `handle_call` (e.g. the spawned call task
-        // fails to join), the connection goes back into the pool with an OPEN read
-        // transaction — pinning it to a stale WAL snapshot so every later view (and
-        // `/signers` lookup, served from this same pool) on it reads pre-commit state.
-        // `ROLLBACK` (+ clearing the savepoint stack) restores a fresh snapshot; it
-        // errors harmlessly when nothing is open (the normal case), so ignore it here
-        // and verify the outcome below instead.
+        // THE floor-view flake fix. A view can leave a streaming-iterator resource
+        // (e.g. an undrained `Keys` map iterator) in the runtime's resource table; its
+        // backing libsql `Rows` stays an ACTIVE STATEMENT while held. In WAL mode a
+        // connection cannot advance its read snapshot while it has an active statement
+        // (SQLite WAL / SQLDelight #2123), so the NEXT view checked out on this pooled
+        // connection reads a STALE, frozen snapshot — silently missing just-committed
+        // writes (`/view`, `/signers`). Crucially this does NOT flip `is_autocommit`
+        // (it's an implicit statement lock, not a `BEGIN`), so the check below can't
+        // see it. Dropping the resource table finalizes those cursors and releases the
+        // pin, letting the connection advance to the latest commit on the next read.
+        *obj.table.lock().await = wasmtime::component::ResourceTable::new();
+        // Then reset any explicit transaction a cancelled view left open (`BEGIN…COMMIT`
+        // not reached). `ROLLBACK` errors harmlessly when nothing is open (the normal
+        // case), so ignore it and verify the outcome below.
         let _ = obj.storage.rollback_transaction().await;
         // Only hand the connection back if it is provably out of any transaction. If the
         // rollback could not clear it (e.g. a statement still in progress), it is still
-        // pinned to a stale snapshot — discard it so deadpool builds a fresh connection
-        // rather than serve stale reads. Returning the connection regardless (the prior
-        // behaviour) let one poisoned connection serve stale `/view` / `/signers` reads
-        // indefinitely — the root cause of the floor-view and signer-id cluster flakes.
+        // pinned — discard it so deadpool builds a fresh connection rather than serve
+        // stale reads.
         if obj.storage.conn.is_autocommit() {
             Ok(())
         } else {
@@ -214,6 +217,146 @@ mod tests {
             runtime.storage.conn.is_autocommit(),
             "recycle must roll the leaked transaction back to autocommit"
         );
+        Ok(())
+    }
+
+    // End-to-end proof of the floor-view fix: a leaked `Keys` cursor in a pooled
+    // runtime's resource table pins its connection to a stale WAL snapshot (a fresh
+    // read misses a concurrent commit), and `recycle` clearing the table drops the
+    // cursor and releases the pin so the next read sees the latest commit.
+    #[tokio::test]
+    async fn recycle_clears_leaked_cursor_that_pinned_the_snapshot() -> anyhow::Result<()> {
+        use crate::database::queries::{footprint_cache_get, footprint_cache_set, insert_block};
+        use crate::runtime::wit::resources::Keys;
+        use crate::test_utils::new_mock_block_hash;
+        use deadpool::managed::{Manager as _, Metrics};
+        use futures_util::StreamExt;
+        use indexer_types::BlockRow;
+
+        let dir = TempDir::new()?;
+        let manager = Manager::new(
+            dir.path().to_path_buf(),
+            "leak.db".into(),
+            bitcoin::Network::Regtest,
+            DEFAULT_VIEW_GAS_LIMIT,
+        )?;
+        let mut rt = manager.create().await.map_err(|e| anyhow::anyhow!("{e}"))?;
+
+        // Seed via a separate writer connection: a block (FK), contract_state rows for
+        // the cursor to stream, and a footprint row to read back.
+        let writer = new_connection(dir.path(), "leak.db").await?;
+        let signer = 1u64;
+        insert_block(
+            &writer,
+            BlockRow::builder()
+                .height(1)
+                .hash(new_mock_block_hash(1))
+                .build(),
+        )
+        .await?;
+        for i in 0..50i64 {
+            writer
+                .execute(
+                    "INSERT INTO contract_state (contract_id, height, tx_id, size, path, value, deleted) \
+                     VALUES (1, 1, NULL, 1, ?1, ?2, 0)",
+                    libsql::params![vec![i as u8], vec![1u8]],
+                )
+                .await?;
+        }
+        footprint_cache_set(&writer, signer, Some(1)).await?;
+
+        // Leak a Keys cursor into the pooled runtime's table (read one row → ACTIVE
+        // statement, never drained), exactly as a partially-consumed `map.keys()` view.
+        let mut stream = Box::pin(rt.storage.keys(1, vec![], None).await?);
+        let _ = stream.next().await;
+        rt.table.lock().await.push(Keys { stream })?;
+
+        // The writer commits a newer footprint; the pinned pooled connection reads stale.
+        footprint_cache_set(&writer, signer, Some(2)).await?;
+        assert_eq!(
+            footprint_cache_get(&rt.storage.conn, signer).await?,
+            Some(1),
+            "a leaked cursor must pin the pooled connection to the stale snapshot"
+        );
+        assert!(
+            rt.storage.conn.is_autocommit(),
+            "the pin does NOT flip autocommit — the recycle check alone is blind to it"
+        );
+
+        // recycle clears the table → drops the leaked cursor → releases the pin.
+        manager
+            .recycle(&mut rt, &Metrics::default())
+            .await
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+        assert_eq!(
+            footprint_cache_get(&rt.storage.conn, signer).await?,
+            Some(2),
+            "after recycle drops the leaked cursor, the connection reads the latest commit"
+        );
+        Ok(())
+    }
+
+    // Faithful reproduction of the floor-view flake at the pool level: a real runtime
+    // pool (checkout/recycle + read-only-runtime savepoint reads), a reactor-style
+    // writer committing via explicit transactions, and heavy concurrent pool load.
+    // INVARIANT: after the writer's COMMIT returns, a freshly-checked-out pooled view
+    // MUST see >= the just-committed value. A view that lags a committed write IS the
+    // production bug (a `/view` read missing a confirmed write).
+    #[tokio::test]
+    async fn runtime_pool_view_never_lags_committed_write_under_load() -> anyhow::Result<()> {
+        use crate::database::queries::{footprint_cache_get, footprint_cache_set};
+        use std::sync::Arc;
+
+        let dir = TempDir::new()?;
+        let path = dir.path().to_path_buf();
+        let writer = new_connection(&path, "stress.db").await?;
+        let pool = Arc::new(
+            super::new(
+                path.clone(),
+                "stress.db".into(),
+                bitcoin::Network::Regtest,
+                DEFAULT_VIEW_GAS_LIMIT,
+            )
+            .await?,
+        );
+        let signer = 1u64;
+        footprint_cache_set(&writer, signer, Some(1)).await?;
+
+        // Background load: many tasks hammer pool checkout/recycle + savepoint-wrapped
+        // reads, plus a second writer churning the WAL — the concurrency the bug needs.
+        let mut bg = Vec::new();
+        for _ in 0..16 {
+            let p = pool.clone();
+            bg.push(tokio::spawn(async move {
+                loop {
+                    if let Ok(rt) = p.get().await {
+                        let _ = rt.storage.savepoint().await;
+                        let _ = footprint_cache_get(&rt.storage.conn, signer).await;
+                        let _ = rt.storage.commit().await;
+                    }
+                }
+            }));
+        }
+
+        for v in 2..=6000u64 {
+            writer.execute("BEGIN", ()).await?;
+            footprint_cache_set(&writer, signer, Some(v)).await?;
+            writer.execute("COMMIT", ()).await?;
+
+            let rt = pool.get().await.map_err(|e| anyhow::anyhow!("{e:?}"))?;
+            rt.storage.savepoint().await?;
+            let seen = footprint_cache_get(&rt.storage.conn, signer)
+                .await?
+                .unwrap_or(0);
+            rt.storage.commit().await?;
+            assert!(
+                seen >= v,
+                "runtime pool view LAGGED a committed write: committed {v}, pooled view saw {seen}"
+            );
+        }
+        for h in bg {
+            h.abort();
+        }
         Ok(())
     }
 }

--- a/core/indexer/src/runtime/storage.rs
+++ b/core/indexer/src/runtime/storage.rs
@@ -978,4 +978,132 @@ mod tests {
         );
         Ok(())
     }
+
+    // Floor-view flake probe at the libsql level. Cluster scenario: the reactor
+    // (writer) commits, the reader pool confirms it (what `wait_for_txids` polls),
+    // THEN the runtime pool serves the `/view` floor read. All three are separate
+    // connections on one WAL db. If a fresh autocommit read on the view connection
+    // can lag a commit the reader connection already saw, that IS the floor-view
+    // flake's mechanism. A pass means libsql cross-connection visibility is sound
+    // and the flake lives elsewhere (the cluster/consensus path), not here.
+    #[tokio::test]
+    async fn fresh_view_read_never_lags_reader_pool() -> Result<()> {
+        let (_reader, writer, (temp, db_name)) = new_test_db().await?;
+        let writer_conn = writer.connection();
+        let reader_pool_conn = new_connection(temp.path(), &db_name).await?;
+        let view_conn = new_connection(temp.path(), &db_name).await?;
+
+        let key = "view_freshness_probe";
+        for i in 1..=3000u64 {
+            set_meta_u64(&writer_conn, key, i).await?; // reactor commits i
+            let r = get_meta_u64(&reader_pool_conn, key, 0).await?; // reader pool confirms
+            assert_eq!(r, i, "reader pool must see commit {i}, saw {r}");
+            let v = get_meta_u64(&view_conn, key, 0).await?; // runtime pool /view read
+            assert_eq!(
+                v, i,
+                "view read lagged a commit the reader pool already saw: committed {i}, view saw {v}"
+            );
+        }
+        Ok(())
+    }
+
+    // Faithful version of the above: the writer commits via an EXPLICIT
+    // transaction (like the reactor's batch savepoint), CONCURRENTLY, while the
+    // view reads through the same `savepoint()`→read→`commit()` wrapper the
+    // read-only `/view` runtime uses. Monotonicity invariant: a view read that
+    // STARTS after the reader pool already observed value R must see >= R — it
+    // can never go backwards. A violation reproduces the floor-view flake.
+    #[tokio::test]
+    async fn savepoint_wrapped_view_read_never_goes_backwards_under_concurrent_writes() -> Result<()>
+    {
+        let (_reader, writer, (temp, db_name)) = new_test_db().await?;
+        let writer_conn = writer.connection();
+        let reader_pool_conn = new_connection(temp.path(), &db_name).await?;
+        let view = Storage::builder()
+            .conn(new_connection(temp.path(), &db_name).await?)
+            .build();
+        let key = "view_monotonic_probe";
+        set_meta_u64(&writer_conn, key, 0).await?;
+
+        // Writer task: bump the value as fast as possible, concurrently.
+        let w = writer_conn.clone();
+        let writer_task = tokio::spawn(async move {
+            for i in 1..=5000u64 {
+                set_meta_u64(&w, key, i).await.unwrap();
+            }
+        });
+
+        // Reader confirms a value, then the view (savepoint-wrapped) must not lag it.
+        for _ in 0..20000u64 {
+            let r = get_meta_u64(&reader_pool_conn, key, 0).await?;
+            view.savepoint().await?;
+            let v = get_meta_u64(&view.conn, key, 0).await?;
+            view.commit().await?;
+            assert!(
+                v >= r,
+                "savepoint-wrapped view read went BACKWARDS: reader pool already saw {r}, view saw {v}"
+            );
+            if writer_task.is_finished() {
+                break;
+            }
+        }
+        writer_task.await.unwrap();
+        Ok(())
+    }
+
+    // THE root cause, proven directly (SQLDelight #2123 / SQLite WAL): a connection
+    // that holds an UNDRAINED cursor cannot advance its read snapshot in WAL mode
+    // ("a reader can't move its end mark while it has active statements"). A FRESH
+    // read on that same connection then returns STALE data even though another
+    // connection already committed — and `is_autocommit()` is still TRUE (it's an
+    // implicit statement lock, not a BEGIN), so the recycle's autocommit check is
+    // blind to it. Dropping the cursor releases the pin. This is the floor-view flake.
+    #[tokio::test]
+    async fn held_cursor_pins_wal_snapshot_until_dropped() -> Result<()> {
+        let (_reader, writer, (temp, db_name)) = new_test_db().await?;
+        let writer_conn = writer.connection();
+        let view_conn = new_connection(temp.path(), &db_name).await?;
+
+        let key = "wal_pin_probe";
+        set_meta_u64(&writer_conn, key, 1).await?;
+        writer_conn
+            .execute("CREATE TABLE probe (x INTEGER)", ())
+            .await?;
+        for i in 0..200i64 {
+            writer_conn
+                .execute("INSERT INTO probe VALUES (?1)", [i])
+                .await?;
+        }
+
+        // The view opens a cursor and reads ONE row, leaving the statement ACTIVE
+        // (the leaked `Keys` stream in production). The connection is still autocommit.
+        let mut held = view_conn.query("SELECT x FROM probe", ()).await?;
+        let _ = held.next().await?;
+        assert!(
+            view_conn.is_autocommit(),
+            "an open cursor does NOT flip autocommit — the recycle check can't see it"
+        );
+        assert_eq!(get_meta_u64(&view_conn, key, 0).await?, 1);
+
+        // Another connection commits a newer value.
+        set_meta_u64(&writer_conn, key, 2).await?;
+
+        // A FRESH read on the view connection while the cursor is held: pinned to the
+        // old snapshot → STALE. This is the bug.
+        let pinned = get_meta_u64(&view_conn, key, 0).await?;
+
+        // Dropping the cursor releases the pin; the next read sees the latest.
+        drop(held);
+        let after_drop = get_meta_u64(&view_conn, key, 0).await?;
+
+        assert_eq!(
+            pinned, 1,
+            "REPRO: a held cursor pinned the WAL snapshot — fresh read saw stale {pinned}"
+        );
+        assert_eq!(
+            after_drop, 2,
+            "FIX: after dropping the cursor the connection advances to the latest commit"
+        );
+        Ok(())
+    }
 }

--- a/core/indexer/src/runtime/wit/mod.rs
+++ b/core/indexer/src/runtime/wit/mod.rs
@@ -1,4 +1,4 @@
-mod resources;
+pub(crate) mod resources;
 
 pub use resources::{
     Contract, CoreContext, FallContext, FileDescriptor, HasContractId, Holder, Keys, ProcContext,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches pooled `/view` connection lifecycle on the consensus indexer hot path; behavior change is narrowly scoped to recycle cleanup with strong new tests, but incorrect table clearing could affect in-flight resources if misapplied outside recycle.
> 
> **Overview**
> Fixes stale `/view` and `/signers` reads when pooled read-only runtimes are reused after a view leaves an undrained streaming iterator (e.g. `Keys` from `map.keys()`) in the Wasm **resource table**. In WAL mode that keeps an active statement on the libsql connection, pins the read snapshot without changing `is_autocommit`, so rollback-only recycle could not see it.
> 
> **`Manager::recycle`** now replaces the runtime’s `ResourceTable` with a fresh one (dropping leaked cursors) before the existing transaction rollback and autocommit check. Comments document the WAL pin mechanism; connection discard on failed rollback is unchanged.
> 
> Adds regression coverage: pool-level leaked-`Keys` + recycle, stressed pool checkout under concurrent writes, libsql freshness/monotonicity probes, and a direct “held cursor pins snapshot until dropped” test. **`wit::resources`** is **`pub(crate)`** so pool tests can construct a leaked `Keys` resource.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a13afd353bd99a645f775f56986d3ed4153ab40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->