### PR TITLE
fix(sdk-native): fix Android JNI adapter load crash (DT_NEEDED path + fbjni unwrap)

### DIFF
--- a/sdk-native/android/CMakeLists.txt
+++ b/sdk-native/android/CMakeLists.txt
@@ -38,17 +38,27 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
 
 # The Rust core ships as a pre-linked shared library (libkontor_sdk_native.so in
-# jniLibs), not a static archive — see build-mobile.sh for why. Link it as a
-# SHARED import: Gradle packages the .so into the APK's lib/<abi>/, and the
-# dynamic linker resolves it at load time (KontorSdkNativeModule.kt loads it
-# explicitly before this JSI adapter, so it is already in the process).
+# jniLibs), not a static archive — see build-mobile.sh for why. Gradle packages
+# the .so into the APK's lib/<abi>/, and KontorSdkNativeModule.kt loads it
+# explicitly (System.loadLibrary("kontor_sdk_native")) before this JSI adapter,
+# so it is already resolved in the process by the time the adapter is loaded.
+#
+# Link it via a library search directory + -l, NOT by absolute path. The core
+# cdylib carries no DT_SONAME (uniffi's cdylib is emitted without one), so linking
+# it by full path makes the linker bake that build-time path in verbatim as this
+# adapter's DT_NEEDED — e.g.
+#   ../../../../src/main/jniLibs/arm64-v8a/libkontor_sdk_native.so
+# On device every .so is flattened into lib/<abi>/, so that path cannot be
+# resolved and the process aborts (UnsatisfiedLinkError) the first time the
+# adapter loads. Resolved through -l instead, the linker records the bare basename
+# "libkontor_sdk_native.so", which the loader matches against the core already
+# loaded above.
 cmake_path(
-  SET MY_RUST_LIB
-  ${CMAKE_SOURCE_DIR}/src/main/jniLibs/${ANDROID_ABI}/libkontor_sdk_native.so
+  SET MY_RUST_LIB_DIR
+  ${CMAKE_SOURCE_DIR}/src/main/jniLibs/${ANDROID_ABI}
   NORMALIZE
 )
-add_library(my_rust_lib SHARED IMPORTED)
-set_target_properties(my_rust_lib PROPERTIES IMPORTED_LOCATION ${MY_RUST_LIB})
+target_link_directories(kontor-sdk-native PRIVATE ${MY_RUST_LIB_DIR})
 
 # Add ReactAndroid libraries, being careful to account for different versions.
 find_package(ReactAndroid REQUIRED CONFIG)
@@ -77,5 +87,5 @@ target_link_libraries(
   fbjni::fbjni
   ReactAndroid::jsi
   ${LOGCAT}
-  my_rust_lib
+  kontor_sdk_native
 )

--- a/sdk-native/android/cpp-adapter.cpp
+++ b/sdk-native/android/cpp-adapter.cpp
@@ -2,9 +2,11 @@
 #include <jni.h>
 #include <jsi/jsi.h>
 #include <ReactCommon/CallInvokerHolder.h>
+#include <fbjni/fbjni.h>
 #include "kontor-sdk-native.h"
 
 namespace jsi = facebook::jsi;
+namespace jni = facebook::jni;
 namespace react = facebook::react;
 
 // Automated testing checks Java_com_kontor_sdknative_KontorSdkNativeModule and kontormobile
