### PR TITLE
fix(sdk-native): ship a clean RN TurboModule tarball (rc.6)

### DIFF
--- a/.github/workflows/build-mobile-artifacts.yml
+++ b/.github/workflows/build-mobile-artifacts.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Package iOS piece
         if: matrix.name == 'ios'
         working-directory: ./sdk-native
-        run: tar -czf sdk-native-ios.tgz KontorSdkNativeFramework.xcframework
+        run: tar -czf sdk-native-ios.tgz KontorSdkNative.xcframework
       - name: Package Android piece
         if: matrix.name == 'android'
         working-directory: ./sdk-native

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -254,8 +254,8 @@ jobs:
             echo "## sdk-native ${{ matrix.name }} shipped artifacts"
             echo '```'
             if [ "${{ matrix.name }}" = "ios" ]; then
-              du -sh KontorSdkNativeFramework.xcframework
-              find KontorSdkNativeFramework.xcframework -name KontorSdkNative -type f -exec du -h {} +
+              du -sh KontorSdkNative.xcframework
+              find KontorSdkNative.xcframework -name KontorSdkNative -type f -exec du -h {} +
             else
               du -sh android/src/main/jniLibs android/src/main/jniLibs/*/
             fi

--- a/sdk-native/KontorSdkNative.podspec
+++ b/sdk-native/KontorSdkNative.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/KontorProtocol/Kontor.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}", "cpp/**/*.{hpp,cpp,c,h}"
-  s.vendored_frameworks = "KontorSdkNativeFramework.xcframework"
+  s.vendored_frameworks = "KontorSdkNative.xcframework"
   s.dependency    "uniffi-bindgen-react-native", "0.29.3-1"
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.

--- a/sdk-native/README.md
+++ b/sdk-native/README.md
@@ -40,7 +40,7 @@ generated bindings into the `KontorBackend` surface. The generated
 bindings are committed (the published package ships them) and CI fails if
 they drift from what `npm run ubrn:generate` emits. Both native targets
 build under `--profile mobile`: the Android `.so`s and the iOS
