### PR TITLE
fix(runtime): #434 remainders — memory-weighted component cache bound + per-call context-resource drain

### DIFF
--- a/core/indexer/src/runtime/call.rs
+++ b/core/indexer/src/runtime/call.rs
@@ -67,6 +67,21 @@ pub(crate) struct PreparedCall {
     pub func: Func,
     pub is_proc: bool,
     pub fuel_limit: u64,
+    pub ctx: CtxResource,
+}
+
+/// Handle of the context resource `prepare_call` pushed into the shared
+/// `ResourceTable` as the call's first argument. The table outlives the
+/// per-call `Store` (it lives as long as the `Runtime`), so this entry must
+/// be drained when the call settles — otherwise every op leaks one entry
+/// until pool recycle, and the reactor's runtime is never recycled (#434).
+/// Carries the raw rep because `try_into_resource_any` consumes the typed
+/// `Resource<T>`; `new_own(rep)` reconstructs it for deletion.
+pub(crate) enum CtxResource {
+    Core(u32),
+    View(u32),
+    Proc(u32),
+    Fall(u32),
 }
 
 impl Runtime {
@@ -205,7 +220,7 @@ impl Runtime {
         }
 
         let mut is_proc = false;
-        {
+        let ctx = {
             let mut table = self.table.lock().await;
             match (resource_type, signer) {
                 (t, Some(Signer::Core(signer)))
@@ -215,31 +230,36 @@ impl Runtime {
                     // core call, inherited for a nested one) — this arm only wires up
                     // the trusted CoreContext resource.
                     is_proc = true;
+                    let res = table
+                        .push(CoreContext {
+                            signer: *signer.clone(),
+                            contract_id,
+                        })
+                        .map_err(anyhow::Error::from)?;
+                    let rep = res.rep();
                     params.insert(
                         0,
                         wasmtime::component::Val::Resource(
-                            table
-                                .push(CoreContext {
-                                    signer: *signer.clone(),
-                                    contract_id,
-                                })
-                                .map_err(anyhow::Error::from)?
-                                .try_into_resource_any(&mut store)
+                            res.try_into_resource_any(&mut store)
                                 .map_err(anyhow::Error::from)?,
                         ),
-                    )
+                    );
+                    CtxResource::Core(rep)
                 }
-                (t, _) if t.eq(&wasmtime::component::ResourceType::host::<ViewContext>()) => params
-                    .insert(
+                (t, _) if t.eq(&wasmtime::component::ResourceType::host::<ViewContext>()) => {
+                    let res = table
+                        .push(ViewContext { contract_id })
+                        .map_err(anyhow::Error::from)?;
+                    let rep = res.rep();
+                    params.insert(
                         0,
                         wasmtime::component::Val::Resource(
-                            table
-                                .push(ViewContext { contract_id })
-                                .map_err(anyhow::Error::from)?
-                                .try_into_resource_any(&mut store)
+                            res.try_into_resource_any(&mut store)
                                 .map_err(anyhow::Error::from)?,
                         ),
-                    ),
+                    );
+                    CtxResource::View(rep)
+                }
                 (t, Some(signer))
                     if t.eq(&wasmtime::component::ResourceType::host::<ProcContext>()) =>
                 {
@@ -251,20 +271,22 @@ impl Runtime {
                     // the override rules (cross-input Sponsor or aggregate-
                     // publisher).
                     let payer = payer_holder(signer, payment);
+                    let res = table
+                        .push(ProcContext {
+                            signer: signer.clone(),
+                            payer,
+                            contract_id,
+                        })
+                        .map_err(anyhow::Error::from)?;
+                    let rep = res.rep();
                     params.insert(
                         0,
                         wasmtime::component::Val::Resource(
-                            table
-                                .push(ProcContext {
-                                    signer: signer.clone(),
-                                    payer,
-                                    contract_id,
-                                })
-                                .map_err(anyhow::Error::from)?
-                                .try_into_resource_any(&mut store)
+                            res.try_into_resource_any(&mut store)
                                 .map_err(anyhow::Error::from)?,
                         ),
-                    )
+                    );
+                    CtxResource::Proc(rep)
                 }
 
                 (t, signer) if t.eq(&wasmtime::component::ResourceType::host::<FallContext>()) => {
@@ -272,20 +294,22 @@ impl Runtime {
                     // FallContext has a payer iff it has a signer — a fall
                     // context with no acting signer has no payer either.
                     let payer = signer.map(|s| payer_holder(s, payment));
+                    let res = table
+                        .push(FallContext {
+                            signer: signer.cloned(),
+                            payer,
+                            contract_id,
+                        })
+                        .map_err(anyhow::Error::from)?;
+                    let rep = res.rep();
                     params.insert(
                         0,
                         wasmtime::component::Val::Resource(
-                            table
-                                .push(FallContext {
-                                    signer: signer.cloned(),
-                                    payer,
-                                    contract_id,
-                                })
-                                .map_err(anyhow::Error::from)?
-                                .try_into_resource_any(&mut store)
+                            res.try_into_resource_any(&mut store)
                                 .map_err(anyhow::Error::from)?,
                         ),
-                    )
+                    );
+                    CtxResource::Fall(rep)
                 }
                 (t, signer) => {
                     return Err(ExecutionError::Deterministic(anyhow!(
@@ -295,7 +319,7 @@ impl Runtime {
                     )));
                 }
             }
-        }
+        };
 
         if is_proc && payment.is_none() && fuel_override.is_none() {
             return Err(ExecutionError::Deterministic(anyhow!(
@@ -386,7 +410,29 @@ impl Runtime {
             func,
             is_proc,
             fuel_limit,
+            ctx,
         })
+    }
+
+    /// Drain the call's context resource from the shared table once the call
+    /// has settled. Best-effort: the entry not being there (already drained)
+    /// must never fail the call path.
+    async fn drain_ctx_resource(&self, ctx: CtxResource) {
+        let mut table = self.table.lock().await;
+        let _ = match ctx {
+            CtxResource::Core(rep) => table
+                .delete(Resource::<CoreContext>::new_own(rep))
+                .map(|_| ()),
+            CtxResource::View(rep) => table
+                .delete(Resource::<ViewContext>::new_own(rep))
+                .map(|_| ()),
+            CtxResource::Proc(rep) => table
+                .delete(Resource::<ProcContext>::new_own(rep))
+                .map(|_| ()),
+            CtxResource::Fall(rep) => table
+                .delete(Resource::<FallContext>::new_own(rep))
+                .map(|_| ()),
+        };
     }
 
     /// Spawn the WASM call, catch panics, and handle the result.
@@ -398,6 +444,7 @@ impl Runtime {
         params: Vec<Val>,
         mut results: Vec<Val>,
         is_fallback: bool,
+        ctx: CtxResource,
     ) -> Result<(Result<String, ExecutionError>, Store<Runtime>)> {
         let (result, results, mut store) = tokio::spawn(async move {
             match std::panic::AssertUnwindSafe(func.call_async(&mut store, &params, &mut results))
@@ -423,6 +470,10 @@ impl Runtime {
         let call_result = self
             .handle_call(is_fallback, result, results, &mut store)
             .await;
+
+        // The call has settled (committed or rolled back) — drain its context
+        // resource from the shared table, success and failure alike.
+        self.drain_ctx_resource(ctx).await;
 
         Ok((call_result, store))
     }
@@ -631,6 +682,7 @@ impl Runtime {
             func,
             is_proc,
             fuel_limit: _,
+            ctx,
         } = self
             .prepare_call(
                 contract_address,
@@ -641,7 +693,7 @@ impl Runtime {
             )
             .await?;
         let (mut result, mut store) = self
-            .call_and_handle(store, func, params, results, is_fallback)
+            .call_and_handle(store, func, params, results, is_fallback, ctx)
             .await?;
         let fuel = store.get_fuel().unwrap();
         accessor

--- a/core/indexer/src/runtime/component_cache.rs
+++ b/core/indexer/src/runtime/component_cache.rs
@@ -1,28 +1,46 @@
 use moka::future::Cache;
 use wasmtime::component::Component;
 
-const COMPONENT_CACHE_CAPACITY: u64 = 64;
+/// Total-weight bound for the cache, where each entry weighs its encoded
+/// component binary size (the best cheap proxy for the compiled machine
+/// code's memory footprint — `Component` exposes no in-memory size). An
+/// entry-count bound alone lets a handful of pathological contracts pin
+/// unbounded memory (#434); 256 MiB is far above any legitimate working
+/// set while keeping the worst case bounded.
+const COMPONENT_CACHE_MAX_BYTES: u64 = 256 * 1024 * 1024;
 
 #[derive(Clone)]
 pub struct ComponentCache {
-    inner: Cache<u64, Component>,
+    inner: Cache<u64, (Component, u32)>,
 }
 
 impl ComponentCache {
     pub fn new() -> Self {
         Self {
             inner: Cache::builder()
-                .max_capacity(COMPONENT_CACHE_CAPACITY)
+                // Weight 0 would make an entry invisible to the bound —
+                // floor at 1.
+                .weigher(|_key, (_component, size): &(Component, u32)| (*size).max(1))
+                .max_capacity(COMPONENT_CACHE_MAX_BYTES)
                 .build(),
         }
     }
 
     pub async fn get(&self, key: &u64) -> Option<Component> {
+        self.inner.get(key).await.map(|(component, _)| component)
+    }
+
+    /// Entry with its recorded weight — for callers that re-`put` entries into
+    /// another cache and must preserve the weight (test prewarming).
+    pub async fn get_weighted(&self, key: &u64) -> Option<(Component, u32)> {
         self.inner.get(key).await
     }
 
-    pub async fn put(&self, key: u64, value: Component) {
-        self.inner.insert(key, value).await
+    /// Cache a compiled component, weighed by `size_bytes` — the encoded
+    /// component binary length the caller already has in hand.
+    pub async fn put(&self, key: u64, value: Component, size_bytes: usize) {
+        let weight = u32::try_from(size_bytes).unwrap_or(u32::MAX);
+        self.inner.insert(key, (value, weight)).await
     }
 
     /// Drop a cached component. Used when a publish rolls back: the contract id

--- a/core/indexer/src/runtime/mod.rs
+++ b/core/indexer/src/runtime/mod.rs
@@ -814,6 +814,7 @@ impl Runtime {
             func,
             is_proc,
             fuel_limit: starting_fuel,
+            ctx,
         } = self
             .prepare_call(contract_address, signer, payment.as_ref(), expr, None)
             .await?;
@@ -824,7 +825,7 @@ impl Runtime {
         )
         .await;
         let (mut result, mut store) = self
-            .call_and_handle(store, func, params, results, is_fallback)
+            .call_and_handle(store, func, params, results, is_fallback, ctx)
             .await?;
         OptionFuture::from(
             self.gauge
@@ -860,7 +861,7 @@ impl Runtime {
         let bytes = self.storage.component_bytes(contract_id).await?;
         let component = Component::from_binary(&self.engine, &bytes)?;
         self.component_cache
-            .put(contract_id, component.clone())
+            .put(contract_id, component.clone(), bytes.len())
             .await;
         Ok((bytes, component))
     }
@@ -895,8 +896,50 @@ impl HasData for Runtime {
 #[cfg(test)]
 mod tests {
     use crate::database::queries::exists_contract_state;
+    use crate::runtime::token;
+    use crate::runtime::wit::resources::ViewContext;
     use crate::test_utils::test_runtime;
     use stdlib::KeyElement;
+
+    /// Context resources are drained from the shared `ResourceTable` when a
+    /// call settles (#434): the table outlives the per-call stores, so a leak
+    /// here accumulates for the runtime's whole life — and the reactor's
+    /// runtime is never recycled. Freed table slots are reused, so probes
+    /// pushed before and after a burst of calls must land on the same rep;
+    /// before the drain, every call leaked one context entry and the second
+    /// probe's rep grew by the call count.
+    #[tokio::test]
+    async fn call_context_resources_are_drained() {
+        let (mut runtime, _dir, _name) = test_runtime().await.expect("test runtime");
+
+        let probe = {
+            let mut table = runtime.table.lock().await;
+            let res = table.push(ViewContext { contract_id: 1 }).expect("push");
+            let rep = res.rep();
+            table.delete(res).expect("delete probe");
+            rep
+        };
+
+        for _ in 0..5 {
+            runtime
+                .execute(None, None, &token::address(), "total-supply()")
+                .await
+                .expect("view call");
+        }
+
+        let probe_after = {
+            let mut table = runtime.table.lock().await;
+            let res = table.push(ViewContext { contract_id: 1 }).expect("push");
+            let rep = res.rep();
+            table.delete(res).expect("delete probe");
+            rep
+        };
+
+        assert_eq!(
+            probe_after, probe,
+            "call context resources must be drained — a growing rep means the table leaks one entry per call"
+        );
+    }
 
     /// The structural security boundary: filestorage's component imports the
     /// native-only `file-registry` interface, so it links against the native

--- a/core/indexer/src/test_utils.rs
+++ b/core/indexer/src/test_utils.rs
@@ -331,13 +331,15 @@ pub async fn new_test_db() -> Result<(Reader, Writer, (TempDir, String))> {
     Ok((reader, writer, (temp_dir, db_name)))
 }
 
+/// A prewarmed native contract: id, compiled component, and its cache weight
+/// (encoded binary size).
+type PrewarmedComponent = (u64, wasmtime::component::Component, u32);
+
 /// Shared engine + pre-compiled native contract components.
 /// First caller compiles all native contracts; subsequent callers get cached results.
-async fn shared_test_engine() -> (wasmtime::Engine, Vec<(u64, wasmtime::component::Component)>) {
-    static ONCE: tokio::sync::OnceCell<(
-        wasmtime::Engine,
-        Vec<(u64, wasmtime::component::Component)>,
-    )> = tokio::sync::OnceCell::const_new();
+async fn shared_test_engine() -> (wasmtime::Engine, Vec<PrewarmedComponent>) {
+    static ONCE: tokio::sync::OnceCell<(wasmtime::Engine, Vec<PrewarmedComponent>)> =
+        tokio::sync::OnceCell::const_new();
 
     ONCE.get_or_init(|| async {
         let engine = Runtime::new_engine().expect("Failed to create engine");
@@ -371,8 +373,8 @@ async fn shared_test_engine() -> (wasmtime::Engine, Vec<(u64, wasmtime::componen
         // `Runtime::publish_native_contracts`.
         let mut components = Vec::new();
         for id in 1..=NATIVE_CONTRACTS.len() as u64 {
-            if let Some(component) = cache.get(&id).await {
-                components.push((id, component));
+            if let Some((component, size)) = cache.get_weighted(&id).await {
+                components.push((id, component, size));
             }
         }
 
@@ -430,8 +432,8 @@ async fn test_runtime_inner(
     let storage = Storage::builder().height(1).conn(conn).build();
     let (engine, prewarmed) = shared_test_engine().await;
     let cache = ComponentCache::new();
-    for (id, component) in &prewarmed {
-        cache.put(*id, component.clone()).await;
+    for (id, component, size) in &prewarmed {
+        cache.put(*id, component.clone(), *size as usize).await;
     }
     let linkers = Runtime::new_linkers(&engine)?;
     let mut runtime = Runtime::new_with(engine, linkers, cache, storage).await?;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the consensus contract execution path and long-lived reactor runtime lifecycle; changes are leak fixes and cache eviction policy, not execution semantics, but incorrect draining could break calls.
> 
> **Overview**
> Addresses **#434** runtime memory growth by fixing two leak/bound issues on the indexer execution path.
> 
> **Per-call context cleanup:** `prepare_call` now records a `CtxResource` handle (raw rep per context type) on `PreparedCall` and passes it through `call_and_handle`, which **best-effort deletes** that entry from the shared `ResourceTable` after every settled call. The table outlives per-call stores, so without this drain each op leaked one slot and blocked reactor runtime recycling.
> 
> **Component cache bound:** `ComponentCache` no longer caps at **64 entries**; it uses a **256 MiB** total weight budget with each entry weighed by encoded WASM binary size. `put` takes `size_bytes`; tests prewarm via `get_weighted` so weights are preserved when copying caches.
> 
> Adds `call_context_resources_are_drained` to assert table slot reuse after repeated view calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cd5b85999190b4e4e1a6c1c71243405515df0e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->