### PR TITLE
Unmeter trusted core-signer calls (i64-safe SYSTEM_FUEL_CEILING) + operator-configurable /view budget

### DIFF
--- a/core/indexer/src/config.rs
+++ b/core/indexer/src/config.rs
@@ -7,9 +7,10 @@ use serde::{Deserialize, Serialize};
 use crate::consensus::signing::ConsensusMode;
 use crate::logging;
 
-/// Default per-call gas budget for read-only `/view` queries. Matches the runtime's
-/// fixed non-proc default, so the out-of-the-box pool behaves exactly as before.
-pub const DEFAULT_VIEW_GAS_LIMIT: u64 = 100_000;
+/// Default per-call gas budget for read-only `/view` queries. Generous out of the
+/// box (operators raise it further on read/archive nodes); independent of the fixed
+/// system core-call budget, which is effectively unmetered.
+pub const DEFAULT_VIEW_GAS_LIMIT: u64 = 1_000_000;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Parser)]
 pub struct Config {
@@ -178,7 +179,7 @@ pub struct Config {
         long,
         env = "VIEW_GAS_LIMIT",
         default_value_t = DEFAULT_VIEW_GAS_LIMIT,
-        help = "Per-call gas budget for read-only /view queries (default 100000; raise on read/archive nodes)"
+        help = "Per-call gas budget for read-only /view queries (default 1000000; raise on read/archive nodes)"
     )]
     pub view_gas_limit: u64,
 }

--- a/core/indexer/src/database/connection.rs
+++ b/core/indexer/src/database/connection.rs
@@ -10,3 +10,25 @@ pub async fn new_connection(data_dir: &Path, filename: &str) -> Result<Connectio
     initialize_database(data_dir, &conn).await?;
     Ok(conn)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Guards against silently dropping the `busy_timeout` PRAGMA again (it was once
+    // reverted on the false premise that libsql sets a default — it does not; a raw
+    // connection reports 0). Without a non-zero timeout, transient WAL lock
+    // contention returns `database is locked` immediately and the reactor exits.
+    #[tokio::test]
+    async fn new_connection_sets_busy_timeout() -> anyhow::Result<()> {
+        let dir = tempfile::TempDir::new()?;
+        let conn = new_connection(dir.path(), "bt.db").await?;
+        let mut rows = conn.query("PRAGMA busy_timeout", ()).await?;
+        let val: i64 = rows.next().await?.expect("PRAGMA returns a row").get(0)?;
+        assert_eq!(
+            val, 5000,
+            "new_connection must set busy_timeout; libsql defaults to 0"
+        );
+        Ok(())
+    }
+}

--- a/core/indexer/src/database/init.rs
+++ b/core/indexer/src/database/init.rs
@@ -40,6 +40,16 @@ pub async fn initialize_database(data_dir: &Path, conn: &libsql::Connection) -> 
     conn.execute(CREATE_CONTRACT_STATE_TRIGGER, ()).await?;
     conn.query("PRAGMA journal_mode = WAL;", ()).await?;
     conn.query("PRAGMA synchronous = NORMAL;", ()).await?;
