### PR TITLE
diag: detect stale /view pool snapshots (visible tip < committed tip)

### DIFF
--- a/core/indexer/src/api/handlers/contracts.rs
+++ b/core/indexer/src/api/handlers/contracts.rs
@@ -6,6 +6,7 @@ use indexer_types::{
     ContractListRow, ContractProvenanceResponse, ContractResponse, PaginatedResponse,
     ProvenanceEntry, ViewExpr, ViewResult,
 };
+use libsql::Connection;
 
 use super::validate_query;
 use crate::api::{Env, error::HttpError, result::Result};
@@ -21,12 +22,9 @@ pub async fn post_contract(
     let contract_address = address
         .parse::<ContractAddress>()
         .map_err(|_| HttpError::BadRequest("Invalid contract address".to_string()))?;
-    let result = env
-        .runtime_pool
-        .get()
-        .await?
-        .execute(None, None, &contract_address, &expr)
-        .await;
+    let mut runtime = env.runtime_pool.get().await?;
+    warn_if_stale_view_snapshot(&env, &runtime.storage.conn, &address, &expr).await;
+    let result = runtime.execute(None, None, &contract_address, &expr).await;
     Ok(match result {
         Ok(value) => ViewResult::Ok { value },
         Err(e) => ViewResult::Err {
@@ -34,6 +32,51 @@ pub async fn post_contract(
         },
     }
     .into())
+}
+
+/// Diagnostic (non-fatal): the `/view` pool serves reads on a *separate* connection
+/// from the reactor's writer. If that connection's visible block tip lags the
+/// reactor's last-committed tip, the view executes against pre-commit state — e.g. a
+/// just-registered signer or just-deposited row is missing, so a `floor`/balance
+/// reads a stale `0`. That race is otherwise invisible in the logs; surface it (one
+/// O(1) `MAX(height)` read) so it's greppable and alertable in prod and CI. Emitted
+/// on `target: "view_snapshot"` for filtering; carries the height delta + the view
+/// that raced, which is exactly what the on-node logs were missing during the
+/// storage-deposit floor-view flake investigation.
+async fn warn_if_stale_view_snapshot(env: &Env, conn: &Connection, address: &str, expr: &str) {
+    // The reactor's last-published committed tip, copied out so the `watch` borrow is
+    // released before the await. `None` = no block indexed yet → nothing to lag.
+    let Some(committed) = env.info_rx.borrow().height else {
+        return;
+    };
+    let visible = match queries::max_block_height(conn).await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::debug!(target: "view_snapshot", error = ?e, "could not read view snapshot tip");
+            return;
+        }
+    };
+    // Trim the expr so a large view argument can't bloat the log line.
+    let expr_short: String = expr.chars().take(80).collect();
+    match visible {
+        Some(v) if v < committed => tracing::warn!(
+            target: "view_snapshot",
+            visible = v,
+            committed,
+            delta = committed - v,
+            contract = %address,
+            expr = %expr_short,
+            "stale /view snapshot: pool connection lags the committed tip; view may read \
+             pre-commit state (missing signer/deposit → stale 0)"
+        ),
+        _ => tracing::debug!(
+            target: "view_snapshot",
+            visible = ?visible,
+            committed,
+            contract = %address,
+            "fresh /view snapshot"
+        ),
+    }
 }
 
 pub async fn get_contracts(

--- a/core/indexer/src/api/handlers/contracts.rs
+++ b/core/indexer/src/api/handlers/contracts.rs
@@ -43,39 +43,59 @@ pub async fn post_contract(
 /// on `target: "view_snapshot"` for filtering; carries the height delta + the view
 /// that raced, which is exactly what the on-node logs were missing during the
 /// storage-deposit floor-view flake investigation.
-async fn warn_if_stale_view_snapshot(env: &Env, conn: &Connection, address: &str, expr: &str) {
-    // The reactor's last-published committed tip, copied out so the `watch` borrow is
-    // released before the await. `None` = no block indexed yet → nothing to lag.
-    let Some(committed) = env.info_rx.borrow().height else {
+async fn warn_if_stale_view_snapshot(env: &Env, view_conn: &Connection, address: &str, expr: &str) {
+    // The authoritative committed tip: `MAX(height)` on a FRESH reader-pool connection
+    // — the same read path `/api/transactions` uses (hence the one the test harness's
+    // `wait_for_txids` confirms on). Deliberately NOT `info_rx.height`: that snapshot
+    // is published ASYNCHRONOUSLY after the commit, so right after a write it can still
+    // report the OLD height and mask a genuinely-stale pinned view — the exact window
+    // this diagnostic exists to catch. Comparing the two read pools directly measures
+    // "does /view lag the path that already saw the commit?", which IS the flake.
+    let committed = match env.reader.connection().await {
+        Ok(conn) => match queries::max_block_height(&conn).await {
+            Ok(h) => h,
+            Err(e) => {
+                tracing::debug!(target: "view_snapshot", error = ?e, "could not read committed tip");
+                return;
+            }
+        },
+        Err(e) => {
+            tracing::debug!(target: "view_snapshot", error = ?e, "could not acquire reader connection");
+            return;
+        }
+    };
+    // No block committed yet → nothing for the view to lag.
+    let Some(committed) = committed else {
         return;
     };
-    let visible = match queries::max_block_height(conn).await {
-        Ok(v) => v,
+    let visible = match queries::max_block_height(view_conn).await {
+        Ok(h) => h,
         Err(e) => {
             tracing::debug!(target: "view_snapshot", error = ?e, "could not read view snapshot tip");
             return;
         }
     };
-    // Trim the expr so a large view argument can't bloat the log line.
-    let expr_short: String = expr.chars().take(80).collect();
-    match visible {
-        Some(v) if v < committed => tracing::warn!(
+    // A view that sees NO blocks (`None`) or a lower tip both lag the committed tip.
+    if visible.is_none_or(|v| v < committed) {
+        let expr_short: String = expr.chars().take(80).collect();
+        tracing::warn!(
             target: "view_snapshot",
-            visible = v,
+            visible = ?visible,
             committed,
-            delta = committed - v,
+            delta = committed - visible.unwrap_or(0),
             contract = %address,
             expr = %expr_short,
             "stale /view snapshot: pool connection lags the committed tip; view may read \
              pre-commit state (missing signer/deposit → stale 0)"
-        ),
-        _ => tracing::debug!(
+        );
+    } else {
+        tracing::debug!(
             target: "view_snapshot",
             visible = ?visible,
             committed,
             contract = %address,
             "fresh /view snapshot"
-        ),
+        );
     }
 }
 

--- a/core/indexer/src/database/queries/blocks.rs
+++ b/core/indexer/src/database/queries/blocks.rs
@@ -23,6 +23,25 @@ pub async fn rollback_to_height(conn: &Connection, height: u64) -> Result<u64, E
     Ok(num_rows)
 }
 
+/// The highest block height VISIBLE to `conn` — `MAX(height) FROM blocks`, an O(1)
+/// index lookup. Unlike [`select_block_latest`] it returns just the height and is
+/// used by the `/view` staleness diagnostic to compare a pooled read connection's
+/// snapshot against the reactor's committed tip. `None` = the connection sees no
+/// blocks (empty table / pre-first-block).
+pub async fn max_block_height(conn: &Connection) -> Result<Option<u64>, Error> {
+    Ok(
+        match conn
+            .query("SELECT MAX(height) FROM blocks", params![])
+            .await?
+            .next()
+            .await?
+        {
+            Some(r) => r.get::<Option<u64>>(0)?,
+            None => None,
+        },
+    )
+}
+
 pub async fn select_block_latest(conn: &Connection) -> Result<Option<BlockRow>, Error> {
     let mut rows = conn
         .query(

--- a/core/indexer/src/runtime/host_files.rs
+++ b/core/indexer/src/runtime/host_files.rs
@@ -465,6 +465,24 @@ impl built_in::deposit::HostWithStore for Runtime {
         };
         let signer_id = match holder_ref {
             HolderRef::SignerId(id) => id,
+            // An x-only pubkey reaching here is UNRESOLVED: the `floor` view resolves
+            // its holder-ref (a signers-table lookup) before calling this, so a
+            // lingering pubkey means the lookup found no signer-id. For a holder that
+            // HAS deposited that's the "unresolved-pubkey floor reads 0" symptom —
+            // typically a stale `/view` snapshot where the signer row committed with the
+            // deposit isn't visible yet. Log it (still return 0) so the otherwise-silent
+            // 0 is greppable alongside the `/view` snapshot-staleness warning.
+            HolderRef::XOnlyPubkey(pk) => {
+                tracing::warn!(
+                    target: "view_snapshot",
+                    pubkey = %pk,
+                    "storage_floor got an UNRESOLVED x-only pubkey -> returning 0; the \
+                     signer-id lookup found nothing (stale /view snapshot?), so a real \
+                     deposit would read as 0"
+                );
+                return Ok(Decimal::try_from(0u64)?);
+            }
+            // Core / burner / utxo holders own no deposits — 0 is correct, no warning.
             _ => return Ok(Decimal::try_from(0u64)?),
         };
         // O(1) read of the eager `depositor_footprint` cache (maintained in the write

--- a/core/indexer/src/runtime/storage.rs
+++ b/core/indexer/src/runtime/storage.rs
@@ -573,7 +573,7 @@ impl Storage {
 mod tests {
     use super::*;
     use crate::database::connection::new_connection;
-    use crate::database::queries::insert_block;
+    use crate::database::queries::{insert_block, max_block_height};
     use crate::test_utils::{new_mock_block_hash, new_test_db};
     use indexer_types::BlockRow;
 
@@ -979,6 +979,53 @@ mod tests {
             get_meta_u64(&view_conn, key, 0).await?,
             2,
             "after the recycle reset, the connection must read the latest committed state"
+        );
+        Ok(())
+    }
+
+    // The `/view` staleness diagnostic's discriminator: `max_block_height` on a
+    // pooled read connection must report the LOWER tip when that connection is pinned
+    // to an older snapshot — that's the `visible < committed` the WARN fires on — and
+    // must recover to the committed tip once the pin is released. Proves the detector
+    // can actually see a stale `/view` connection (vs. a fresh one that matches).
+    #[tokio::test]
+    async fn max_block_height_reports_stale_view_connection() -> Result<()> {
+        let (_reader, writer, (temp, db_name)) = new_test_db().await?;
+        let writer_conn = writer.connection();
+        // A second physical connection to the same WAL db — a pooled `/view` connection.
+        let view_conn = new_connection(temp.path(), &db_name).await?;
+        let view = Storage::builder().conn(view_conn.clone()).build();
+
+        let block = |h: u64| {
+            BlockRow::builder()
+                .height(h)
+                .hash(new_mock_block_hash(h as u32))
+                .build()
+        };
+        insert_block(&writer_conn, block(1)).await?;
+
+        // The view opens a transaction and reads — pinning its WAL snapshot at tip 1.
+        view.savepoint().await?;
+        assert_eq!(max_block_height(&view_conn).await?, Some(1));
+
+        // The reactor (writer) commits block 2 (autocommit).
+        insert_block(&writer_conn, block(2)).await?;
+
+        // Pinned to its snapshot, the view still sees tip 1 while the committed tip is
+        // 2 — exactly the `visible(1) < committed(2)` the diagnostic WARNs on.
+        assert_eq!(
+            max_block_height(&view_conn).await?,
+            Some(1),
+            "a pinned view connection must report its stale (lower) tip"
+        );
+        assert_eq!(max_block_height(&writer_conn).await?, Some(2));
+
+        // After the recycle reset, a fresh read sees the committed tip — no stale WARN.
+        view.rollback_transaction().await?;
+        assert_eq!(
+            max_block_height(&view_conn).await?,
+            Some(2),
+            "after the reset, the view connection must catch up to the committed tip"
         );
         Ok(())
     }

--- a/core/indexer/src/runtime/storage.rs
+++ b/core/indexer/src/runtime/storage.rs
@@ -1002,6 +1002,9 @@ mod tests {
                 .hash(new_mock_block_hash(h as u32))
                 .build()
         };
+        // Empty table → `None`; the diagnostic treats a `None` view tip as stale when
+        // the committed tip is `Some` (a view pinned before any block was visible).
+        assert_eq!(max_block_height(&view_conn).await?, None);
         insert_block(&writer_conn, block(1)).await?;
 
         // The view opens a transaction and reads — pinning its WAL snapshot at tip 1.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability-only: extra reads and log lines on the view path; view results and floor math are unchanged aside from warnings.
> 
> **Overview**
> Adds **non-fatal diagnostics** for a WAL/read-pool race where `/view` runs on a pooled connection that can lag the committed block tip, so contract views (e.g. storage **floor**) may read pre-commit state and return a stale **0**.
> 
> Before each contract view, **`post_contract`** now calls **`warn_if_stale_view_snapshot`**, which compares `MAX(height)` on the runtime pool connection against a fresh **reader-pool** connection (not async `info_rx.height`). When the view tip is missing or lower, it emits a **`tracing::warn!`** on target **`view_snapshot`** with height delta, contract, and truncated expr.
> 
> New **`queries::max_block_height`** supports that O(1) tip check. **`storage_floor`** logs a matching **`view_snapshot`** warn when an unresolved x-only pubkey implies a failed signer lookup (same flake symptom) while still returning 0.
> 
> A storage test **`max_block_height_reports_stale_view_connection`** pins a view connection and asserts the detector sees `visible < committed`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a01f90d9a4db5ddeb1ea90c547ceee99ba372048. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->