### PR TITLE
fix(consensus): disable the ungated Issuance faucet mint on mainnet

### DIFF
--- a/core/indexer/src/runtime/mod.rs
+++ b/core/indexer/src/runtime/mod.rs
@@ -668,6 +668,16 @@ impl Runtime {
     }
 
     pub async fn issuance(&mut self, signer: &Signer) -> Result<(), ExecutionError> {
+        // `Issuance` is a gas-free faucet mint — a dev/test bootstrap
+        // convenience. It must never mint on mainnet, where the only intended
+        // mint path is protocol emissions; an ungated faucet falsifies the
+        // supply schedule. Reject deterministically (same `network()` gate the
+        // token's dev-mint uses), so every node agrees and no supply is created.
+        if self.network == bitcoin::Network::Bitcoin {
+            return Err(ExecutionError::Deterministic(anyhow!(
+                "Issuance faucet is disabled on mainnet"
+            )));
+        }
         let result = token::api::issuance(
             self,
             &Signer::Core(Box::new(signer.clone())),
@@ -912,8 +922,34 @@ mod tests {
     use crate::database::queries::exists_contract_state;
     use crate::runtime::token;
     use crate::runtime::wit::resources::ViewContext;
-    use crate::test_utils::test_runtime;
+    use crate::test_utils::{test_runtime, test_runtime_with_network};
     use stdlib::KeyElement;
+
+    /// The `Issuance` faucet mint is a dev/test convenience — it must be
+    /// rejected deterministically on mainnet, where the only intended mint is
+    /// protocol emissions; an ungated faucet falsifies the supply schedule.
+    #[tokio::test]
+    async fn issuance_faucet_rejected_on_mainnet() {
+        let (mut runtime, _dir, _name) = test_runtime_with_network(bitcoin::Network::Bitcoin)
+            .await
+            .expect("mainnet test runtime");
+        let signer = super::Signer::Core(Box::new(super::Signer::Nobody));
+        let err = runtime
+            .issuance(&signer)
+            .await
+            .expect_err("issuance must be rejected on mainnet");
+        assert!(
+            matches!(err, super::ExecutionError::Deterministic(_)),
+            "mainnet issuance must reject deterministically, got: {err:?}"
+        );
+
+        // Same call succeeds on a dev network (regtest) — the gate is
+        // network-conditioned, not a blanket disable.
+        let (mut dev, _dir2, _name2) = test_runtime().await.expect("regtest test runtime");
+        dev.issuance(&signer)
+            .await
+            .expect("issuance must succeed on a dev network");
+    }
 
     /// `_` is the ContractAddress wire separator — a name containing it mints
     /// an ambiguously-parseable address, permanent once published (#308). The


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches consensus token minting and supply schedule enforcement; a wrong network gate could block legitimate ops or leave mainnet mintable.
> 
> **Overview**
> **Blocks the gas-free `Issuance` faucet on Bitcoin mainnet** so consensus nodes cannot mint extra supply via the dev/test bootstrap path; only non-mainnet networks keep the existing 10-token `token::api::issuance` behavior.
> 
> `Runtime::issuance` now checks `self.network == bitcoin::Network::Bitcoin` and returns **`ExecutionError::Deterministic`** with `"Issuance faucet is disabled on mainnet"` before any mint runs, matching the intent of the token contract’s network-gated dev mint.
> 
> Adds **`issuance_faucet_rejected_on_mainnet`**: mainnet runtime must fail deterministically; default regtest **`test_runtime()`** must still succeed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dff312bc59222d3c07b2a8375170a2cd39aec28b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->