+    // Wait-and-retry on transient lock contention instead of returning
+    // `database is locked` (SQLITE_BUSY) on the first conflict. libsql 0.9.30's
+    // `connect()` never calls `sqlite3_busy_timeout`, so the default is 0 (no
+    // wait) — a prior revert removed this PRAGMA assuming libsql sets 5000 by
+    // default, which is NOT true for this version. Without it, brief WAL/checkpoint
+    // contention makes the reactor's block-write fail immediately and the node
+    // exits (flaky cluster-test node deaths). This does NOT mask SQLITE_BUSY_SNAPSHOT
+    // (a hard error a busy handler can't wait on) — that's handled separately by
+    // pinning the read-only pool `query_only = ON`.
+    conn.query("PRAGMA busy_timeout = 5000;", ()).await?;
     conn.load_extension_enable()?;
     for (name, bytes) in [("crypto", CRYPTO_LIB)] {
         let p = data_dir.join(format!("{}.{}", name, LIB_FILE_EXT));

--- a/core/indexer/src/runtime/call.rs
+++ b/core/indexer/src/runtime/call.rs
@@ -47,6 +47,13 @@ fn payer_holder(signer: &Signer, payment: Option<&Payment>) -> Holder {
     Holder::for_signer_id(signer_id)
 }
 
+/// The paying account as a `Signer::Id`. Gas hold/release move tokens on its
+/// behalf, wrapping it in a `Signer::Core` at the call site so the move is
+/// system-authorized rather than the payer acting for themselves.
+fn payer_signer(payment: &Payment) -> Signer {
+    Signer::Id(Identity::new(payment.signer_id))
+}
+
 /// Everything `prepare_call` produces for the caller to run + settle a call: the
 /// instantiated store, the resolved function with its lowered params/results, and
 /// the op metadata. A named struct in place of a positional 9-tuple.
@@ -63,13 +70,22 @@ pub(crate) struct PreparedCall {
 }
 
 impl Runtime {
+    /// Token cost of a gas amount (`gas × gas_to_token_multiplier`). Infallible in
+    /// practice — a u64 always converts to Decimal and the arbitrary-precision
+    /// multiply can't overflow — so a failure here is a bug, not a user error.
+    fn gas_to_token(&self, gas: u64) -> Decimal {
+        Decimal::try_from(gas)
+            .expect("u64 to decimal")
+            .mul(self.gas_to_token_multiplier)
+            .expect("gas to token amount")
+    }
+
     pub(crate) async fn prepare_call(
         &self,
         contract_address: &ContractAddress,
         signer: Option<&Signer>,
         payment: Option<&Payment>,
         expr: &str,
-        is_top_level: bool,
         fuel_override: Option<u64>,
     ) -> Result<PreparedCall, ExecutionError> {
         // Reject an oversized/over-nested call expression BEFORE it reaches the
@@ -77,6 +93,10 @@ impl Runtime {
         // otherwise overflow the host stack and abort the node — a deterministic
         // rejection here keeps that a normal failed op instead.
         validate_expr(expr)?;
+        // The outermost frame iff no frame is on the stack yet (we push ours at the
+        // end). This replaces a redundant `is_top_level` parameter that the two
+        // call sites always passed in agreement with the stack state.
+        let is_top_level = self.stack.is_empty().await;
         let contract_id = self
             .storage
             .contract_id(contract_address)
@@ -296,17 +316,11 @@ impl Runtime {
             && !signer.is_core()
         {
             let payment = payment.expect("payment is required for top-level proc calls");
-            let payer = Signer::Id(Identity::new(payment.signer_id));
-            let hold_amount = Decimal::try_from(fuel_limit)
-                .expect("u64 to decimal")
-                .div(
-                    self.gas_to_fuel_multiplier
-                        .try_into()
-                        .expect("u64 to decimal"),
-                )
-                .expect("Failed to convert fuel limit into gas limit")
-                .mul(self.gas_to_token_multiplier)
-                .expect("Failed to convert gas limit into token limit");
+            let payer = payer_signer(payment);
+            // fuel_limit == payment.gas_limit × gas_to_fuel_multiplier for a top-level
+            // user op (see the budget decision above), so the hold is the committed
+            // gas limit's token cost.
+            let hold_amount = self.gas_to_token(payment.gas_limit);
             tracing::info!(
                 node = %self.node_label,
                 %hold_amount,
@@ -536,14 +550,11 @@ impl Runtime {
         // committed/rolled back this op's savepoint.
         if is_op_result && !signer.is_core() {
             let payment = payment.expect("payment required for op-result release");
-            let payer = Signer::Id(Identity::new(payment.signer_id));
+            let payer = payer_signer(payment);
             // The deposit gas reserved this op is RETURNED, not burned (it only
             // capped growth); burn = the execution slice = gas - charge.
             let charge_gas = self.deposit.take().await;
-            let burn_amount = Decimal::try_from(gas.saturating_sub(charge_gas))
-                .expect("u64 to decimal")
-                .mul(self.gas_to_token_multiplier)
-                .expect("Failed to convert gas to token amount");
+            let burn_amount = self.gas_to_token(gas.saturating_sub(charge_gas));
             tracing::info!(
                 node = %self.node_label,
                 gas,
@@ -628,7 +639,6 @@ impl Runtime {
                 signer.as_ref(),
                 None,
                 expr,
-                false,
                 Some(starting_fuel),
             )
             .await?;
@@ -755,28 +765,23 @@ const MAX_STRING_LITERAL_BYTES: usize = 16 * 1024;
 /// below the overflow depth. CONSENSUS-LOAD-BEARING — see `MAX_STRING_LITERAL_BYTES`.
 const MAX_EXPR_DEPTH: usize = 64;
 
-/// Effective "unmetered" fuel budget for trusted, must-complete CORE calls (per-block
-/// hooks, issuance, genesis) — see the top-of-stack core branch in `prepare_call`.
-/// ~10^7× the old 100k-gas non-proc cap, so it's unreachable by any legitimate
-/// per-block work (it only ever fires as a clean deterministic halt on a genuine
-/// non-terminating bug). NOT `u64::MAX`: remaining fuel is bound into the storage read
-/// path as a SQL i64 size-budget, so this MUST stay within i64 range (with headroom for
-/// any `× gas_to_fuel_multiplier`). CONSENSUS-LOAD-BEARING — all nodes must share the
-/// value (a node with a lower budget would stall on a block others commit); change only
-/// behind a coordinated upgrade.
-/// Fuel budget for trusted, system-paid, MUST-COMPLETE core calls (per-block
-/// hooks, issuance, native publishing) — effectively unmetered.
+/// Fuel budget for trusted, system-paid, MUST-COMPLETE core calls (per-block hooks,
+/// issuance, native publishing) — effectively unmetered. Decided from the signer in
+/// `prepare_call`.
 ///
-/// `i64::MAX as u64`, NOT `u64::MAX`: the remaining fuel is bound into the
-/// storage read path as a SQL i64 size-budget (`CASE WHEN size <= :fuel`,
-/// contract_state.rs), so it must fit in i64 (`u64::MAX as i64 == -1` would make
-/// every core read fail). i64::MAX is the largest i64-safe budget.
+/// `i64::MAX as u64`, NOT `u64::MAX`: the remaining fuel is bound into the storage
+/// read path as a SQL i64 size-budget (`CASE WHEN size <= :fuel`, contract_state.rs),
+/// so it must fit in i64 (`u64::MAX as i64 == -1` would make every core read fail).
+/// i64::MAX is the largest i64-safe budget.
 ///
-/// Fork-safe: core fuel never enters the checkpoint hash and the call runs inside
-/// the block savepoint, so an over-budget hang can only stall a node a height
-/// behind — never fork committed state. `gas_consumed` is a start−end difference,
-/// so true usage still records. (The cap does not bound wall-clock work; per-block
-/// core work is bounded by design — see the block-lifecycle hooks.)
+/// Fork-safe: core fuel never enters the checkpoint hash and the call runs inside the
+/// block savepoint, so an over-budget hang can only stall a node a height behind —
+/// never fork committed state. `gas_consumed` is a start−end difference, so true usage
+/// still records. (The cap does not bound wall-clock work; per-block core work is
+/// bounded by design — see the block-lifecycle hooks.)
+///
+/// CONSENSUS-LOAD-BEARING: all nodes must share this value — a node with a lower budget
+/// would stall on a block the others commit. Change only behind a coordinated upgrade.
 const SYSTEM_FUEL_CEILING: u64 = i64::MAX as u64;
 
 /// Deterministically reject a call expression that would overflow the recursive

--- a/core/indexer/src/runtime/call.rs
+++ b/core/indexer/src/runtime/call.rs
@@ -89,14 +89,23 @@ impl Runtime {
             .load_component(contract_id)
             .await
             .map_err(ExecutionError::NonDeterministic)?;
-        let mut fuel_limit = match fuel_override {
+        // The fuel budget is decided ONCE here, from the signer, so it can't drift
+        // across the per-context arms below.
+        let fuel_limit = match fuel_override {
+            // Nested cross-contract call: inherit the remaining fuel the parent threaded.
             Some(f) => f,
-            None => match payment {
-                Some(p) => p.gas_limit * self.gas_to_fuel_multiplier,
-                // payment-`None` is a read-only `/view` call → the operator-configurable
-                // view cap, NOT the consensus core-call budget (the Core-context
-                // procedure path keeps `fuel_limit_for_non_procs`).
-                None => self.fuel_limit_for_view(),
+            None => match (signer, payment) {
+                // Trusted, system-paid, MUST-COMPLETE consensus work (per-block hooks,
+                // issuance, native publishing) — effectively unmetered, regardless of
+                // which context the procedure takes. Metering is a DoS/economic control
+                // for UNTRUSTED user ops; a finite cap on must-complete system work
+                // would eventually false-halt a healthy network on legitimate growth.
+                // See `SYSTEM_FUEL_CEILING`.
+                (Some(s), _) if s.is_core() => SYSTEM_FUEL_CEILING,
+                // User op: metered by the payer's committed gas limit.
+                (_, Some(p)) => p.gas_limit * self.gas_to_fuel_multiplier,
+                // Read-only `/view`: the operator-configurable view cap.
+                (_, None) => self.fuel_limit_for_view(),
             },
         };
         let mut store = self
@@ -184,34 +193,10 @@ impl Runtime {
                 (t, Some(Signer::Core(signer)))
                     if t.eq(&wasmtime::component::ResourceType::host::<CoreContext>()) =>
                 {
+                    // Fuel was already set above (SYSTEM_FUEL_CEILING for a top-level
+                    // core call, inherited for a nested one) — this arm only wires up
+                    // the trusted CoreContext resource.
                     is_proc = true;
-                    if self.stack.is_empty().await {
-                        // Core calls are trusted, system-paid consensus block-processing
-                        // (per-block hooks, issuance, etc.) — they MUST complete for the
-                        // block to advance and have no revert-and-continue semantics. So
-                        // they are effectively NOT metered: fuel metering is a DoS/economic
-                        // control for UNTRUSTED user ops, a category error for trusted
-                        // system work, and the old fixed 100k cap would eventually
-                        // false-halt a healthy network on legitimate growth. (Safe: a core
-                        // call runs in the block savepoint and commits-or-rolls-back, so an
-                        // over-budget hang can only stall a node a height behind — never
-                        // fork committed state — and core fuel never enters the checkpoint
-                        // hash. `gas_consumed` is a start−end difference, so it still
-                        // records true usage.)
-                        //
-                        // NOT u64::MAX: the remaining fuel is bound into the storage read
-                        // path as a SQL i64 size-budget (`CASE WHEN size <= :fuel`,
-                        // contract_state.rs), so it must fit in i64. CORE_CALL_FUEL_CEILING
-                        // is i64-safe and ~10^7× the old limit — unreachable by any
-                        // legitimate per-block work, so it only ever fires as a clean
-                        // deterministic halt on a genuine non-terminating bug.
-                        fuel_limit = CORE_CALL_FUEL_CEILING;
-                        store
-                            .set_fuel(fuel_limit)
-                            .expect("Failed to set fuel for core context procedure");
-                    } else {
-                        fuel_limit = store.get_fuel().unwrap_or(0);
-                    }
                     params.insert(
                         0,
                         wasmtime::component::Val::Resource(
@@ -779,7 +764,20 @@ const MAX_EXPR_DEPTH: usize = 64;
 /// any `× gas_to_fuel_multiplier`). CONSENSUS-LOAD-BEARING — all nodes must share the
 /// value (a node with a lower budget would stall on a block others commit); change only
 /// behind a coordinated upgrade.
-const CORE_CALL_FUEL_CEILING: u64 = 1_000_000_000_000_000; // 1e15 fuel = 1e12 gas
+/// Fuel budget for trusted, system-paid, MUST-COMPLETE core calls (per-block
+/// hooks, issuance, native publishing) — effectively unmetered.
+///
+/// `i64::MAX as u64`, NOT `u64::MAX`: the remaining fuel is bound into the
+/// storage read path as a SQL i64 size-budget (`CASE WHEN size <= :fuel`,
+/// contract_state.rs), so it must fit in i64 (`u64::MAX as i64 == -1` would make
+/// every core read fail). i64::MAX is the largest i64-safe budget.
+///
+/// Fork-safe: core fuel never enters the checkpoint hash and the call runs inside
+/// the block savepoint, so an over-budget hang can only stall a node a height
+/// behind — never fork committed state. `gas_consumed` is a start−end difference,
+/// so true usage still records. (The cap does not bound wall-clock work; per-block
+/// core work is bounded by design — see the block-lifecycle hooks.)
+const SYSTEM_FUEL_CEILING: u64 = i64::MAX as u64;
 
 /// Deterministically reject a call expression that would overflow the recursive
 /// WAVE parser — along its two recursion axes: an over-long string literal, or

--- a/core/indexer/src/runtime/mod.rs
+++ b/core/indexer/src/runtime/mod.rs
@@ -815,7 +815,7 @@ impl Runtime {
             is_proc,
             fuel_limit: starting_fuel,
         } = self
-            .prepare_call(contract_address, signer, payment.as_ref(), expr, true, None)
+            .prepare_call(contract_address, signer, payment.as_ref(), expr, None)
             .await?;
         OptionFuture::from(
             self.gauge

--- a/core/indexer/src/runtime/mod.rs
+++ b/core/indexer/src/runtime/mod.rs
@@ -107,6 +107,7 @@ use indexer_types::{BuildProvenance, CommitId, Forge, Payment, Platform, Source}
 use wit_validator::Validator as WitValidator;
 
 use crate::bls::RegistrationProof;
+use crate::config::DEFAULT_VIEW_GAS_LIMIT;
 use crate::database;
 use crate::database::native_contracts::{NATIVE_CONTRACTS, is_native_contract_id};
 use crate::database::types::CORE_SIGNER_ID;
@@ -223,10 +224,11 @@ pub struct Runtime {
     /// start, drained at the settle boundary to compute the execution burn
     /// (`burn = gas - charge`).
     pub deposit: DepositMeter,
-    /// Fuel budget for non-procedure work that IS consensus-relevant: top-level
-    /// core-signer/system procedures (`call.rs` Core-context path) and native-api
-    /// (`execute_api`/`core_payment`) calls. FIXED — never operator-configurable, so
-    /// all nodes meter core calls identically.
+    /// Nominal gas limit stamped on system-issued `Payment`s (`core_payment`,
+    /// `execute_api`). FIXED — never operator-configurable. Trusted core calls
+    /// themselves run unmetered at `SYSTEM_FUEL_CEILING` (decided from the signer in
+    /// `prepare_call`), so this is the Payment's nominal cap, not the core fuel
+    /// budget; it still bounds a user-signed `execute_api` call (the test path).
     pub gas_limit_for_non_procs: u64,
     /// Fuel budget for read-only `/view` calls (the payment-`None` path) ONLY.
     /// Operator-configurable per node (set from `Config::view_gas_limit` on the
@@ -313,9 +315,10 @@ impl Runtime {
             gauge: Some(FuelGauge::new()),
             deposit: DepositMeter::new(),
             gas_limit_for_non_procs: 100_000,
-            // Default matches gas_limit_for_non_procs (preserves prior /view behavior);
-            // the pool overrides this from node config, the reactor leaves it as-is.
-            view_gas_limit: 100_000,
+            // The pool overrides this from node config on read-only runtimes; the
+            // reactor's consensus runtime leaves it at the default (views never run
+            // there). Independent of the system core-call budget.
+            view_gas_limit: DEFAULT_VIEW_GAS_LIMIT,
             gas_to_fuel_multiplier: 1_000,
             gas_to_token_multiplier: Decimal::from("1e-9"),
             previous_output: None,

--- a/core/indexer/src/runtime/pool.rs
+++ b/core/indexer/src/runtime/pool.rs
@@ -139,8 +139,8 @@ mod tests {
 
     // The operator's view cap sets ONLY `view_gas_limit`, and only on pooled
     // (read-only) runtimes. It must NEVER touch `gas_limit_for_non_procs` — the
-    // consensus core-call budget — so a too-low view cap can only break views, never
-    // starve core calls / affect consensus.
+    // fixed system budget — so a too-low view cap can only break views, never
+    // affect consensus.
     #[tokio::test]
     async fn view_cap_is_decoupled_from_core_call_budget() -> anyhow::Result<()> {
         let dir = TempDir::new()?;
@@ -157,22 +157,23 @@ mod tests {
             custom,
         )?;
         let pooled = pool.create().await.map_err(|e| anyhow::anyhow!("{e}"))?;
-        // The view cap moved...
+        // A directly-built (consensus) Runtime carries the untouched defaults.
+        let conn = new_connection(dir.path(), "consensus.db").await?;
+        let consensus =
+            Runtime::new(ComponentCache::new(), Storage::builder().conn(conn).build()).await?;
+
+        // The view cap moved on the pooled runtime...
         assert_eq!(
             pooled.view_gas_limit, custom,
             "pooled /view runtime must use the operator-configured view cap"
         );
-        // ...but the consensus core-call budget did NOT, even on the pool runtime.
+        // ...but the fixed system budget did NOT — it matches a directly-built
+        // runtime even on the pool runtime.
         assert_eq!(
-            pooled.gas_limit_for_non_procs, DEFAULT_VIEW_GAS_LIMIT,
-            "the view cap must not touch the core-call budget"
+            pooled.gas_limit_for_non_procs, consensus.gas_limit_for_non_procs,
+            "the view cap must not touch the system core-call budget"
         );
-
-        // Consensus path: a directly-built Runtime is untouched on both fields.
-        let conn = new_connection(dir.path(), "consensus.db").await?;
-        let consensus =
-            Runtime::new(ComponentCache::new(), Storage::builder().conn(conn).build()).await?;
-        assert_eq!(consensus.gas_limit_for_non_procs, DEFAULT_VIEW_GAS_LIMIT);
+        // And the consensus runtime's view field stays at the default.
         assert_eq!(consensus.view_gas_limit, DEFAULT_VIEW_GAS_LIMIT);
         Ok(())
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes consensus-load-bearing core fuel ceiling and centralizes metering in `prepare_call`; incorrect classification could stall or over-meter block processing. DB busy_timeout and higher default view gas affect node stability and read serving, not block validity.
> 
> **Overview**
> **Trusted core-signer execution** is now given an effectively unmetered fuel budget in one place at the start of `prepare_call` (core signer → `SYSTEM_FUEL_CEILING`), instead of bumping fuel again inside the `CoreContext` wiring path. The ceiling is renamed and set to **`i64::MAX as u64`** so storage reads that bind remaining fuel as a SQL `i64` size budget stay valid (unlike `u64::MAX`). User ops still meter on `Payment.gas_limit`; read-only `/view` calls still use the operator **`view_gas_limit`**, kept separate from the fixed system `Payment` nominal cap (`gas_limit_for_non_procs`).
> 
> The default **`/view` gas limit** rises from **100k to 1M** (`DEFAULT_VIEW_GAS_LIMIT` and CLI help), with runtime defaults wired through that constant.
> 
> **SQLite `PRAGMA busy_timeout = 5000`** is applied again on DB init (libsql does not set it), with a regression test on `new_connection` so transient WAL lock contention waits instead of failing the reactor immediately.
> 
> Small cleanups: `is_top_level` is inferred from an empty call stack; gas hold/release uses a shared `gas_to_token` helper and holds tokens for **`payment.gas_limit`**; the pool test asserts the view cap does not alter the system budget against a consensus-built runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0eb50ea483f6426549f1235c5f5d38d7d1fbd9d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->