### PR TITLE
 fix(reactor): bound pending_blocks to prevent unbounded-buffer OOM

### DIFF
--- a/core/indexer/src/api/client.rs
+++ b/core/indexer/src/api/client.rs
@@ -57,7 +57,7 @@ impl Client {
     pub async fn status(&self) -> Result<NodeStatus> {
         Ok(self
             .client
-            .get(format!("{}/status", &self.url))
+            .get(format!("{}/status", self.url))
             .send()
             .await?
             .json::<NodeStatus>()
@@ -69,7 +69,7 @@ impl Client {
     /// elapse. Backs the regtest harness's `wait_for_txids`.
     pub async fn index_wait(&self, since: &str, wait_ms: u64) -> Result<Info> {
         // `since` is a sha256 hex digest — URL-safe, no escaping needed.
-        let url = format!("{}?wait={}&since={}", &self.url, wait_ms, since);
+        let url = format!("{}?wait={}&since={}", self.url, wait_ms, since);
         Self::handle_response(self.client.get(url).send().await?).await
     }
 
@@ -77,7 +77,7 @@ impl Client {
     pub async fn checkpoint_at(&self, height: u64) -> Result<CheckpointRow> {
         Self::handle_response(
             self.client
-                .get(format!("{}/checkpoints/{height}", &self.url))
+                .get(format!("{}/checkpoints/{height}", self.url))
                 .send()
                 .await?,
         )
@@ -87,7 +87,7 @@ impl Client {
     pub async fn compose(&self, reveal: Reveal) -> Result<ComposeOutputs> {
         Self::handle_response(
             self.client
-                .post(format!("{}/transactions/compose", &self.url))
+                .post(format!("{}/transactions/compose", self.url))
                 .json(&reveal)
                 .send()
                 .await?,
@@ -98,7 +98,7 @@ impl Client {
     pub async fn compose_commit(&self, reveal: Reveal) -> Result<CommitOutputs> {
         Self::handle_response(
             self.client
-                .post(format!("{}/transactions/compose/commit", &self.url))
+                .post(format!("{}/transactions/compose/commit", self.url))
                 .json(&reveal)
                 .send()
                 .await?,
@@ -109,7 +109,7 @@ impl Client {
     pub async fn compose_reveal(&self, reveal: Reveal) -> Result<RevealOutputs> {
         Self::handle_response(
             self.client
-                .post(format!("{}/transactions/compose/reveal", &self.url))
+                .post(format!("{}/transactions/compose/reveal", self.url))
                 .json(&reveal)
                 .send()
                 .await?,
@@ -123,7 +123,7 @@ impl Client {
     ) -> Result<Vec<OpWithResult>> {
         Self::handle_response(
             self.client
-                .post(format!("{}/transactions/inspect", &self.url))
+                .post(format!("{}/transactions/inspect", self.url))
                 .json(&tx_hex)
                 .send()
                 .await?,
@@ -134,7 +134,7 @@ impl Client {
     pub async fn transaction_simulate(&self, tx_hex: TransactionHex) -> Result<Vec<OpWithResult>> {
         Self::handle_response(
             self.client
-                .post(format!("{}/transactions/simulate", &self.url))
+                .post(format!("{}/transactions/simulate", self.url))
                 .json(&tx_hex)
                 .send()
                 .await?,
@@ -145,7 +145,7 @@ impl Client {
     pub async fn transaction_inspect(&self, txid: &bitcoin::Txid) -> Result<Vec<OpWithResult>> {
         Self::handle_response(
             self.client
-                .get(format!("{}/transactions/{}/inspect", &self.url, txid))
+                .get(format!("{}/transactions/{}/inspect", self.url, txid))
                 .send()
                 .await?,
         )
@@ -158,7 +158,7 @@ impl Client {
         };
         Self::handle_response(
             self.client
-                .post(format!("{}/contracts/{}", &self.url, contract_address))
+                .post(format!("{}/contracts/{}", self.url, contract_address))
                 .json(&view_expr)
                 .send()
                 .await?,
@@ -169,7 +169,7 @@ impl Client {
     pub async fn wit(&self, contract_address: &ContractAddress) -> Result<ContractResponse> {
         Self::handle_response(
             self.client
-                .get(format!("{}/contracts/{}", &self.url, contract_address))
+                .get(format!("{}/contracts/{}", self.url, contract_address))
                 .send()
                 .await?,
         )
@@ -184,7 +184,7 @@ impl Client {
             self.client
                 .get(format!(
                     "{}/contracts/{}/provenance",
-                    &self.url, contract_address
+                    self.url, contract_address
                 ))
                 .send()
                 .await?,
@@ -195,7 +195,7 @@ impl Client {
     pub async fn result(&self, id: &OpResultId) -> Result<Option<ResultRow>> {
         Self::handle_response(
             self.client
-                .get(format!("{}/results/{}", &self.url, id))
+                .get(format!("{}/results/{}", self.url, id))
                 .send()
                 .await?,
         )
@@ -207,7 +207,7 @@ impl Client {
     pub async fn transaction(&self, txid: &str) -> Result<Option<TransactionRow>> {
         let res = self
             .client
-            .get(format!("{}/transactions/{}", &self.url, txid))
+            .get(format!("{}/transactions/{}", self.url, txid))
             .send()
             .await?;
         if res.status() == StatusCode::NOT_FOUND {
@@ -219,7 +219,7 @@ impl Client {
     pub async fn signer(&self, identifier: &str) -> Result<SignerResponse> {
         Self::handle_response(
             self.client
-                .get(format!("{}/signers/{}", &self.url, identifier))
+                .get(format!("{}/signers/{}", self.url, identifier))
                 .send()
                 .await?,
         )
@@ -231,7 +231,7 @@ impl Client {
     pub async fn signer_footprint(&self, identifier: &str) -> Result<Option<FootprintResponse>> {
         let res = self
             .client
-            .get(format!("{}/signers/{}/footprint", &self.url, identifier))
+            .get(format!("{}/signers/{}/footprint", self.url, identifier))
             .send()
             .await?;
         if res.status() == StatusCode::NOT_FOUND {
@@ -246,7 +246,7 @@ impl Client {
     pub async fn signer_opt(&self, identifier: &str) -> Result<Option<SignerResponse>> {
         let res = self
             .client
-            .get(format!("{}/signers/{}", &self.url, identifier))
+            .get(format!("{}/signers/{}", self.url, identifier))
             .send()
             .await?;
         if res.status() == StatusCode::NOT_FOUND {

--- a/core/indexer/src/config.rs
+++ b/core/indexer/src/config.rs
@@ -157,13 +157,19 @@ pub struct Config {
 
     /// Blocks below the tip to retain before a `contract_state` version becomes
     /// eligible for pruning. Floored at the consensus finality window at the
-    /// prune call site. Default 144 ≈ one day of Bitcoin blocks — deep enough
-    /// that a reorg crossing the prune horizon is effectively impossible.
+    /// prune call site. Must stay ABOVE the reactor's maximum in-flight block
+    /// buffer (`MAX_PENDING_BLOCKS` + the block channel capacity) plus real
+    /// reorg headroom: a rollback queued behind a full buffer is processed only
+    /// after the buffered blocks are decided, so `last_height` can sprint that
+    /// far past the fork before the rollback lands — the retained history is
+    /// what lets that self-heal instead of tripping the deep-reorg bail.
+    /// Default 288 ≈ two days of Bitcoin blocks: 160 of buffer sprint + 128 of
+    /// genuine reorg headroom.
     #[clap(
         long,
         env = "PRUNE_RETAIN_BLOCKS",
-        default_value = "144",
-        help = "Blocks below tip to retain before pruning (default 144 ≈ 1 day of Bitcoin blocks)"
+        default_value = "288",
+        help = "Blocks below tip to retain before pruning (default 288 ≈ 2 days of Bitcoin blocks)"
     )]
     pub prune_retain_blocks: u64,
 
@@ -205,7 +211,7 @@ impl Config {
             genesis_file: PathBuf::new(),
             consensus_propose_timeout_ms: 10000,
             prune: true,
-            prune_retain_blocks: 144,
+            prune_retain_blocks: 288,
             view_gas_limit: DEFAULT_VIEW_GAS_LIMIT,
         }
     }

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -63,6 +63,16 @@ use executor::Executor;
 /// buffer again. Consensus always drains from the lowest buffered height, so
 /// gating the tail never starves it. At full mainnet blocks 128 caps the buffer
 /// near a few hundred MB; on signet it is negligible.
+///
+/// The gate also delays `BlockEvent::Rollback`: a rollback queued behind a full
+/// buffer is processed only after the buffered (possibly orphaned) blocks are
+/// decided, so `last_height` can advance up to this cap plus the block channel
+/// capacity past a reorg fork before the rollback lands. That self-heals — the
+/// rollback truncates and the poller re-sends from the fork — PROVIDED the
+/// pruned-state retain window still covers the fork: `prune_retain_blocks` must
+/// exceed `MAX_PENDING_BLOCKS` + channel capacity + real reorg headroom, or the
+/// deep-reorg bail in `process_block_event` fires on an ordinary shallow reorg.
+/// Keep this constant and that config default in lockstep.
 const MAX_PENDING_BLOCKS: usize = 128;
 
 pub type Simulation = (

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -54,6 +54,17 @@ use crate::{
 
 use executor::Executor;
 
+/// High-water mark on `consensus_state::pending_blocks`: the reactor stops
+/// draining `block_rx` once this many blocks are buffered ahead of consensus,
+/// letting the bounded poller→reactor channel fill and backpressure the Bitcoin
+/// poller. Without it, initial catch-up (or any consensus stall) buffers every
+/// block up to the chain tip — an unbounded `BTreeMap` of full blocks that
+/// OOM-kills the pod, which restarts, stalls consensus further, and grows the
+/// buffer again. Consensus always drains from the lowest buffered height, so
+/// gating the tail never starves it. At full mainnet blocks 128 caps the buffer
+/// near a few hundred MB; on signet it is negligible.
+const MAX_PENDING_BLOCKS: usize = 128;
+
 pub type Simulation = (
     indexer_types::Transaction,
     oneshot::Sender<Result<Vec<OpWithResult>>>,
@@ -293,11 +304,17 @@ impl<E: Executor> Reactor<E> {
         fee_publish_ticker.tick().await; // consume the immediate first tick
 
         loop {
-            // Drain pending block events before entering select
-            while let Ok(event) = self.block_rx.try_recv() {
-                self.process_block_event(event)
-                    .await
-                    .context("process_block_event failed (try_recv drain)")?;
+            // Drain pending block events before entering select, but stop at the
+            // high-water mark so the bounded channel backpressures the poller
+            // instead of buffering to the chain tip.
+            while self.consensus.pending_blocks.len() < MAX_PENDING_BLOCKS {
+                match self.block_rx.try_recv() {
+                    Ok(event) => self
+                        .process_block_event(event)
+                        .await
+                        .context("process_block_event failed (try_recv drain)")?,
+                    Err(_) => break,
+                }
             }
 
             let hard_deadline_instant = self.consensus.pending_proposal.as_ref().map(|p| {
@@ -335,7 +352,8 @@ impl<E: Executor> Reactor<E> {
                     info!("Cancelled");
                     break;
                 }
-                Some(event) = self.block_rx.recv() => {
+                Some(event) = self.block_rx.recv(),
+                    if self.consensus.pending_blocks.len() < MAX_PENDING_BLOCKS => {
                     self.process_block_event(event)
                         .await
                         .context("process_block_event failed")?;

--- a/core/indexer/src/reactor/reactor_cluster_tests.rs
+++ b/core/indexer/src/reactor/reactor_cluster_tests.rs
@@ -1319,3 +1319,54 @@ async fn prod_reactor_simulate_transaction() -> Result<()> {
     cluster.shutdown().await;
     Ok(())
 }
+
+/// A node that can't finalize (here: consensus lacks quorum) must bound
+/// `pending_blocks` and backpressure the block producer rather than buffer every
+/// block up to the chain tip in memory — the unbounded-growth OOM that took down
+/// the signet validator set. See `MAX_PENDING_BLOCKS`.
+#[tokio::test]
+async fn prod_reactor_pending_blocks_bounded_under_stalled_consensus() -> Result<()> {
+    // 4-validator genesis, boot only 2 → 200/400 voting power, below the >2/3
+    // BFT threshold, so no `Value::Block` is ever decided and `pending_blocks`
+    // never drains. Without the high-water gate the reactor would drain its block
+    // channel into the map without limit.
+    let cluster = ReactorCluster::start_with(4, 2).await?;
+
+    // Flood one node with far more blocks than the buffer + channel can hold. Each
+    // send has a generous timeout; the first send that blocks past it is the
+    // backpressure point — the reactor has stopped draining at the high-water mark.
+    let producer = cluster.block_txs[0].clone();
+    let flood = 1200u64;
+    let mut accepted = 0u64;
+    for height in 1..=flood {
+        let event = BlockEvent::BlockInsert {
+            target_height: height,
+            block: indexer_types::Block {
+                height,
+                hash: crate::test_utils::new_mock_block_hash(height as u32),
+                prev_hash: crate::test_utils::new_mock_block_hash(height.saturating_sub(1) as u32),
+                transactions: Vec::new(),
+            },
+        };
+        match tokio::time::timeout(Duration::from_secs(5), producer.send(event)).await {
+            Ok(Ok(())) => accepted += 1,
+            _ => break,
+        }
+    }
+
+    // With the gate, accepted saturates near MAX_PENDING_BLOCKS (held in the map)
+    // plus the 256-slot test channel — far below the flood. Without it, all 1200
+    // would be accepted into the unbounded map.
+    let ceiling = super::MAX_PENDING_BLOCKS as u64 + 256 + 16;
+    assert!(
+        accepted >= super::MAX_PENDING_BLOCKS as u64,
+        "reactor did not drain up to the high-water mark: accepted {accepted}"
+    );
+    assert!(
+        accepted <= ceiling,
+        "pending_blocks is unbounded: accepted {accepted}/{flood} exceeds {ceiling} — high-water gate not applied"
+    );
+
+    cluster.shutdown().await;
+    Ok(())
+}

--- a/core/macros/src/model.rs
+++ b/core/macros/src/model.rs
@@ -54,7 +54,7 @@ pub fn generate_struct(
 
                 if utils::is_map_type(field_ty) {
                     let (k_ty, v_ty) = get_map_types(field_ty)?;
-                    let field_model_name = Ident::new(&format!("{}{}{}Model", type_name, &field_name.to_string().to_pascal_case(), write_prefix), field.span());
+                    let field_model_name = Ident::new(&format!("{}{}{}Model", type_name, field_name.to_string().to_pascal_case(), write_prefix), field.span());
                     let vi = value_item(write, &v_ty, field.span())?;
 
                     if vi.is_primitive {
@@ -227,7 +227,7 @@ pub fn generate_struct(
                     }
                 } else if utils::is_deque_type(field_ty) {
                     let v_ty = get_deque_type(field_ty)?;
-                    let field_model_name = Ident::new(&format!("{}{}{}Model", type_name, &field_name.to_string().to_pascal_case(), write_prefix), field.span());
+                    let field_model_name = Ident::new(&format!("{}{}{}Model", type_name, field_name.to_string().to_pascal_case(), write_prefix), field.span());
                     let vi = value_item(write, &v_ty, field.span())?;
                     let item_ty = &vi.item_ty;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core reactor block ingestion and default pruning retention, which affects memory under consensus stalls and reorg safety; behavior is covered by a new cluster test but production catch-up/reorg edge cases warrant review.
> 
> **Overview**
> When consensus stalls (catch-up or missing quorum), the reactor no longer drains the block channel into an unbounded `pending_blocks` map. It stops accepting new block events once **`MAX_PENDING_BLOCKS` (128)** buffered blocks are ahead of consensus, so the poller channel fills and **backpressures** the Bitcoin follower instead of OOMing the pod.
> 
> The event loop applies that cap on both the pre-`select!` `try_recv` drain and the `block_rx` branch. Docs call out that delayed rollbacks behind a full buffer can advance `last_height` past a fork before truncation; **`prune_retain_blocks` default is raised from 144 to 288** so pruned nodes still retain enough history for that path to self-heal without hitting the deep-reorg bail.
> 
> Adds cluster test **`prod_reactor_pending_blocks_bounded_under_stalled_consensus`** (2/4 validators, flood blocks, assert accept count stays near the ceiling). Unrelated nits: drop redundant `&` in URL `format!` strings in the API client and macro model name generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04046b0e9dd036ef5673d020f923aff72fba84d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->