### PR TITLE
fix: integer fee-threshold math (#429), contract-name charset gate (#308), /healthz probes (#214)

### DIFF
--- a/core/indexer/src/api/handlers/info.rs
+++ b/core/indexer/src/api/handlers/info.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use axum::Json;
 use axum::extract::{Query, State};
+use axum::http::StatusCode;
 use indexer_types::{ConsensusMode, Info};
 use serde::{Deserialize, Serialize};
 use tokio::time::timeout;
@@ -101,4 +102,44 @@ pub async fn get_status(State(env): State<Env>) -> Json<NodeStatus> {
         reactor_ready: env.reactor_ready.load(Ordering::Relaxed),
         consensus_listen_addr: env.consensus_listen_addr.borrow().clone(),
     })
+}
+
+/// Body for `GET /healthz/ready` — context for an operator reading probe
+/// output; orchestrators only look at the status code.
+#[derive(Serialize)]
+pub struct Healthz {
+    pub ready: bool,
+    pub reactor_ready: bool,
+    /// Highest indexed block, `null` until the first block lands.
+    pub height: Option<u64>,
+}
+
+/// `GET /healthz/live` — process liveness. Answers 200 whenever the API task
+/// is serving; a hung or deadlocked process fails the probe by not answering
+/// at all (#214).
+pub async fn get_healthz_live() -> &'static str {
+    "ok"
+}
+
+/// `GET /healthz/ready` — readiness for traffic: the exact predicate the
+/// `require_available` middleware gates on (reactor started AND chain state
+/// exists), so a pod reads ready precisely when its chain endpoints stop
+/// answering 503 (#214).
+pub async fn get_healthz_ready(State(env): State<Env>) -> (StatusCode, Json<Healthz>) {
+    let reactor_ready = env.reactor_ready.load(Ordering::Relaxed);
+    let height = env.info_rx.borrow().height;
+    let ready = reactor_ready && height.is_some();
+    let code = if ready {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (
+        code,
+        Json(Healthz {
+            ready,
+            reactor_ready,
+            height,
+        }),
+    )
 }

--- a/core/indexer/src/api/handlers/info_tests.rs
+++ b/core/indexer/src/api/handlers/info_tests.rs
@@ -185,3 +185,46 @@ async fn info_publisher_republishes_on_event() -> Result<()> {
     handle.await?;
     Ok(())
 }
+
+/// `/healthz/ready` mirrors the `require_available` predicate exactly — 503
+/// until the reactor latch is set AND chain state exists, 200 after — while
+/// `/healthz/live` answers 200 whenever the API serves at all (#214).
+#[tokio::test]
+async fn healthz_ready_tracks_availability() -> Result<()> {
+    use super::{get_healthz_live, get_healthz_ready};
+    use std::sync::atomic::Ordering;
+
+    let (mut env, _conn, _dir) = new_test_env().await?;
+    let (info_tx, info_rx) = watch::channel(InfoCore::default());
+    env.info_rx = info_rx;
+    let reactor_ready = env.reactor_ready.clone();
+    reactor_ready.store(false, Ordering::Relaxed);
+    let app = Router::new()
+        .route("/healthz/live", get(get_healthz_live))
+        .route("/healthz/ready", get(get_healthz_ready))
+        .with_state(env);
+    let server = TestServer::new(app);
+
+    // Liveness is unconditional.
+    let res = server.get("/healthz/live").await;
+    res.assert_status(StatusCode::OK);
+
+    // Not ready: latch unset and no chain state.
+    let res = server.get("/healthz/ready").await;
+    res.assert_status(StatusCode::SERVICE_UNAVAILABLE);
+
+    // Latch set but still no chain state — half the predicate is not enough.
+    reactor_ready.store(true, Ordering::Relaxed);
+    let res = server.get("/healthz/ready").await;
+    res.assert_status(StatusCode::SERVICE_UNAVAILABLE);
+
+    // Chain state lands: ready.
+    info_tx.send(InfoCore {
+        height: Some(1),
+        ..Default::default()
+    })?;
+    let res = server.get("/healthz/ready").await;
+    res.assert_status(StatusCode::OK);
+
+    Ok(())
+}

--- a/core/indexer/src/api/router.rs
+++ b/core/indexer/src/api/router.rs
@@ -23,9 +23,10 @@ use tracing::{Level, Span, error, field, info, span};
 
 use crate::api::handlers::{
     get_block_transactions, get_blocks, get_contract, get_contract_provenance, get_contracts,
-    get_fees, get_index, get_metrics, get_result, get_results, get_signer, get_signer_footprint,
-    get_status, get_transaction, get_transaction_inspect, get_transactions, post_compose,
-    post_contract, post_simulate, post_transaction_broadcast, post_transaction_hex_inspect,
+    get_fees, get_healthz_live, get_healthz_ready, get_index, get_metrics, get_result, get_results,
+    get_signer, get_signer_footprint, get_status, get_transaction, get_transaction_inspect,
+    get_transactions, post_compose, post_contract, post_simulate, post_transaction_broadcast,
+    post_transaction_hex_inspect,
 };
 
 use super::{
@@ -180,6 +181,11 @@ pub fn new(context: Env, prom_handle: PrometheusHandle) -> Router {
 
     Router::new()
         .nest("/api", chain_routes.merge(always_available))
+        // Probe endpoints at the root, where orchestrators look (#214):
+        // liveness answers whenever the API task is serving; readiness
+        // mirrors the `require_available` predicate exactly.
+        .route("/healthz/live", get(get_healthz_live))
+        .route("/healthz/ready", get(get_healthz_ready))
         .layer(
             ServiceBuilder::new()
                 .layer(SetRequestIdLayer::new(

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -30,9 +30,12 @@ use super::executor::Executor;
 use super::mempool_fee_index::MempoolFeeIndex;
 
 /// Multiplier applied to `MempoolFeeIndex::fastest_fee()` to derive the
-/// per-batch acceptance threshold. 0.9 means we accept txs at or above
-/// 90% of the median fee rate in projected block 0.
-const FEE_THRESHOLD_MULTIPLIER: f64 = 0.9;
+/// per-batch acceptance threshold, as an integer ratio: 9/10 means we accept
+/// txs at or above 90% of the median fee rate in projected block 0. Integer
+/// math because this feeds proposal validation — a consensus-adjacent path
+/// where float rounding is a determinism hazard (#429).
+const FEE_THRESHOLD_NUM: u64 = 9;
+const FEE_THRESHOLD_DEN: u64 = 10;
 
 /// Compute the per-batch fee acceptance threshold (sat/vB). Hoisted out
 /// of `validate_transaction` so callers compute it once per validation
@@ -44,7 +47,7 @@ const FEE_THRESHOLD_MULTIPLIER: f64 = 0.9;
 /// reconnect's Sync). Defense in depth against effectively disabling
 /// fee validation.
 fn compute_fee_threshold(fee_index: &MempoolFeeIndex) -> u64 {
-    let raw = (fee_index.fastest_fee() as f64 * FEE_THRESHOLD_MULTIPLIER) as u64;
+    let raw = fee_index.fastest_fee().saturating_mul(FEE_THRESHOLD_NUM) / FEE_THRESHOLD_DEN;
     raw.max(fee_index.min_fee())
 }
 

--- a/core/indexer/src/runtime/mod.rs
+++ b/core/indexer/src/runtime/mod.rs
@@ -460,6 +460,20 @@ impl Runtime {
         provenance
             .validate()
             .map_err(ExecutionError::Deterministic)?;
+        // Contract names are embedded in the wire address format
+        // `name_height_txindex` — `_` is the separator, so a name containing
+        // it mints an ambiguously-parseable address, permanent once published
+        // (#308). Enforce kebab-case (lowercase alphanumerics and hyphens)
+        // deterministically on every node.
+        if name.is_empty()
+            || !name
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        {
+            return Err(ExecutionError::Deterministic(anyhow!(
+                "invalid contract name {name:?}: must be non-empty kebab-case ([a-z0-9-])"
+            )));
+        }
         let address = ContractAddress {
             name: name.to_string(),
             height: self.storage.height,
@@ -900,6 +914,45 @@ mod tests {
     use crate::runtime::wit::resources::ViewContext;
     use crate::test_utils::test_runtime;
     use stdlib::KeyElement;
+
+    /// `_` is the ContractAddress wire separator — a name containing it mints
+    /// an ambiguously-parseable address, permanent once published (#308). The
+    /// gate must reject deterministically, before any storage is touched.
+    #[tokio::test]
+    async fn publish_rejects_non_kebab_contract_names() {
+        let (mut runtime, _dir, _name) = test_runtime().await.expect("test runtime");
+        runtime
+            .set_context(
+                1,
+                Some(super::TransactionContext::builder().build()),
+                None,
+                None,
+            )
+            .await;
+        let signer = super::Signer::Core(Box::new(super::Signer::Nobody));
+        let payment = runtime.core_payment();
+        let provenance = super::native_provenance().expect("provenance");
+        for bad in ["counter_v2", "Counter", "has space", ""] {
+            let err = runtime
+                .publish(&signer, payment.clone(), bad, b"", &provenance)
+                .await
+                .expect_err("bad name must be rejected");
+            assert!(
+                matches!(err, super::ExecutionError::Deterministic(_)),
+                "{bad:?} must reject deterministically, got: {err:?}"
+            );
+        }
+        // The gate must not over-reject legitimate kebab names: this one only
+        // fails later, at wasm decode — proving it passed the name check.
+        let err = runtime
+            .publish(&signer, payment, "valid-name-0", b"", &provenance)
+            .await
+            .expect_err("empty bytes cannot compile");
+        assert!(
+            !format!("{err:?}").contains("invalid contract name"),
+            "kebab name must pass the gate: {err:?}"
+        );
+    }
 
     /// Context resources are drained from the shared `ResourceTable` when a
     /// call settles (#434): the table outlives the per-call stores, so a leak


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes consensus-adjacent fee threshold math and deterministic publish validation; health readiness must stay aligned with `require_available` or traffic routing will be wrong.
> 
> **Overview**
> Adds **root-level Kubernetes-style probes** so orchestrators can distinguish liveness from readiness without hitting gated `/api` routes. **`GET /healthz/live`** always returns 200 while the API task is serving; **`GET /healthz/ready`** returns **503** until **reactor ready** and **indexed height** exist—the same predicate as **`require_available`**—and includes a small JSON body (`ready`, `reactor_ready`, `height`) for operators.
> 
> **Batch fee acceptance** no longer uses floating-point scaling (90% of fastest fee). It now uses **integer ratio math** (`9/10` with saturating multiply/divide) on the consensus-adjacent validation path to avoid float rounding as a determinism hazard.
> 
> **Contract publish** now rejects names that are not **non-empty kebab-case** (`[a-z0-9-]`) before storage, because `_` is the wire address separator and invalid names would be permanently ambiguous once published.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ba9abc05030d280c9b8045a42c8cd2dd66aabe4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->