@@ -24,32 +26,20 @@ Java_com_kontor_sdknative_KontorSdkNativeModule_nativeInstallRustCrate(
     jlong rtPtr,
     jobject callInvokerHolderJavaObj
 ) {
-    // https://github.com/realm/realm-js/blob/main/packages/realm/binding/android/src/main/cpp/io_realm_react_RealmReactModule.cpp#L122-L145
-    // React Native uses the fbjni library for handling JNI, which has the concept of "hybrid objects",
-    // which are Java objects containing a pointer to a C++ object. The CallInvokerHolder, which has the
-    // invokeAsync method we want access to, is one such hybrid object.
-    // Rather than reworking our code to use fbjni throughout, this code unpacks the C++ object from the Java
-    // object `callInvokerHolderJavaObj` manually, based on reverse engineering the fbjni code.
-
-    // 1. Get the Java object referred to by the mHybridData field of the Java holder object
-    auto callInvokerHolderClass = env->GetObjectClass(callInvokerHolderJavaObj);
-    auto hybridDataField = env->GetFieldID(callInvokerHolderClass, "mHybridData", "Lcom/facebook/jni/HybridData;");
-    auto hybridDataObj = env->GetObjectField(callInvokerHolderJavaObj, hybridDataField);
-
-    // 2. Get the destructor Java object referred to by the mDestructor field from the myHybridData Java object
-    auto hybridDataClass = env->FindClass("com/facebook/jni/HybridData");
-    auto destructorField =
-        env->GetFieldID(hybridDataClass, "mDestructor", "Lcom/facebook/jni/HybridData$Destructor;");
-    auto destructorObj = env->GetObjectField(hybridDataObj, destructorField);
-
-    // 3. Get the mNativePointer field from the mDestructor Java object
-    auto destructorClass = env->FindClass("com/facebook/jni/HybridData$Destructor");
-    auto nativePointerField = env->GetFieldID(destructorClass, "mNativePointer", "J");
-    auto nativePointerValue = env->GetLongField(destructorObj, nativePointerField);
-
-    // 4. Cast the mNativePointer back to its C++ type
-    auto nativePointer = reinterpret_cast<facebook::react::CallInvokerHolder*>(nativePointerValue);
-    auto jsCallInvoker = nativePointer->getCallInvoker();
+    // React Native's CallInvokerHolder (CallInvokerHolderImpl on the Java side)
+    // is an fbjni HybridClass: a Java object that wraps a C++ instance. Unwrap it
+    // the way RN itself does in TurboModuleManager.cpp — wrap the incoming jobject
+    // in an fbjni alias_ref and pull the C++ instance out with cthis().
+    //
+    // Do NOT reflect on fbjni's private fields (the old realm-js snippet here read
+    // an mHybridData field off the holder): RN 0.83 / New Arch moved
+    // CallInvokerHolderImpl onto com.facebook.jni.HybridClassBase and dropped that
+    // field, so the reflection path throws NoSuchFieldError and aborts the process
+    // on the first Kontor call. cthis() depends only on fbjni's public HybridClass
+    // contract, so it is version-agnostic across that change.
+    auto callInvokerHolder = jni::alias_ref<react::CallInvokerHolder::javaobject>{
+        reinterpret_cast<react::CallInvokerHolder::javaobject>(callInvokerHolderJavaObj)};
+    auto jsCallInvoker = callInvokerHolder->cthis()->getCallInvoker();
 
     auto runtime = reinterpret_cast<jsi::Runtime *>(rtPtr);
     return kontormobile::installRustCrate(*runtime, jsCallInvoker);


### PR DESCRIPTION
## Summary

Fixes two independent bugs that made the Android JSI adapter abort on the **first Kontor call**. Both only surface on-device (not in the host/unit environment), so they slipped past the existing checks.

### 1. `CMakeLists.txt` — `DT_NEEDED` baked with an absolute build-time path

The Rust core ships as a pre-linked shared library (`libkontor_sdk_native.so`) with **no `DT_SONAME`** — uniffi's cdylib is emitted without one. Linking it into the adapter by absolute path (`add_library(... SHARED IMPORTED)` + `IMPORTED_LOCATION`) therefore made the linker record that full build-time path verbatim as the adapter's `DT_NEEDED`, e.g. `.../src/main/jniLibs/arm64-v8a/libkontor_sdk_native.so`.

On device every `.so` is flattened into `lib/<abi>/`, so that path cannot be resolved → `UnsatisfiedLinkError` when the adapter loads.

**Fix:** link via a library search directory + `-l` (`target_link_directories` + `kontor_sdk_native`). The linker then records the bare basename `libkontor_sdk_native.so`, which the Android loader matches against the core already loaded by `KontorSdkNativeModule` (via `System.loadLibrary("kontor_sdk_native")`) **before** the adapter.

### 2. `cpp-adapter.cpp` — `CallInvokerHolder` unwrapped via private-field reflection

The old code (a copied realm-js snippet) reached the C++ `CallInvokerHolder` by reflecting on fbjni's private `mHybridData` / `mDestructor` / `mNativePointer` fields. RN 0.83 / New Arch moved `CallInvokerHolderImpl` onto `com.facebook.jni.HybridClassBase` and **dropped `mHybridData`** → `NoSuchFieldError`, aborting the process on the first call.

**Fix:** use fbjni's public `HybridClass` contract — wrap the incoming `jobject` in an `alias_ref` and call `cthis()`. This is the exact path RN itself uses in `TurboModuleManager.cpp`, and it is version-agnostic across the `HybridClassBase` change.

## Review notes

- `CallInvokerHolder` is confirmed an fbjni `HybridClass` (`CallInvokerHolder.h`), and RN's own `TurboModuleManager.cpp` uses `->cthis()->getCallInvoker()` identically.
- Load order verified: the core is loaded before the adapter, so basename resolution succeeds.
- No dangling references to the removed `my_rust_lib` target.

## Testing

Native Android build/link is validated by the `build-mobile-artifacts` CI workflow (not cheaply reproducible locally without the full NDK + gradle + RN toolchain).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native load/link behavior and JNI entry for every Android Kontor call; fixes are targeted but failures would still block the whole mobile SDK on device.
> 
> **Overview**
> Fixes two on-device crashes that hit the Android JSI adapter on the **first Kontor call**.
> 
> **CMake linking:** The Rust core is now linked with `target_link_directories` and `-lkontor_sdk_native` instead of an `IMPORTED` `.so` at a full build path. That avoids baking a jniLibs-relative path into the adapter’s `DT_NEEDED`, which the loader cannot resolve once APK libs are flattened under `lib/<abi>/` (previously `UnsatisfiedLinkError` on adapter load). Basename resolution still works because `KontorSdkNativeModule` loads `kontor_sdk_native` before the adapter.
> 
> **CallInvoker unwrapping:** `nativeInstallRustCrate` no longer reflects private fbjni fields (`mHybridData`, etc.) to reach `CallInvokerHolder`. It uses `fbjni::alias_ref` and `cthis()->getCallInvoker()`, matching React Native’s TurboModule path and avoiding `NoSuchFieldError` on RN 0.83 / New Arch where `mHybridData` was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fb9ec1757ed1065fe33ffb8d5cc4ae79a7afce6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->