### PR TITLE
Floor flake test log

### DIFF
--- a/core/indexer/tests/contracts/storage_deposit.rs
+++ b/core/indexer/tests/contracts/storage_deposit.rs
@@ -223,10 +223,25 @@ async fn test_token_floor_view_reports_deposit() -> Result<()> {
     submit.execute().await?;
 
     let floor = token::floor(runtime, alice_ref.clone()).await?;
-    assert!(
-        floor > zero,
-        "floor must be positive after a deposited write, got {floor}"
-    );
+    if floor <= zero {
+        // On-failure discriminator (NOT polling — the assertion has already failed on
+        // this first read; re-reading only enriches the panic so a CI flake finally
+        // names its cause). A regtest `floor` read that comes back 0 right after a
+        // deposited write has two very different explanations:
+        //   * re-read POSITIVE  → a transient read-after-write VISIBILITY lag on the
+        //     `/view` path (pool/snapshot/timing) — the deposit is there, the first
+        //     read just didn't see it.
+        //   * re-read STILL 0    → a PERSISTENT accounting bug (the resolved signer-id
+        //     ≠ the id the deposit was recorded under, or the deposit wasn't recorded),
+        //     NOT a snapshot/timing issue.
+        // Capturing this only on failure keeps prod untouched and doesn't mask the flake.
+        let reread = token::floor(runtime, alice_ref.clone()).await;
+        panic!(
+            "floor must be positive after a deposited write, got {floor}; \
+             re-read = {reread:?} — POSITIVE ⇒ transient /view visibility lag; \
+             still 0 ⇒ persistent accounting bug (signer-id mismatch or deposit not recorded)"
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only diagnostic change with no production or runtime behavior impact.
> 
> **Overview**
> In `test_token_floor_view_reports_deposit`, the post-write check that `token.floor` is positive no longer uses a plain `assert!`. When the first read is still zero, the test **re-reads once** and panics with both values so CI failures distinguish **transient `/view` read-after-write lag** (re-read positive) from a **persistent accounting/signer-id bug** (re-read still zero).
> 
> The test still fails on the first bad read; the re-read only runs on failure and does not retry until pass, so flakes are not masked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 276ede356fd0862d027cda04234acd3f81557d87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->