### PR TITLE
fix(consensus): rollback/finality hardening pass (#433, #427, #426, #424, #430)

### DIFF
--- a/core/indexer/src/database/queries/batches.rs
+++ b/core/indexer/src/database/queries/batches.rs
@@ -25,34 +25,55 @@ pub async fn insert_batch(
     Ok(())
 }
 
-pub async fn delete_batches_above_anchor(conn: &Connection, max_anchor: u64) -> Result<u64, Error> {
-    let rows = conn
-        .execute(
-            "DELETE FROM batches WHERE anchor_height > ?",
-            params![max_anchor],
+/// The immutable decided txid list for a batch, written at decide time (see
+/// schema.sql `batch_txids`). Idempotent per (batch_height, position).
+pub async fn insert_batch_txids(
+    conn: &Connection,
+    batch_height: u64,
+    txids: &[String],
+) -> Result<(), Error> {
+    for (position, txid) in txids.iter().enumerate() {
+        conn.execute(
+            "INSERT OR IGNORE INTO batch_txids (batch_height, position, txid) VALUES (?, ?, ?)",
+            params![batch_height, position as u64, txid.as_str()],
         )
         .await?;
-
-    Ok(rows)
+    }
+    Ok(())
 }
 
-/// Delete the `unconfirmed_batch_txs` children of every batch above
-/// `max_anchor`. Must run before `delete_batches_above_anchor`: the FK carries
-/// no cascade (deliberately — see schema.sql), so surviving children would
-/// make the parent delete fail.
-pub async fn delete_unconfirmed_batch_txs_above_anchor(
+/// Startup cleanup: forget the decided-but-unexecuted SUFFIX of consensus
+/// history. `X` is the last consensus height whose anchor this node has
+/// actually processed; everything above `X` is deleted (children first — the
+/// FKs carry no cascade, deliberately) and re-synced from peers. A suffix,
+/// NOT an anchor band: deleting by `anchor_height > ?` punches holes in the
+/// consensus-height sequence when anchors are non-monotone across a rollback,
+/// and a gap can never be refilled locally. Returns (deleted batches, X).
+pub async fn delete_unexecuted_batch_suffix(
     conn: &Connection,
-    max_anchor: u64,
-) -> Result<u64, Error> {
-    let rows = conn
-        .execute(
-            "DELETE FROM unconfirmed_batch_txs WHERE batch_height IN \
-             (SELECT consensus_height FROM batches WHERE anchor_height > ?)",
-            params![max_anchor],
+    last_block_height: u64,
+) -> Result<(u64, u64), Error> {
+    let mut rows = conn
+        .query(
+            "SELECT COALESCE(MAX(consensus_height), 0) FROM batches WHERE anchor_height <= ?",
+            params![last_block_height],
         )
         .await?;
-
-    Ok(rows)
+    let x: u64 = match rows.next().await? {
+        Some(row) => row.get(0)?,
+        None => 0,
+    };
+    conn.execute(
+        "DELETE FROM unconfirmed_batch_txs WHERE batch_height > ?",
+        params![x],
+    )
+    .await?;
+    conn.execute("DELETE FROM batch_txids WHERE batch_height > ?", params![x])
+        .await?;
+    let deleted = conn
+        .execute("DELETE FROM batches WHERE consensus_height > ?", params![x])
+        .await?;
+    Ok((deleted, x))
 }
 
 pub async fn select_latest_consensus_height(conn: &Connection) -> Result<Option<u64>, Error> {
@@ -78,6 +99,7 @@ pub async fn select_batch(
 ) -> Result<Option<BatchQueryResult>, Error> {
     let results = query_batches(
         conn,
+        "",
         &format!("WHERE b.consensus_height = {consensus_height}"),
     )
     .await?;
@@ -100,7 +122,15 @@ pub async fn select_batches_from_anchor(
     conn: &Connection,
     from_anchor: u64,
 ) -> Result<Vec<BatchQueryResult>, Error> {
-    query_batches(conn, &format!("WHERE b.anchor_height >= {from_anchor}")).await
+    // INDEXED BY: production DBs never run ANALYZE, so without stats the
+    // planner full-scans `batches` for this anchor-band filter instead of
+    // using the index built for it.
+    query_batches(
+        conn,
+        "INDEXED BY idx_batches_anchor_height",
+        &format!("WHERE b.anchor_height >= {from_anchor}"),
+    )
+    .await
 }
 
 pub async fn select_batches_in_range(
@@ -110,22 +140,29 @@ pub async fn select_batches_in_range(
 ) -> Result<Vec<BatchQueryResult>, Error> {
     query_batches(
         conn,
+        "",
         &format!("WHERE b.consensus_height >= {start} AND b.consensus_height <= {end}"),
     )
     .await
 }
 
+/// Load batches with their CERTIFIED txid lists (`batch_txids`, written at
+/// decide time) — not the `transactions` join: execution rows are absent for
+/// record-only batches and cascade-deleted by rollbacks, so deriving the
+/// served value from them diverges from the certificate. Rows recorded before
+/// `batch_txids` existed fall back to the `transactions` join.
 async fn query_batches(
     conn: &Connection,
+    index_hint: &str,
     where_clause: &str,
 ) -> Result<Vec<BatchQueryResult>, Error> {
     let sql = format!(
         "SELECT b.consensus_height, b.anchor_height, b.anchor_hash, b.is_block, b.certificate, \
-                t.txid \
-         FROM batches b \
-         LEFT JOIN transactions t ON t.batch_height = b.consensus_height \
+                bt.txid \
+         FROM batches b {index_hint} \
+         LEFT JOIN batch_txids bt ON bt.batch_height = b.consensus_height \
          {where_clause} \
-         ORDER BY b.consensus_height, t.id"
+         ORDER BY b.consensus_height, bt.position"
     );
     let mut rows = conn.query(&sql, ()).await?;
 
@@ -150,6 +187,35 @@ async fn query_batches(
                 certificate: row.get(4)?,
                 txids: txid.into_iter().collect(),
             });
+        }
+    }
+
+    // Legacy fallback: batches recorded before the batch_txids table existed
+    // have no certified rows — recover their txids from the transactions join
+    // (valid only while those execution rows survive, which matched the old
+    // serving behavior anyway). One query for all such heights.
+    let legacy: Vec<u64> = results
+        .iter()
+        .filter(|r| !r.is_block && r.txids.is_empty())
+        .map(|r| r.consensus_height)
+        .collect();
+    if !legacy.is_empty() {
+        let in_list = legacy
+            .iter()
+            .map(u64::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "SELECT batch_height, txid FROM transactions \
+             WHERE batch_height IN ({in_list}) ORDER BY batch_height, id"
+        );
+        let mut rows = conn.query(&sql, ()).await?;
+        while let Some(row) = rows.next().await? {
+            let height: u64 = row.get(0)?;
+            let txid: String = row.get(1)?;
+            if let Some(r) = results.iter_mut().find(|r| r.consensus_height == height) {
+                r.txids.push(txid);
+            }
         }
     }
 

--- a/core/indexer/src/database/queries/batches.rs
+++ b/core/indexer/src/database/queries/batches.rs
@@ -36,6 +36,25 @@ pub async fn delete_batches_above_anchor(conn: &Connection, max_anchor: u64) -> 
     Ok(rows)
 }
 
+/// Delete the `unconfirmed_batch_txs` children of every batch above
+/// `max_anchor`. Must run before `delete_batches_above_anchor`: the FK carries
+/// no cascade (deliberately — see schema.sql), so surviving children would
+/// make the parent delete fail.
+pub async fn delete_unconfirmed_batch_txs_above_anchor(
+    conn: &Connection,
+    max_anchor: u64,
+) -> Result<u64, Error> {
+    let rows = conn
+        .execute(
+            "DELETE FROM unconfirmed_batch_txs WHERE batch_height IN \
+             (SELECT consensus_height FROM batches WHERE anchor_height > ?)",
+            params![max_anchor],
+        )
+        .await?;
+
+    Ok(rows)
+}
+
 pub async fn select_latest_consensus_height(conn: &Connection) -> Result<Option<u64>, Error> {
     // `SELECT MAX(...)` always yields a row (NULL on empty table). Read the
     // column directly as `Option<u64>` so NULL surfaces as `None` and any

--- a/core/indexer/src/database/sql/schema.sql
+++ b/core/indexer/src/database/sql/schema.sql
@@ -18,6 +18,13 @@ CREATE TABLE IF NOT EXISTS batches (
   is_block BOOLEAN NOT NULL DEFAULT 0
 );
 
+-- The batch_height FK (here and on unconfirmed_batch_txs) deliberately has NO
+-- cascade: batches are the decided consensus record and are never deleted while
+-- children exist. Rollbacks delete transactions via the height->blocks cascade;
+-- the one path that deletes batches (startup cleanup of decided-but-unexecuted
+-- rows, ConsensusState::new) deletes children explicitly first, and FK
+-- enforcement failing LOUD there is the guard against any future deletion path
+-- forgetting to.
 CREATE TABLE IF NOT EXISTS transactions (
   id INTEGER PRIMARY KEY,
   txid TEXT NOT NULL UNIQUE,

--- a/core/indexer/src/database/sql/schema.sql
+++ b/core/indexer/src/database/sql/schema.sql
@@ -36,13 +36,31 @@ CREATE TABLE IF NOT EXISTS transactions (
   FOREIGN KEY (batch_height) REFERENCES batches (consensus_height)
 );
 
--- Rollback replay reloads decided values by anchor (`WHERE anchor_height >= ?`
--- joined to transactions on batch_height). `batches` grows one row per
--- consensus height for the life of the chain and runs this on every Bitcoin
--- reorg — without these two indexes it's a full scan on both sides of the join.
+-- Rollback replay reloads decided values by anchor (`WHERE anchor_height >= ?`).
+-- `batches` grows one row per consensus height for the life of the chain —
+-- without these indexes the reload and the legacy txid fallback are full scans.
+-- NB: production DBs never run ANALYZE, so the planner won't pick
+-- idx_batches_anchor_height on its own — `select_batches_from_anchor` names it
+-- via INDEXED BY.
 CREATE INDEX IF NOT EXISTS idx_batches_anchor_height ON batches (anchor_height);
 CREATE INDEX IF NOT EXISTS idx_transactions_batch_height ON transactions (batch_height)
   WHERE batch_height IS NOT NULL;
+
+-- The immutable decided txid list of each batch, written at decide time and
+-- kept for as long as the batch row exists. Sync must serve the CERTIFIED
+-- value for a consensus height regardless of whether this node executed the
+-- batch (anchor-gate record-only skips insert no `transactions` rows) or
+-- rolled its effects back (the blocks cascade deletes the `transactions`
+-- rows) — deriving served txids from `transactions` made the served value
+-- diverge from the certificate in both cases. `position` preserves decided
+-- order. Same no-cascade FK policy as the other batch children (see above).
+CREATE TABLE IF NOT EXISTS batch_txids (
+  batch_height INTEGER NOT NULL,
+  position INTEGER NOT NULL,
+  txid TEXT NOT NULL,
+  PRIMARY KEY (batch_height, position),
+  FOREIGN KEY (batch_height) REFERENCES batches (consensus_height)
+);
 
 CREATE TABLE IF NOT EXISTS contracts (
   id INTEGER PRIMARY KEY,

--- a/core/indexer/src/database/sql/schema.sql
+++ b/core/indexer/src/database/sql/schema.sql
@@ -36,6 +36,14 @@ CREATE TABLE IF NOT EXISTS transactions (
   FOREIGN KEY (batch_height) REFERENCES batches (consensus_height)
 );
 
+-- Rollback replay reloads decided values by anchor (`WHERE anchor_height >= ?`
+-- joined to transactions on batch_height). `batches` grows one row per
+-- consensus height for the life of the chain and runs this on every Bitcoin
+-- reorg — without these two indexes it's a full scan on both sides of the join.
+CREATE INDEX IF NOT EXISTS idx_batches_anchor_height ON batches (anchor_height);
+CREATE INDEX IF NOT EXISTS idx_transactions_batch_height ON transactions (batch_height)
+  WHERE batch_height IS NOT NULL;
+
 CREATE TABLE IF NOT EXISTS contracts (
   id INTEGER PRIMARY KEY,
   name TEXT NOT NULL,

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -19,8 +19,8 @@ use crate::consensus::finality_types::{
 };
 use crate::consensus::{CommitCertificate, Ctx, Height, ProposalData, Value};
 use crate::database::queries::{
-    insert_batch, insert_transaction, insert_unconfirmed_batch_tx, select_block_at_height,
-    select_existing_txids,
+    insert_batch, insert_batch_txids, insert_transaction, insert_unconfirmed_batch_tx,
+    select_block_at_height, select_existing_txids,
 };
 use crate::metrics::{CONSENSUS_HEIGHT, ITEMS_INDEXED};
 
@@ -108,31 +108,37 @@ fn dependency_sort(txs: &[bitcoin::Transaction]) -> Vec<usize> {
 /// replayed batches; dropping a parent while keeping its child would execute
 /// the child against missing UTXOs and commit its deterministic failure —
 /// silent state divergence (#427). Operates over the ordered replay sequence,
-/// since a child may sit in a later batch than its parent. One forward pass
-/// reaches the fixed point because parents always precede children: within a
-/// batch by the dependency-order consensus rule, across batches because a
-/// child can only be decided after its parent's batch existed.
+/// since a child may sit in a later batch than its parent. Iterates the
+/// forward pass to a true fixed point rather than assuming parents always
+/// precede children across batches — decided order makes that overwhelmingly
+/// likely, but no consensus rule ENFORCES the cross-batch direction, and the
+/// loop costs one extra no-growth pass in the normal case.
 fn transitive_exclusion(
     batches: &[Vec<bitcoin::Transaction>],
     excluded: &HashSet<Txid>,
 ) -> HashSet<Txid> {
     let mut excluded = excluded.clone();
-    for txs in batches {
-        for tx in txs {
-            let txid = tx.compute_txid();
-            if excluded.contains(&txid) {
-                continue;
-            }
-            if tx
-                .input
-                .iter()
-                .any(|i| excluded.contains(&i.previous_output.txid))
-            {
-                excluded.insert(txid);
+    loop {
+        let before = excluded.len();
+        for txs in batches {
+            for tx in txs {
+                let txid = tx.compute_txid();
+                if excluded.contains(&txid) {
+                    continue;
+                }
+                if tx
+                    .input
+                    .iter()
+                    .any(|i| excluded.contains(&i.previous_output.txid))
+                {
+                    excluded.insert(txid);
+                }
             }
         }
+        if excluded.len() == before {
+            return excluded;
+        }
     }
-    excluded
 }
 
 /// Check that a batch's transactions are in a valid dependency order:
@@ -170,7 +176,51 @@ pub(super) fn batch_is_ordered(txs: &[bitcoin::Transaction]) -> bool {
     true
 }
 
+/// What `process_decided_batch` did with a decided batch. Callers must not
+/// announce `RecordedOnly` batches as processed — their transactions were
+/// never executed here.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum BatchOutcome {
+    /// Executed and committed at its anchor.
+    Executed,
+    /// Recorded for sync/bookkeeping only (empty batch, or anchor mismatch).
+    RecordedOnly,
+}
+
 impl<E: Executor> Reactor<E> {
+    /// Persist a decided batch's certified content, idempotently: the
+    /// immutable txid list (`batch_txids`, what sync serves for this
+    /// consensus height) and the raw txs (`unconfirmed_batch_txs`, what
+    /// replay and unfinalized-batch sync resolve from). Written for executed
+    /// AND record-only batches — the certificate covers both.
+    async fn record_batch_txs(
+        &self,
+        conn: &libsql::Connection,
+        consensus_height: Height,
+        batch_txs: &[bitcoin::Transaction],
+    ) -> Result<()> {
+        let txids: Vec<String> = batch_txs
+            .iter()
+            .map(|tx| tx.compute_txid().to_string())
+            .collect();
+        insert_batch_txids(conn, consensus_height.as_u64(), &txids)
+            .await
+            .context("Failed to insert batch txids")?;
+        for raw_tx in batch_txs {
+            let txid = raw_tx.compute_txid();
+            let serialized = bitcoin::consensus::serialize(raw_tx);
+            insert_unconfirmed_batch_tx(
+                conn,
+                &txid.to_string(),
+                consensus_height.as_u64(),
+                &serialized,
+            )
+            .await
+            .context("Failed to insert unconfirmed batch tx")?;
+        }
+        Ok(())
+    }
+
     pub(super) async fn process_decided_batch(
         &mut self,
         anchor_height: u64,
@@ -178,7 +228,7 @@ impl<E: Executor> Reactor<E> {
         consensus_height: Height,
         certificate: &[u8],
         batch_txs: &[bitcoin::Transaction],
-    ) -> Result<()> {
+    ) -> Result<BatchOutcome> {
         let started_at = Instant::now();
         let conn = self.db_conn();
 
@@ -218,7 +268,7 @@ impl<E: Executor> Reactor<E> {
                 duration_ms = started_at.elapsed().as_millis() as u64,
                 "Empty batch recorded"
             );
-            return Ok(());
+            return Ok(BatchOutcome::RecordedOnly);
         }
 
         // A decided batch may only EXECUTE against the exact chain state it was
@@ -251,7 +301,12 @@ impl<E: Executor> Reactor<E> {
             )
             .await
             .context("Failed to record anchor-mismatched batch for sync")?;
-            return Ok(());
+            // Persist the certified content too (idempotent): a skipped batch
+            // must still be servable to syncing peers with its real txs, and
+            // the batch_txids/unconfirmed rows are what the sync path reads.
+            self.record_batch_txs(&conn, consensus_height, batch_txs)
+                .await?;
+            return Ok(BatchOutcome::RecordedOnly);
         }
 
         // Execute in decided order. `validate_batch` enforces dependency
@@ -296,19 +351,9 @@ impl<E: Executor> Reactor<E> {
         .await
         .context("Failed to insert batch")?;
 
-        // Store raw txs for replay/sync recovery
-        for raw_tx in batch_txs {
-            let txid = raw_tx.compute_txid();
-            let serialized = bitcoin::consensus::serialize(raw_tx);
-            insert_unconfirmed_batch_tx(
-                &conn,
-                &txid.to_string(),
-                consensus_height.as_u64(),
-                &serialized,
-            )
-            .await
-            .context("Failed to insert unconfirmed batch tx")?;
-        }
+        // Store the certified txid list + raw txs for replay/sync recovery
+        self.record_batch_txs(&conn, consensus_height, batch_txs)
+            .await?;
 
         for t in &parsed_txs {
             let tx_id = insert_transaction(
@@ -365,7 +410,7 @@ impl<E: Executor> Reactor<E> {
             "Batch processing complete"
         );
 
-        Ok(())
+        Ok(BatchOutcome::Executed)
     }
 
     pub(super) async fn make_value(&mut self) -> Result<Option<Value>> {
@@ -589,23 +634,39 @@ impl<E: Executor> Reactor<E> {
         Ok(true)
     }
 
-    pub(super) async fn initiate_rollback(
+    /// Load the decided values to replay for a rollback from `from_anchor`.
+    /// MUST run BEFORE the DB truncation: the query joins the `transactions`
+    /// rows for each batch's txids, and those are cascade-deleted with their
+    /// blocks by the rollback.
+    pub(super) async fn load_replay_decisions(
         &mut self,
         from_anchor: u64,
-        excluded_txids: HashSet<Txid>,
-    ) -> Result<()> {
+    ) -> Result<Vec<consensus_state::DeferredDecision>> {
         let conn = self.db_conn();
-        let replay_batches = self
-            .consensus
+        self.consensus
             .get_decided_from_anchor(&conn, from_anchor)
             .await
-            .context("Failed to load replay batches for rollback")?;
+            .context("Failed to load replay batches for rollback")
+    }
 
+    /// Install the replay decisions loaded by `load_replay_decisions` and kick
+    /// off block redelivery. Runs AFTER the DB truncation: the raw-tx
+    /// resolution below can touch bitcoind, and a transient failure here is
+    /// fatal-but-recoverable (the rollback already happened; on restart the
+    /// startup cleanup forgets the unexecuted suffix and the node re-syncs).
+    /// Before the truncation it would instead CANCEL a rollback that finality
+    /// already demanded.
+    pub(super) async fn prepare_replay(
+        &mut self,
+        from_anchor: u64,
+        replay_batches: Vec<consensus_state::DeferredDecision>,
+        excluded_txids: HashSet<Txid>,
+    ) -> Result<()> {
         info!(
             from_anchor,
             replay_batches = replay_batches.len(),
             excluded = excluded_txids.len(),
-            "Initiating rollback"
+            "Initiating rollback replay"
         );
 
         let mut deferred: std::collections::VecDeque<consensus_state::DeferredDecision> =
@@ -705,6 +766,31 @@ impl<E: Executor> Reactor<E> {
                             .await
                             .context("handle_block_with_decision failed in deferred drain")?;
                     } else {
+                        // No pending block at this height. Before parking the
+                        // queue on it, check whether the height was already
+                        // executed: a block row with the SAME hash means this
+                        // decision is a duplicate record (a re-decide after a
+                        // rollback, or a sync replaying both) — already
+                        // satisfied; a DIFFERENT hash means the decided block
+                        // was reorged away. Either way the decision is
+                        // terminal — parking it would wedge the drain forever
+                        // on a delivery that can never come.
+                        match select_block_at_height(&self.db_conn(), bh).await {
+                            Ok(Some(row)) => {
+                                warn!(
+                                    block_height = bh,
+                                    decided = %decided_hash,
+                                    executed = %row.hash,
+                                    consensus_height = %decision.consensus_height,
+                                    "Dropping deferred block decision — height already executed"
+                                );
+                                continue;
+                            }
+                            Ok(None) => {}
+                            Err(e) => {
+                                warn!(error = %e, block_height = bh, "Block lookup failed during drain; parking decision");
+                            }
+                        }
                         info!(
                             block_height = bh,
                             consensus_height = %decision.consensus_height,
@@ -731,20 +817,35 @@ impl<E: Executor> Reactor<E> {
                         let anchor_height = *anchor_height;
                         let anchor_hash = *anchor_hash;
                         let resolved_txs = self.resolve_batch_txs(txs).await?;
-                        self.process_decided_batch(
-                            anchor_height,
-                            anchor_hash,
-                            decision.consensus_height,
-                            &decision.certificate,
-                            &resolved_txs,
-                        )
-                        .await
-                        .context("process_decided_batch failed in deferred drain")?;
-                        if let Some(tx) = &self.event_tx {
-                            let txids: Vec<String> = resolved_txs
-                                .iter()
-                                .map(|tx| tx.compute_txid().to_string())
-                                .collect();
+                        let outcome = self
+                            .process_decided_batch(
+                                anchor_height,
+                                anchor_hash,
+                                decision.consensus_height,
+                                &decision.certificate,
+                                &resolved_txs,
+                            )
+                            .await
+                            .context("process_decided_batch failed in deferred drain")?;
+                        // Executed batches announce their txids; EMPTY batches
+                        // announce with no txids — BatchProcessed is the
+                        // "chain moved" heartbeat the info publisher (and so
+                        // API availability) is driven by, and empty deadline
+                        // batches are the only events a quiet chain produces.
+                        // Only a non-empty record-only skip stays silent:
+                        // nothing executed, and claiming its txids were
+                        // processed is exactly the audit bug.
+                        if (outcome == BatchOutcome::Executed || resolved_txs.is_empty())
+                            && let Some(tx) = &self.event_tx
+                        {
+                            let txids: Vec<String> = if outcome == BatchOutcome::Executed {
+                                resolved_txs
+                                    .iter()
+                                    .map(|tx| tx.compute_txid().to_string())
+                                    .collect()
+                            } else {
+                                Vec::new()
+                            };
                             if tx.send(Event::BatchProcessed { txids }).await.is_err() {
                                 warn!("Event receiver dropped, cannot send BatchProcessed event");
                             }
@@ -868,24 +969,7 @@ impl<E: Executor> Reactor<E> {
                         .context("Failed to encode commit certificate")?
                         .encode_to_vec();
 
-                    if *anchor_height < last_height {
-                        warn!(
-                            anchor = anchor_height,
-                            last_height,
-                            consensus_height = %certificate.height,
-                            "Skipping stale batch — anchor below current height"
-                        );
-                        insert_batch(
-                            &conn,
-                            certificate.height.as_u64(),
-                            *anchor_height,
-                            &anchor_hash.to_string(),
-                            &cert_bytes,
-                            false,
-                        )
-                        .await
-                        .context("Failed to record stale batch for sync")?;
-                    } else if *anchor_height > last_height {
+                    if *anchor_height > last_height {
                         info!(
                             anchor = anchor_height,
                             last_height,
@@ -900,21 +984,38 @@ impl<E: Executor> Reactor<E> {
                             },
                         );
                     } else {
-                        self.process_decided_batch(
-                            *anchor_height,
-                            *anchor_hash,
-                            certificate.height,
-                            &cert_bytes,
-                            &full_txs,
-                        )
-                        .await
-                        .context("process_decided_batch failed in Finalized handler")?;
-                        result = consensus_state::ConsensusResult::BatchProcessed {
-                            txids: full_txs
-                                .iter()
-                                .map(|tx| tx.compute_txid().to_string())
-                                .collect(),
-                        };
+                        // anchor_height <= last_height: process_decided_batch's
+                        // anchor gate executes at an exact tip match and
+                        // records-only (with certified content) for anything
+                        // stale — one gate for both callers.
+                        let outcome = self
+                            .process_decided_batch(
+                                *anchor_height,
+                                *anchor_hash,
+                                certificate.height,
+                                &cert_bytes,
+                                &full_txs,
+                            )
+                            .await
+                            .context("process_decided_batch failed in Finalized handler")?;
+                        // Executed batches announce their txids; EMPTY batches
+                        // announce with no txids — BatchProcessed is the "chain
+                        // moved" heartbeat driving the info publisher and
+                        // therefore API availability, and empty deadline
+                        // batches are the only events a quiet chain produces.
+                        // Only a non-empty record-only skip stays silent.
+                        if outcome == BatchOutcome::Executed || full_txs.is_empty() {
+                            result = consensus_state::ConsensusResult::BatchProcessed {
+                                txids: if outcome == BatchOutcome::Executed {
+                                    full_txs
+                                        .iter()
+                                        .map(|tx| tx.compute_txid().to_string())
+                                        .collect()
+                                } else {
+                                    Vec::new()
+                                },
+                            };
+                        }
                     }
                 }
                 Value::Block { height, hash } => {

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -103,6 +103,38 @@ fn dependency_sort(txs: &[bitcoin::Transaction]) -> Vec<usize> {
     ordered
 }
 
+/// Expand a set of excluded txids to every batch tx that (transitively) spends
+/// an excluded tx's output. Rollback replay filters excluded txids out of
+/// replayed batches; dropping a parent while keeping its child would execute
+/// the child against missing UTXOs and commit its deterministic failure —
+/// silent state divergence (#427). Operates over the ordered replay sequence,
+/// since a child may sit in a later batch than its parent. One forward pass
+/// reaches the fixed point because parents always precede children: within a
+/// batch by the dependency-order consensus rule, across batches because a
+/// child can only be decided after its parent's batch existed.
+fn transitive_exclusion(
+    batches: &[Vec<bitcoin::Transaction>],
+    excluded: &HashSet<Txid>,
+) -> HashSet<Txid> {
+    let mut excluded = excluded.clone();
+    for txs in batches {
+        for tx in txs {
+            let txid = tx.compute_txid();
+            if excluded.contains(&txid) {
+                continue;
+            }
+            if tx
+                .input
+                .iter()
+                .any(|i| excluded.contains(&i.previous_output.txid))
+            {
+                excluded.insert(txid);
+            }
+        }
+    }
+    excluded
+}
+
 /// Check that a batch's transactions are in a valid dependency order:
 /// every tx that spends another batch tx's output appears *after* that
 /// producer.
@@ -186,6 +218,39 @@ impl<E: Executor> Reactor<E> {
                 duration_ms = started_at.elapsed().as_millis() as u64,
                 "Empty batch recorded"
             );
+            return Ok(());
+        }
+
+        // A decided batch may only EXECUTE against the exact chain state it was
+        // anchored to: the local tip must sit at `anchor_height` with
+        // `anchor_hash`. Anything else — a deferred drain whose anchor fell
+        // behind, or a replay whose anchor block was reorged away — is recorded
+        // for sync/bookkeeping but NOT executed: executing against a different
+        // tip writes state (and a checkpoint) at a height the chain disagrees
+        // about, i.e. silent divergence. A skipped batch's txids then simply
+        // never confirm here and the finality window resolves it.
+        // `None` ⇔ all-zeros is the pre-genesis convention `make_value` and
+        // proposal validation anchor with.
+        let local_hash = self.last_hash.unwrap_or(BlockHash::all_zeros());
+        if anchor_height != self.last_height || anchor_hash != local_hash {
+            warn!(
+                anchor_height,
+                %anchor_hash,
+                last_height = self.last_height,
+                %local_hash,
+                consensus_height = %consensus_height,
+                "Skipping decided batch — anchor does not match local tip; recording only"
+            );
+            insert_batch(
+                &conn,
+                consensus_height.as_u64(),
+                anchor_height,
+                &anchor_hash.to_string(),
+                certificate,
+                false,
+            )
+            .await
+            .context("Failed to record anchor-mismatched batch for sync")?;
             return Ok(());
         }
 
@@ -546,10 +611,41 @@ impl<E: Executor> Reactor<E> {
         let mut deferred: std::collections::VecDeque<consensus_state::DeferredDecision> =
             replay_batches.into();
         if !excluded_txids.is_empty() {
-            for decision in &mut deferred {
-                if let Value::Batch { ref mut txs, .. } = decision.value {
-                    txs.retain(|tx| !excluded_txids.contains(&tx.txid()));
+            // Resolve every replay batch to raw transactions first: exclusion
+            // must see tx INPUTS to also drop descendants of excluded txs — the
+            // DB-loaded decisions carry only txids, and filtering a parent out
+            // while keeping its child would break the dependency order the
+            // batch was decided under (#427). Resolution pulls from the same
+            // sources the deferred drain would use later.
+            let mut resolved: Vec<Vec<bitcoin::Transaction>> = Vec::with_capacity(deferred.len());
+            for decision in &deferred {
+                match &decision.value {
+                    Value::Batch { txs, .. } => resolved.push(self.resolve_batch_txs(txs).await?),
+                    Value::Block { .. } => resolved.push(Vec::new()),
                 }
+            }
+            let excluded = transitive_exclusion(&resolved, &excluded_txids);
+            for (decision, txs) in deferred.iter_mut().zip(resolved) {
+                if let Value::Batch {
+                    anchor_height,
+                    anchor_hash,
+                    ..
+                } = &decision.value
+                {
+                    let (anchor_height, anchor_hash) = (*anchor_height, *anchor_hash);
+                    let kept: Vec<bitcoin::Transaction> = txs
+                        .into_iter()
+                        .filter(|tx| !excluded.contains(&tx.compute_txid()))
+                        .collect();
+                    decision.value = Value::new_batch_raw(anchor_height, anchor_hash, kept);
+                }
+            }
+            // The excluded txids must also leave the proposal pool, or the next
+            // make_value re-proposes the very txs whose missing confirmations
+            // caused this rollback — repeating the same finality failure in a
+            // loop with no forward progress.
+            for txid in &excluded {
+                self.consensus.pending_transactions.remove(txid);
             }
         }
         self.consensus.deferred_decisions = deferred;
@@ -572,13 +668,34 @@ impl<E: Executor> Reactor<E> {
             };
 
             match &decision.value {
-                Value::Block { height: bh, .. } => {
+                Value::Block {
+                    height: bh,
+                    hash: decided_hash,
+                } => {
                     let bh = *bh;
+                    let decided_hash = *decided_hash;
                     let block = {
                         let cs = &mut self.consensus;
                         cs.pending_blocks.remove(&bh)
                     };
                     if let Some(block) = block {
+                        // A rollback can leave a decision whose block was
+                        // reorged away; the block now pending at this height
+                        // belongs to the NEW chain. Executing it under the old
+                        // decision would bind the wrong block to that consensus
+                        // record — drop the stale decision instead and leave
+                        // the block pending for a fresh proposal.
+                        if block.hash != decided_hash {
+                            warn!(
+                                block_height = bh,
+                                decided = %decided_hash,
+                                local = %block.hash,
+                                consensus_height = %decision.consensus_height,
+                                "Dropping stale deferred block decision — hash mismatch after rollback"
+                            );
+                            self.consensus.pending_blocks.insert(bh, block);
+                            continue;
+                        }
                         info!(
                             block_height = bh,
                             consensus_height = %decision.consensus_height,
@@ -881,10 +998,11 @@ impl<E: Executor> Reactor<E> {
 
 #[cfg(test)]
 mod tests {
-    use super::{batch_is_ordered, dependency_sort};
+    use super::{batch_is_ordered, dependency_sort, transitive_exclusion};
     use bitcoin::absolute::LockTime;
     use bitcoin::transaction::Version;
-    use bitcoin::{Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness};
+    use bitcoin::{Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness};
+    use std::collections::HashSet;
 
     /// A tx spending each outpoint in `parents`, with one output. `nonce`
     /// perturbs the output value so distinct txs get distinct txids.
@@ -962,5 +1080,51 @@ mod tests {
         let b = tx(&[OutPoint::null()], 2);
         let c = tx(&[OutPoint::null()], 3);
         assert_eq!(dependency_sort(&[a, b, c]), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn transitive_exclusion_drops_descendants_within_a_batch() {
+        let parent = tx(&[OutPoint::null()], 1);
+        let child = tx(&[spend(&parent)], 2);
+        let grandchild = tx(&[spend(&child)], 3);
+        let independent = tx(&[OutPoint::null()], 4);
+
+        let excluded: HashSet<Txid> = [parent.compute_txid()].into();
+        let batch = vec![
+            parent.clone(),
+            child.clone(),
+            grandchild.clone(),
+            independent.clone(),
+        ];
+        let result = transitive_exclusion(&[batch], &excluded);
+
+        assert!(result.contains(&parent.compute_txid()));
+        assert!(result.contains(&child.compute_txid()));
+        assert!(result.contains(&grandchild.compute_txid()));
+        assert!(!result.contains(&independent.compute_txid()));
+    }
+
+    #[test]
+    fn transitive_exclusion_crosses_batch_boundaries() {
+        let parent = tx(&[OutPoint::null()], 1);
+        let child = tx(&[spend(&parent)], 2);
+        let excluded: HashSet<Txid> = [parent.compute_txid()].into();
+
+        // Parent in batch 0, child in batch 1 — the closure must follow the
+        // dependency across the replay sequence.
+        let result = transitive_exclusion(&[vec![parent.clone()], vec![child.clone()]], &excluded);
+        assert!(result.contains(&child.compute_txid()));
+    }
+
+    #[test]
+    fn transitive_exclusion_leaves_unrelated_batches_untouched() {
+        let a = tx(&[OutPoint::null()], 1);
+        let b = tx(&[OutPoint::null()], 2);
+        let excluded: HashSet<Txid> = [tx(&[OutPoint::null()], 9).compute_txid()].into();
+
+        let result = transitive_exclusion(&[vec![a.clone()], vec![b.clone()]], &excluded);
+        assert!(!result.contains(&a.compute_txid()));
+        assert!(!result.contains(&b.compute_txid()));
+        assert_eq!(result.len(), 1);
     }
 }

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -29,10 +29,10 @@ use crate::consensus::{
     ValidatorSet, Value,
 };
 use crate::database::queries::{
-    delete_batches_above_anchor, delete_unconfirmed_batch_txs_above_anchor, get_checkpoint_latest,
-    get_transaction_by_txid, select_batches_from_anchor, select_batches_in_range,
-    select_block_at_height, select_block_latest, select_existing_txids,
-    select_latest_consensus_height, select_min_batch_height, select_unconfirmed_batch_txs,
+    delete_unexecuted_batch_suffix, get_checkpoint_latest, get_transaction_by_txid,
+    select_batches_from_anchor, select_batches_in_range, select_block_at_height,
+    select_block_latest, select_existing_txids, select_latest_consensus_height,
+    select_min_batch_height, select_unconfirmed_batch_txs,
 };
 
 /// Result from processing a consensus message.
@@ -136,27 +136,20 @@ impl ConsensusState {
     ) -> Result<Self> {
         let current_validator_set = genesis.validator_set;
 
-        // Delete batch decisions that reference anchor heights above what we've
-        // actually processed — committed to the batches table but never executed
-        // before the node shut down (the node forgets them and re-syncs those
-        // consensus heights from peers). Their `unconfirmed_batch_txs` children
-        // must go first: the FK carries no cascade (deliberately — see
-        // schema.sql), so a crash mid-rollback-replay leaves children that would
-        // make the parent delete fail. That failure used to be swallowed by an
-        // `if let Ok`, silently resuming consensus above decisions this node
-        // never executed (#424) — it now propagates.
-        let deleted_txs = delete_unconfirmed_batch_txs_above_anchor(&conn, last_block_height)
+        // Forget the decided-but-unexecuted SUFFIX of consensus history —
+        // committed to the batches table but never executed before the node
+        // shut down; those consensus heights re-sync from peers. Children are
+        // deleted first (the FKs carry no cascade — deliberately, see
+        // schema.sql). A failure here must be LOUD: the old `if let Ok`
+        // silently resumed consensus above decisions this node never executed
+        // (#424).
+        let (deleted, resume_floor) = delete_unexecuted_batch_suffix(&conn, last_block_height)
             .await
-            .context("Failed to delete unconfirmed txs of unprocessed batches")?;
-        let deleted = delete_batches_above_anchor(&conn, last_block_height)
-            .await
-            .context("Failed to delete unprocessed batches above last block height")?;
-        if deleted > 0 || deleted_txs > 0 {
+            .context("Failed to delete unexecuted batch suffix")?;
+        if deleted > 0 {
             info!(
                 deleted,
-                deleted_txs,
-                last_block_height,
-                "Deleted unprocessed batches above last block height"
+                resume_floor, last_block_height, "Deleted unexecuted batch suffix"
             );
         }
 

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -29,10 +29,10 @@ use crate::consensus::{
     ValidatorSet, Value,
 };
 use crate::database::queries::{
-    delete_batches_above_anchor, get_checkpoint_latest, get_transaction_by_txid,
-    select_batches_from_anchor, select_batches_in_range, select_block_at_height,
-    select_block_latest, select_existing_txids, select_latest_consensus_height,
-    select_min_batch_height, select_unconfirmed_batch_txs,
+    delete_batches_above_anchor, delete_unconfirmed_batch_txs_above_anchor, get_checkpoint_latest,
+    get_transaction_by_txid, select_batches_from_anchor, select_batches_in_range,
+    select_block_at_height, select_block_latest, select_existing_txids,
+    select_latest_consensus_height, select_min_batch_height, select_unconfirmed_batch_txs,
 };
 
 /// Result from processing a consensus message.
@@ -133,18 +133,30 @@ impl ConsensusState {
         engine_handle: malachitebft_app_channel::EngineHandle,
         validator_index: Option<usize>,
         mempool_fee_index: MempoolFeeIndex,
-    ) -> Self {
+    ) -> Result<Self> {
         let current_validator_set = genesis.validator_set;
 
         // Delete batch decisions that reference anchor heights above what we've
-        // actually processed. These were committed to the batches table but never
-        // executed before the node shut down.
-        if let Ok(deleted) = delete_batches_above_anchor(&conn, last_block_height).await
-            && deleted > 0
-        {
+        // actually processed — committed to the batches table but never executed
+        // before the node shut down (the node forgets them and re-syncs those
+        // consensus heights from peers). Their `unconfirmed_batch_txs` children
+        // must go first: the FK carries no cascade (deliberately — see
+        // schema.sql), so a crash mid-rollback-replay leaves children that would
+        // make the parent delete fail. That failure used to be swallowed by an
+        // `if let Ok`, silently resuming consensus above decisions this node
+        // never executed (#424) — it now propagates.
+        let deleted_txs = delete_unconfirmed_batch_txs_above_anchor(&conn, last_block_height)
+            .await
+            .context("Failed to delete unconfirmed txs of unprocessed batches")?;
+        let deleted = delete_batches_above_anchor(&conn, last_block_height)
+            .await
+            .context("Failed to delete unprocessed batches above last block height")?;
+        if deleted > 0 || deleted_txs > 0 {
             info!(
                 deleted,
-                last_block_height, "Deleted unprocessed batches above last block height"
+                deleted_txs,
+                last_block_height,
+                "Deleted unprocessed batches above last block height"
             );
         }
 
@@ -156,7 +168,7 @@ impl ConsensusState {
             }
             _ => Height::new(1),
         };
-        Self {
+        Ok(Self {
             signing_provider,
             address,
             pending_transactions: std::collections::HashMap::new(),
@@ -174,7 +186,7 @@ impl ConsensusState {
             channels,
             engine_handle,
             validator_index,
-        }
+        })
     }
 
     /// Clear consensus state that is invalidated by a reorg rollback.
@@ -293,7 +305,7 @@ impl ConsensusState {
 
         at_deadline.sort_by_key(|b| (b.anchor_height, b.consensus_height));
 
-        for batch in &at_deadline {
+        for (i, batch) in at_deadline.iter().enumerate() {
             let mut missing = Vec::new();
             for txid in &batch.txids {
                 let confirmed = match get_transaction_by_txid(conn, &txid.to_string()).await {
@@ -318,6 +330,14 @@ impl ConsensusState {
             } else {
                 let from_anchor = batch.anchor_height;
                 let mut invalidated = vec![batch.consensus_height];
+
+                // Every remaining at-deadline batch shares this fate: the sort
+                // above orders by (anchor_height, consensus_height), so all of
+                // them have anchor_height >= from_anchor and are replayed by
+                // this same rollback. Fold them into the invalidated set
+                // explicitly — silently dropping them from tracking left
+                // convergence to an implicit replay invariant (#426).
+                invalidated.extend(at_deadline[i + 1..].iter().map(|b| b.consensus_height));
 
                 let mut surviving = Vec::new();
                 for pending in still_pending.drain(..) {

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -285,6 +285,20 @@ impl<E: Executor> Reactor<E> {
                     .await
                     .context("rollback failed during Bitcoin reorg")?;
                 self.consensus.clear_on_rollback();
+                // Decided-but-unexecuted values above the fork must not be
+                // forgotten along with the in-memory queue: reload them from the
+                // batches table so every decided value drains to a deterministic
+                // outcome. Post-reorg, entries whose anchor/block no longer
+                // matches the new chain resolve as record-only skips
+                // (`process_decided_batch`'s anchor gate, the drain's block-hash
+                // check) rather than lingering as a silent divergence between
+                // the consensus record and executed state.
+                let replays = self
+                    .consensus
+                    .get_decided_from_anchor(&self.db_conn(), to_height + 1)
+                    .await
+                    .context("Failed to reload decided values after Bitcoin reorg")?;
+                self.consensus.deferred_decisions = replays.into();
                 let checkpoint = self.consensus.get_checkpoint(&self.db_conn()).await;
                 self.consensus
                     .emit_state_event(StateEvent::RollbackExecuted {
@@ -476,7 +490,15 @@ impl<E: Executor> Reactor<E> {
                                     checkpoint,
                                 });
 
-                                // Process deferred decisions using already-cached blocks
+                                // Process deferred decisions using already-cached blocks.
+                                // `pending_blocks` is deliberately NOT cleared here (#430):
+                                // a finality rollback re-executes against the SAME Bitcoin
+                                // chain, so cached blocks are still the right data and make
+                                // this drain immediate — `replay_blocks_from` re-delivery is
+                                // only the fallback. The Bitcoin-reorg path (`BlockEvent::
+                                // Rollback`) clears them instead because there the blocks
+                                // themselves changed; the drain's block-hash check guards
+                                // any stale remainder in both paths.
                                 self.drain_deferred_decisions()
                                     .await
                                     .context("drain_deferred_decisions failed after finality rollback")?;
@@ -704,7 +726,8 @@ pub async fn start_consensus(
         validator_index,
         mempool_fee_index,
     )
-    .await;
+    .await
+    .context("Failed to build consensus state")?;
     state.observation = observation_channels;
     if let Some(t) = timeouts {
         state.timeouts = t;

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -284,21 +284,15 @@ impl<E: Executor> Reactor<E> {
                 self.rollback(to_height)
                     .await
                     .context("rollback failed during Bitcoin reorg")?;
+                // Decided values above the fork are anchored to blocks that no
+                // longer exist — they are deliberately forgotten here (their
+                // rows stay in the batches table as consensus history) and the
+                // network re-decides against the new chain; their txs return
+                // via the mempool. Do NOT reload them into deferred_decisions:
+                // old-chain entries would order ahead of new-chain decisions in
+                // the drain queue and wedge it (a batch waiting on an anchor
+                // whose only block decision is queued behind it).
                 self.consensus.clear_on_rollback();
-                // Decided-but-unexecuted values above the fork must not be
-                // forgotten along with the in-memory queue: reload them from the
-                // batches table so every decided value drains to a deterministic
-                // outcome. Post-reorg, entries whose anchor/block no longer
-                // matches the new chain resolve as record-only skips
-                // (`process_decided_batch`'s anchor gate, the drain's block-hash
-                // check) rather than lingering as a silent divergence between
-                // the consensus record and executed state.
-                let replays = self
-                    .consensus
-                    .get_decided_from_anchor(&self.db_conn(), to_height + 1)
-                    .await
-                    .context("Failed to reload decided values after Bitcoin reorg")?;
-                self.consensus.deferred_decisions = replays.into();
                 let checkpoint = self.consensus.get_checkpoint(&self.db_conn()).await;
                 self.consensus
                     .emit_state_event(StateEvent::RollbackExecuted {
@@ -470,17 +464,24 @@ impl<E: Executor> Reactor<E> {
                             .any(|b| b.deadline <= self.last_height)
                             && let Some((rollback_anchor, excluded)) = self.consensus.run_finality_checks(&conn, self.last_height).await {
                                 // Read replay decisions from DB before deleting state
-                                self.initiate_rollback(
-                                    rollback_anchor,
-                                    excluded,
-                                ).await
-                                .context("initiate_rollback failed")?;
+                                // (the txid join is cascade-deleted with the blocks).
+                                let replay = self
+                                    .load_replay_decisions(rollback_anchor)
+                                    .await
+                                    .context("load_replay_decisions failed")?;
 
                                 // Rollback to before the invalid anchor so all state at the
                                 // anchor height (including invalid tx effects) is wiped cleanly.
                                 self.rollback(rollback_anchor.saturating_sub(1))
                                     .await
                                     .context("rollback failed during finality rollback")?;
+
+                                // Fallible raw-tx resolution/filtering only after the
+                                // truncation is durable — a failure here must not
+                                // cancel the rollback finality demanded.
+                                self.prepare_replay(rollback_anchor, replay, excluded)
+                                    .await
+                                    .context("prepare_replay failed")?;
 
                                 // Emit rollback event
                                 let checkpoint = self.consensus.get_checkpoint(&conn).await;

--- a/core/indexer/src/reactor/reactor_cluster_tests.rs
+++ b/core/indexer/src/reactor/reactor_cluster_tests.rs
@@ -350,7 +350,8 @@ impl ReactorCluster {
                 validator_index,
                 crate::reactor::mempool_fee_index::MempoolFeeIndex::new(None),
             )
-            .await;
+            .await
+            .expect("ConsensusState::new failed");
             state.observation = Some(ObservationChannels {
                 decided_tx: dtx,
                 finality_tx: ftx,
@@ -618,6 +619,42 @@ impl ReactorCluster {
         BlockResult {
             state_events,
             events,
+        }
+    }
+
+    /// Like `wait_for_block`, but for a block REPLAYED after a rollback: the
+    /// reactor re-executes it under its original consensus decision (reloaded
+    /// from the batches table), so no fresh decide is observed — only
+    /// per-node processing and events.
+    async fn wait_for_block_replayed(&mut self, height: u64, timeout: Duration) {
+        let n = self.node_count;
+        let mut state_count = 0;
+        let mut event_count = 0;
+        let deadline = tokio::time::sleep(timeout);
+        tokio::pin!(deadline);
+
+        loop {
+            if state_count >= n && event_count >= n {
+                break;
+            }
+            tokio::select! {
+                _ = &mut deadline => {
+                    panic!(
+                        "wait_for_block_replayed(height={height}) timed out: state={state_count}/{n} event={event_count}/{n}"
+                    );
+                }
+                Some(_) = self.decided_rx.recv() => {}
+                Some(se) = self.state_rx.recv() => {
+                    if matches!(&se, StateEvent::BlockProcessed { height: h, .. } if *h == height) {
+                        state_count += 1;
+                    }
+                }
+                Some(ev) = self.event_rx.recv() => {
+                    if matches!(&ev, Event::Processed { block, .. } if block.height == height) {
+                        event_count += 1;
+                    }
+                }
+            }
         }
     }
 
@@ -1213,11 +1250,21 @@ async fn prod_reactor_bitcoin_rollback_reverts_state() -> Result<()> {
     cluster.send_block_event(BlockEvent::Rollback { to_height: 1 });
     cluster.wait_for_rollback(1, Duration::from_secs(60)).await;
 
+    // The mock chain re-delivers IDENTICAL blocks after the rollback, so the
+    // reactor replays them under their original consensus decisions (reloaded
+    // from the batches table) — re-executed and events emitted, but no fresh
+    // decide. Re-deciding the same block at a new consensus height (the old
+    // behavior) would leave two decided records for one block, which wedges a
+    // syncing node's replay.
     cluster.mine_empty_and_send();
-    cluster.wait_for_block(2, Duration::from_secs(60)).await;
+    cluster
+        .wait_for_block_replayed(2, Duration::from_secs(60))
+        .await;
 
     cluster.mine_empty_and_send();
-    cluster.wait_for_block(3, Duration::from_secs(60)).await;
+    cluster
+        .wait_for_block_replayed(3, Duration::from_secs(60))
+        .await;
 
     cluster.shutdown().await;
     Ok(())

--- a/core/indexer/src/reactor/reactor_cluster_tests.rs
+++ b/core/indexer/src/reactor/reactor_cluster_tests.rs
@@ -622,42 +622,6 @@ impl ReactorCluster {
         }
     }
 
-    /// Like `wait_for_block`, but for a block REPLAYED after a rollback: the
-    /// reactor re-executes it under its original consensus decision (reloaded
-    /// from the batches table), so no fresh decide is observed — only
-    /// per-node processing and events.
-    async fn wait_for_block_replayed(&mut self, height: u64, timeout: Duration) {
-        let n = self.node_count;
-        let mut state_count = 0;
-        let mut event_count = 0;
-        let deadline = tokio::time::sleep(timeout);
-        tokio::pin!(deadline);
-
-        loop {
-            if state_count >= n && event_count >= n {
-                break;
-            }
-            tokio::select! {
-                _ = &mut deadline => {
-                    panic!(
-                        "wait_for_block_replayed(height={height}) timed out: state={state_count}/{n} event={event_count}/{n}"
-                    );
-                }
-                Some(_) = self.decided_rx.recv() => {}
-                Some(se) = self.state_rx.recv() => {
-                    if matches!(&se, StateEvent::BlockProcessed { height: h, .. } if *h == height) {
-                        state_count += 1;
-                    }
-                }
-                Some(ev) = self.event_rx.recv() => {
-                    if matches!(&ev, Event::Processed { block, .. } if block.height == height) {
-                        event_count += 1;
-                    }
-                }
-            }
-        }
-    }
-
     /// Wait until a rollback is executed and events emitted.
     /// Cross-checks: state_rx (RollbackExecuted), event_rx (Event::Rolledback).
     async fn wait_for_rollback(&mut self, to_height: u64, timeout: Duration) -> RollbackResult {
@@ -1250,21 +1214,67 @@ async fn prod_reactor_bitcoin_rollback_reverts_state() -> Result<()> {
     cluster.send_block_event(BlockEvent::Rollback { to_height: 1 });
     cluster.wait_for_rollback(1, Duration::from_secs(60)).await;
 
-    // The mock chain re-delivers IDENTICAL blocks after the rollback, so the
-    // reactor replays them under their original consensus decisions (reloaded
-    // from the batches table) — re-executed and events emitted, but no fresh
-    // decide. Re-deciding the same block at a new consensus height (the old
-    // behavior) would leave two decided records for one block, which wedges a
-    // syncing node's replay.
+    // Post-rollback, the decisions above the fork are forgotten and the
+    // re-delivered blocks are proposed and decided FRESH; the duplicate
+    // decided rows this leaves for identical blocks are drained safely on
+    // sync by the drain's already-executed/stale checks.
     cluster.mine_empty_and_send();
-    cluster
-        .wait_for_block_replayed(2, Duration::from_secs(60))
-        .await;
+    cluster.wait_for_block(2, Duration::from_secs(60)).await;
 
     cluster.mine_empty_and_send();
-    cluster
-        .wait_for_block_replayed(3, Duration::from_secs(60))
-        .await;
+    cluster.wait_for_block(3, Duration::from_secs(60)).await;
+
+    cluster.shutdown().await;
+    Ok(())
+}
+
+/// A Bitcoin rollback across a NON-empty decided batch: the batch's effects
+/// roll back with the blocks, the forgotten decision is not ghost-replayed
+/// (the audit regression: a decided-value reload placed after the truncation
+/// replayed batches with zero txids), the drain does not wedge on stale
+/// decisions, and the txs re-execute via a fresh mempool→batch decision on
+/// the re-delivered chain.
+#[tokio::test]
+async fn prod_reactor_bitcoin_rollback_across_decided_batch() -> Result<()> {
+    crate::logging::setup();
+
+    let mut cluster = ReactorCluster::start(3).await?;
+    cluster.wait_for_ready().await;
+
+    cluster.mine_empty_and_send();
+    cluster.wait_for_block(1, Duration::from_secs(60)).await;
+    cluster.mine_empty_and_send();
+    cluster.wait_for_block(2, Duration::from_secs(60)).await;
+
+    let mempool_events = cluster.mock_bitcoin().generate_mempool_txs(2);
+    for event in mempool_events.clone() {
+        cluster.send_mempool_event(event);
+    }
+    let first = cluster.wait_for_batch(2, Duration::from_secs(60)).await;
+    assert_eq!(first.txids.len(), 2, "setup batch must carry both txs");
+
+    // Reorg below the batch anchor — its effects are wiped with the blocks
+    // and its decision is forgotten (rows stay as consensus history).
+    cluster.mock_bitcoin().reset_to(1);
+    cluster.send_block_event(BlockEvent::Rollback { to_height: 1 });
+    cluster.wait_for_rollback(1, Duration::from_secs(60)).await;
+
+    // The re-delivered chain decides block 2 fresh; the rolled-back txs
+    // return via the mempool and re-execute in a NEW batch at the same
+    // anchor. This times out if a ghost replay consumed the txids
+    // (empty-batch record with txid_count=0) or if a stale reloaded
+    // decision wedged the drain.
+    cluster.mine_empty_and_send();
+    cluster.wait_for_block(2, Duration::from_secs(60)).await;
+    for event in mempool_events {
+        cluster.send_mempool_event(event);
+    }
+    let replayed = cluster.wait_for_batch(2, Duration::from_secs(60)).await;
+    assert_eq!(
+        replayed.txids.len(),
+        2,
+        "rolled-back batch txs must re-execute in a fresh batch"
+    );
 
     cluster.shutdown().await;
     Ok(())


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches consensus execution gates, rollback/replay ordering, and persistent batch history—bugs could cause silent divergence, wedged drains, or wrong sync data; mitigated by extensive comments and new cluster tests.
> 
> **Overview**
> Hardens indexer consensus around rollbacks, finality, and what peers sync for decided batches.
> 
> **Certified batch txids:** Adds `batch_txids` (and related indexes) so sync serves the decided txid list from decide-time storage, not from `transactions` rows that may be missing (record-only batches) or gone after rollbacks. Batch load paths use `batch_txids` with a legacy `transactions` fallback for older DBs.
> 
> **Execution vs record-only:** `process_decided_batch` only executes when the local Bitcoin tip matches the batch’s anchor height and hash; otherwise it persists the batch and certified txs for sync (`BatchOutcome::RecordedOnly`). Callers avoid announcing those as fully processed except for empty batches (heartbeat).
> 
> **Startup:** Replaces anchor-band batch deletion with suffix cleanup by consensus height (`delete_unexecuted_batch_suffix`); failures propagate instead of being ignored.
> 
> **Finality / rollback ordering:** Replay decisions are loaded before DB truncation, then `prepare_replay` runs after (with transitive UTXO descendant exclusion on replay). Bitcoin reorgs forget deferred decisions without reloading old-chain entries; finality rollbacks keep `pending_blocks` on the same chain. Deferred drain drops stale or duplicate block decisions.
> 
> **Finality cascade:** When one at-deadline batch fails, sibling at-deadline batches at the same or higher anchors are included in the rollback invalidation set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea2fbcccb6b4a8b53d2217d510090a0626657fc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->