-`KontorSdkNativeFramework.xcframework` (device `arm64` + simulator
+`KontorSdkNative.xcframework` (device `arm64` + simulator
 `arm64`/`x86_64`).
 
 Still to do, in a mobile dev environment:
@@ -50,9 +50,15 @@ Still to do, in a mobile dev environment:
 
 ### Expo integration
 
-Consumer Expo apps get zero-config linking: `@kontor/sdk-native` ships an
-`expo-module.config.json` (so Expo autolinking sees it) and an
-`app.plugin.js` config plugin. Add the plugin to the app config —
+`@kontor/sdk-native` is a standard React Native TurboModule: linking is
+handled by React Native autolinking through the podspec (iOS) and
+`build.gradle` (Android) on both bare and Expo apps — it does **not** ship
+an `expo-module.config.json` (that would make Expo autolinking claim the
+package without registering its plain `TurboReactPackage`, so the module
+would be absent from the binary at runtime).
+
+For Expo apps it additionally ships an `app.plugin.js` config plugin. Add
+it to the app config —
 
 ```json
 { "expo": { "plugins": ["@kontor/sdk-native"] } }
@@ -60,9 +66,8 @@ Consumer Expo apps get zero-config linking: `@kontor/sdk-native` ships an
 
 — and `expo prebuild` raises the two floors the prebuilt binaries require:
 iOS deployment target ≥ 15.1 and Android `minSdkVersion` ≥ 24 (it only ever
-raises them, never lowers a higher app target). Bare React Native apps link
-via the podspec / `build.gradle` through the usual community-CLI
-autolinking; there the deployment target / minSdk are set by hand.
+raises them, never lowers a higher app target). Bare React Native apps set
+the deployment target / minSdk by hand.
 
 ## Building
 
@@ -117,7 +122,7 @@ are missing.
   into dynamic `.framework` bundles wrapped in the xcframework.
 
 `./build-mobile.sh ios` is verified locally: it produces
-`KontorSdkNativeFramework.xcframework` (8.6 MB — device `arm64` + simulator
+`KontorSdkNative.xcframework` (8.6 MB — device `arm64` + simulator
 `arm64`/`x86_64`, `@rpath` install name, 133 uniffi FFI symbols exported).
 The Android `.so` build and the full on-device link/load run in CI (which
 also reports the shipped artifact sizes) — see

--- a/sdk-native/build-mobile.sh
+++ b/sdk-native/build-mobile.sh
@@ -52,9 +52,12 @@ IOS_MIN=15.1
 
 # The uniffi cdylib basename produced by cargo for kontor-sdk-native.
 LIB=libkontor_sdk_native
-# The dynamic-framework name embedded in the xcframework.
+# The dynamic-framework name embedded in the xcframework. The xcframework
+# bundle basename MUST equal the wrapped .framework name: CocoaPods derives
+# both the `-framework <name>` linker flag and the copy-target name from the
+# bundle basename, not from Info.plist, so a mismatch fails the app link.
 FRAMEWORK=KontorSdkNative
-XCFRAMEWORK=KontorSdkNativeFramework.xcframework
+XCFRAMEWORK=$FRAMEWORK.xcframework
 
 # Locate the cdylib cargo emitted for a target (it lives at the profile
 # root, or under deps/ depending on cargo version).

--- a/sdk-native/expo-module.config.json
+++ b/sdk-native/expo-module.config.json
@@ -1,3 +1,0 @@
-{
-  "platforms": ["apple", "android"]
-}

--- a/sdk-native/package-lock.json
+++ b/sdk-native/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontor/sdk-native",
-  "version": "0.3.0-rc.5",
+  "version": "0.3.0-rc.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontor/sdk-native",
-      "version": "0.3.0-rc.5",
+      "version": "0.3.0-rc.6",
       "license": "MIT",
       "dependencies": {
         "uniffi-bindgen-react-native": "0.29.3-1"

--- a/sdk-native/package.json
+++ b/sdk-native/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@kontor/sdk-native",
-  "version": "0.3.0-rc.5",
+  "version": "0.3.0-rc.6",
   "description": "React Native (JSI) backend for @kontor/sdk — native bindings over core/kontor-sdk-native (uniffi). Provides the same KontorBackend surface as the WASM component, so @kontor/sdk runs on iOS/Android.",
   "author": "Unspendable Labs <dev@unspendablelabs.com>",
   "license": "MIT",
+  "homepage": "https://github.com/KontorProtocol/Kontor",
   "publishConfig": {
     "access": "public"
   },
@@ -14,14 +15,26 @@
   },
   "main": "./src/index.ts",
   "types": "./src/index.ts",
+  "codegenConfig": {
+    "name": "RNNativeModuleSpec",
+    "type": "modules",
+    "jsSrcsDir": "src",
+    "android": {
+      "javaPackageName": "com.kontor.sdknative"
+    }
+  },
   "files": [
     "src",
     "cpp",
     "ios",
-    "android",
+    "android/src",
     "android/src/main/jniLibs",
-    "KontorSdkNativeFramework.xcframework",
-    "expo-module.config.json",
+    "android/CMakeLists.txt",
+    "android/build.gradle",
+    "android/cpp-adapter.cpp",
+    "android/gradle.properties",
+    "android/proguard-rules.pro",
+    "KontorSdkNative.xcframework",
     "app.plugin.js",
     "*.podspec"
   ],
@@ -33,7 +46,7 @@
     "//ubrn-build": "build-mobile.sh compiles the cdylib and assembles the SHARED artifacts itself (dynamic-framework xcframework / jniLibs .so); it does not call `ubrn build`, whose assembly emits the oversized static archive.",
     "build:mobile": "bash ./build-mobile.sh",
     "//prepack": "The published tarball must carry the prebuilt binaries (consumers cannot build them: core/ is outside the package). Refuse to pack without an assembled xcframework and at least one jniLibs .so.",
-    "prepack": "test -f KontorSdkNativeFramework.xcframework/Info.plist && ls android/src/main/jniLibs/*/libkontor_sdk_native.so >/dev/null 2>&1 || { echo 'ERROR: native binaries missing/incomplete — run ./build-mobile.sh before packing/publishing.' >&2; exit 1; }",
+    "prepack": "test -f KontorSdkNative.xcframework/Info.plist && ls android/src/main/jniLibs/*/libkontor_sdk_native.so >/dev/null 2>&1 || { echo 'ERROR: native binaries missing/incomplete — run ./build-mobile.sh before packing/publishing.' >&2; exit 1; }",
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {


### PR DESCRIPTION
Fixes the five packaging defects reported against `@kontor/sdk-native@0.3.0-rc.5` by the Horizon Market native example. Each one blocks a clean `expo run:ios` / `expo run:android` and currently forces consumers to patch `node_modules` via postinstall scripts. Root theme for three of them: the tarball shipped build artifacts and was missing standard RN-module manifest fields.

Bumps `@kontor/sdk-native` to **0.3.0-rc.6**. `@kontor/sdk` is left untouched (it has no changes and references `sdk-native` as `*`); bump it separately if you want lockstep releases.

## Fixes

| # | Platform | Stage | Symptom | Fix |
|---|----------|-------|---------|-----|
| D1 | iOS | `pod install` | `Missing required attribute homepage` | add `homepage` to `package.json` |
| D2 | iOS | compile | `'RNNativeModuleSpec.h' file not found` | add `codegenConfig` (name `RNNativeModuleSpec`) so RN iOS codegen emits the spec header |
| D3 | iOS | link | `ld: framework 'KontorSdkNativeFramework' not found` | rename bundle → `KontorSdkNative.xcframework` (basename == wrapped `.framework`) in build script, podspec, `files`, CI |
| D4 | Android | link | `duplicate symbol NativeKontorSdkNativeSpecJSI` | stop shipping generated `android/build/`; `files` now lists android sources explicitly |
| D5 | both | runtime | `getEnforcing('KontorSdkNative') could not be found` | drop `expo-module.config.json` — it's a plain `TurboReactPackage`, so RN autolinking (podspec + `build.gradle`) handles registration |

## Why D3 mattered

The prebuilt binary wrapped a `KontorSdkNative.framework`, but the outer bundle was named `KontorSdkNativeFramework.xcframework`. CocoaPods derives both the `-framework <name>` linker flag and the copy-target name from the **bundle basename**, not `Info.plist`, so it emitted `-framework KontorSdkNativeFramework` and the link failed. `build-mobile.sh` now derives `XCFRAMEWORK=$FRAMEWORK.xcframework` from a single source of truth.

## Verification

`npm pack --dry-run` (with dummy binaries + a stray `android/build/` planted to prove the packlist):

- **absent**: `android/build/`, `android/.cxx`, `expo-module.config.json`, the old `KontorSdkNativeFramework` name
- **present**: `KontorSdkNative.xcframework/…`, all three `jniLibs/*/libkontor_sdk_native.so`, `android/build.gradle`, `android/CMakeLists.txt`, the android/ios/cpp/ts sources

A real `expo run:ios` / `expo run:android` against the Horizon Market native example is the remaining end-to-end check before publishing rc.6.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes published npm contents, iOS framework naming, and module discovery—any mistake breaks consumer `pod install`/link or leaves the native module missing at runtime.
> 
> **Overview**
> Bumps **`@kontor/sdk-native` to 0.3.0-rc.6** and fixes packaging/linking so consumers can build without patching `node_modules`.
> 
> **iOS:** Adds `homepage` and **`codegenConfig`** (`RNNativeModuleSpec`) so CocoaPods and RN codegen emit the TurboModule spec header. Renames the shipped bundle from `KontorSdkNativeFramework.xcframework` to **`KontorSdkNative.xcframework`** (matching the inner `.framework` name) in `build-mobile.sh`, podspec, `prepack`, and CI—CocoaPods uses the xcframework basename for `-framework` linking.
> 
> **Android:** Tightens the npm **`files`** list to ship Android **sources** (`android/src`, Gradle/CMake files, `jniLibs`) instead of a broad `android/` tree that could include **`android/build/`** and cause duplicate JSI symbols at link time.
> 
> **Runtime / Expo:** **Deletes `expo-module.config.json`** so Expo autolinking does not treat the package as an Expo module while the real registration stays on RN autolinking via **`TurboReactPackage`**. README documents that split; **`app.plugin.js`** remains for prebuild min iOS/Android floors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dc80c5387b27783f0f2bbc843dd110686378d31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->