### PR TITLE
fix(consensus): make the finality verdict deadline-bounded, union the rollback exclusion set, and fix the replay off-by-one

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1747,27 +1747,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06aeba2c965fc446d13c56a6ccb2631b78445d7544543dd9a25289977630914"
+checksum = "47ca6361f42d0c945fadc1103501e1c07438e034fd5a86896a3074eff3e860bd"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2d2dde4ec1352715595b5cfa6fe2e5b8ebb9da3457b3ee8db0aa2808c069aa"
+checksum = "2c1dbc96db7cebf747bd5722d482338a5acff91d6be43b6bec145f9471327ffa"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b4982ef9fa54ec9eee841e891e7ddc5434be1250e88de31572e000c888f30b"
+checksum = "353b309eef494e4adb4c6cca76f30ef27daa907534db7d05b5986500f51aa4e1"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -1775,9 +1775,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529143118c4eeb58c39ecb02319557d512be6c61348486422974ab8e3906b8a8"
+checksum = "e3cafe127a4c5d9765b1df54052245d2cbaca7238782805bb5ac94986ccdb591"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1786,9 +1786,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7780677247ad3577e3a6a3ebf43f39b325a11d6393db72b2c9968a910d4d13d"
+checksum = "3964f31c6dc9d21e926ef884d3eec2f1ca83266a233521da4a737143262ceb84"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1817,9 +1817,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9645250416cbf92454fe61160e17e026e0ce405906a54500b114f923ddffc9"
+checksum = "b2f8b35746603b792e4ae34499a39251f310a06c98d4bc2ca02cf4bd29ce3c84"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1830,24 +1830,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ee8d222ff0fd3681791979afbf88586ac9f49010d3db96b3cbe4c96759aee3"
+checksum = "584bd91987927dfe35e79c5d6dd52a117cb64c4fce26df881d02dcc17bd59a8f"
 
 [[package]]
 name = "cranelift-control"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591abe6f5312bd2c4220f1b3bead56c2ad00257c52668015ba013b85dcf2a17a"
+checksum = "af277352af76db01bb42fa4978b672a44406715798edb693cc02e363e12dc505"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5300c49cf940526fe771517b3b3eabd5d0ff164ee61698579cf403fe8d3af3c"
+checksum = "42ad4f0c556d3d57580d07477be9e665f4d2a826971a5ab4642ead20a19df443"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1857,9 +1857,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4adbf760207fdbbe130f1191cce01cdef66831a9f648b1f39ff2800d126d45"
+checksum = "29d69a6b7d8412c716e8599c7330dfbd122c1bc145f3bda05a9e237fba20419d"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.17.1",
@@ -1870,15 +1870,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8315b21ff018226a42a60a4702c2dd75f6447cac26e9bca622e14c22088c2ff5"
+checksum = "52fcdcd4a5c7fa8bfea35e72c0979ad5a699c836364870f0a84169d02a085a88"
 
 [[package]]
 name = "cranelift-native"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d506ef23a60715bde451b06620b14402166ded3b648454fccbf04f3e46a4aa70"
+checksum = "0fee933cf8ec90e58e68163a02bdb0e4d29f2260a7592b3f09cbba52fcd34d12"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1887,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.133.1"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ed47e602652e3410f9387fc0db70fefadcee4d78a78881421aabcab4e26b89"
+checksum = "6bd75e1e2719808c80af27ebe168d2220ec10e519e1d5a52bdbed9bd5cac1a32"
 
 [[package]]
 name = "crc32fast"
@@ -6264,9 +6264,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b92604caae1a1899b6a5b54967289dd538177c626004c91accf9d0ec7e4a12"
+checksum = "3683e69168d2e2374cea51a79fce2e9870e7c622366b8bf7af87fb5c2428a2a9"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -6276,9 +6276,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7ac85c0bb3fb351f10d531230aaa5e366b46d7c4e5328e5f02801d6dac1165"
+checksum = "8ebbd6dada1e3df36ea4a4b8feca2ed230aa92d59e55bf5714eb4286cdd632b0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9110,9 +9110,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4213d2f019a5e44aa8a61d8826dd33a505bff79f749b14a8bafd67321cb9351"
+checksum = "ed27b4a4a5271d2608406a99c8d1cf8aea1e894fe4ec361d470063bcf342f1d7"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -9164,9 +9164,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45863de41977ec6453e859cf843d456fa3fcb45a659b66d16e794f90ec4f5b7"
+checksum = "7712f99b0920d4638023405eb9723ef200efd6d39bfc7466c92e926ca5d130f0"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -9195,9 +9195,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "438bc7dc45fb75297d75f79a9a0ce852345d13ebc6a6863f6f688f013836a9dd"
+checksum = "bb07d96412d6958817749712969cfd6416cbce11639c3f3431dc659816d84ace"
 dependencies = [
  "base64 0.22.1",
  "directories-next",
@@ -9215,9 +9215,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e48f8d4966d62a10b6d70722bc432c1e163890be2801d3b5784589ad36ffc3"
+checksum = "f60f3492a55dbd4eb2e4f1f33ed0626d141f5f4cf4c0194168a4c5006f6601b0"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -9230,15 +9230,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819ad5abd5822a22dbf4014475cdfd1fe790707761cd732d74aaa3ba4d5ba489"
+checksum = "c777c83bb4c3414b23fe84fecd47a46016a0a0b0a39aa786cad0a701fe3cbc7f"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc28372e36eaf8cf70faa83b5779137f7e99c8d18569a125d1580e735cc9e4d"
+checksum = "ffb54b5de8723a9acf2c0bc531df8e773462796a5f87e8f49a3d5ea5c3b32ef7"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -9248,9 +9248,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a433efc6e35112a5457e1dc8bc4d8d39820ac7722267e89bc04e5df641f32124"
+checksum = "9c60bb70116a88791ccceef605b31010c4888a7305e450f01dc7d4f430ad25f0"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -9275,9 +9275,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a1d3a39d0d210f6b8574ee96a4315e0a14c67f3a1fc3cd5372cb10d2fb4422"
+checksum = "24bdf54907e0bad31ad6676d03ed1008fa21489725635136f9c38979c39a98ed"
 dependencies = [
  "cc",
  "cfg-if",
@@ -9290,9 +9290,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f667288cb4dfa68a4639ffac4d5628535dda64ebdc2b990526efb12b30ba803"
+checksum = "ef4edaf07e20511f3ca070a4a0f026c407969f09e536075729872f548ca6f8d4"
 dependencies = [
  "cc",
  "object 0.39.1",
@@ -9302,9 +9302,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba651d44ab0faad4c58106b3adb45068189fb65ef50f0c404b6d9e3bf81a357"
+checksum = "f96a6d7eb246d1306b7db8915a169cd8628a9e6b8299d1d1f8ab109801ef0a66"
 dependencies = [
  "cfg-if",
  "libc",
@@ -9314,9 +9314,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ecc52563b0558af2a7487eb710de07cc4532564b55528876129238e83118cb1"
+checksum = "39472572ea3eb11b7cc7fe7bd6df0005cef87b580eb06a3378d103ac99d45bc3"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -9327,9 +9327,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e747f4a074699ba1b4e4d841fb263f9b7df5bd1555181c4752bf5990d21ba676"
+checksum = "7bf2eff1c108b01566a7c8870de34821e7bda7d327e86e12a548c026e1e3677d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9338,9 +9338,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "46.0.1"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80009f46991622814196d96fac6fc0a938f46b5cba737a8f4e21e24e5a03856f"
+checksum = "d1d9d3ffd05d6e864adc35cff702f56307c454caec3b1d2d89dd6c843219b663"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,7 +21,7 @@ too_many_arguments = "allow"
 
 [workspace.dependencies]
 # IMPORTANT
-wasmtime = { version = "=46.0.1", features = ["wave", "component-model-async"] }
+wasmtime = { version = "=46.0.2", features = ["wave", "component-model-async"] }
 wit-bindgen = "=0.60.0"
 wit-component = "=0.253.0"
 wit-parser = "=0.253.0"

--- a/core/indexer/src/bitcoin_follower/poller/mod.rs
+++ b/core/indexer/src/bitcoin_follower/poller/mod.rs
@@ -195,6 +195,22 @@ fn deliver_blocks(
     }
 }
 
+/// Apply a replay request: rewind so redelivery resumes strictly after `height`.
+///
+/// Only ever rewinds. Plain assignment would let a stale request that predates a
+/// poller-side reorg rollback (`apply_rollback`, which sets its own `next_height`
+/// and does not drain the replay channel) move the poller FORWARD and silently
+/// skip blocks — so both consumers of the channel take the minimum instead.
+fn apply_replay(cache: &mut BlockHashCache, next_height: &mut u64, height: u64) {
+    let resume = height + 1;
+    if resume >= *next_height {
+        return;
+    }
+    info!(height, "Replay request received — resetting poller");
+    cache.truncate_above(height);
+    *next_height = resume;
+}
+
 /// Apply a rollback: truncate the cache, update next_height, and send
 /// the Rollback event. Returns `true` if the channel is still open.
 async fn apply_rollback(
@@ -283,6 +299,16 @@ pub async fn run<C: BitcoinRpc>(
             return Ok(());
         }
 
+        // Replay requests must be observed even while catching up. The only other
+        // consumer is `wait_for_poll` below, which is reachable only when idle at
+        // the tip — so a node genuinely behind on Bitcoin (exactly the one a
+        // rollback replay targets) would never read the channel, and the reactor
+        // can block on the bounded send. One try_recv per iteration is free next
+        // to the tip RPC that follows.
+        while let Ok(height) = replay_rx.try_recv() {
+            apply_replay(&mut cache, &mut next_height, height);
+        }
+
         // 1. Discover tip
         let tip = match retry(
             || bitcoin.get_blockchain_info(),
@@ -325,9 +351,7 @@ pub async fn run<C: BitcoinRpc>(
             {
                 PollResult::Continue => continue,
                 PollResult::Replay(height) => {
-                    info!(height, "Replay request received — resetting poller");
-                    cache.truncate_above(height);
-                    next_height = height + 1;
+                    apply_replay(&mut cache, &mut next_height, height);
                     continue;
                 }
                 PollResult::Cancelled => return Ok(()),

--- a/core/indexer/src/bitcoin_follower/poller/tests.rs
+++ b/core/indexer/src/bitcoin_follower/poller/tests.rs
@@ -783,6 +783,35 @@ async fn run_cancellation_stops_cleanly() {
     assert!(result.is_ok());
 }
 
+/// A replay request means "resume strictly after this height", matching the
+/// rollback convention. Assignment would let a stale request that predates a
+/// poller-side reorg move the poller FORWARD and silently skip blocks, so it
+/// may only ever rewind.
+#[test]
+fn apply_replay_rewinds_to_just_after_the_requested_height() {
+    let mut cache = BlockHashCache::new(10);
+    let mut next_height = 10;
+    apply_replay(&mut cache, &mut next_height, 3);
+    assert_eq!(next_height, 4);
+}
+
+#[test]
+fn apply_replay_ignores_a_request_that_would_move_the_poller_forward() {
+    let mut cache = BlockHashCache::new(10);
+    let mut next_height = 4;
+    // A stale request from before a reorg rollback already rewound us further.
+    apply_replay(&mut cache, &mut next_height, 8);
+    assert_eq!(next_height, 4, "must not skip blocks 4..=8");
+}
+
+#[test]
+fn apply_replay_is_a_noop_at_the_current_position() {
+    let mut cache = BlockHashCache::new(10);
+    let mut next_height = 5;
+    apply_replay(&mut cache, &mut next_height, 4);
+    assert_eq!(next_height, 5);
+}
+
 #[tokio::test]
 async fn run_replay_redelivers_blocks() {
     let blocks = new_numbered_blockchain(5);

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -717,8 +717,12 @@ impl<E: Executor> Reactor<E> {
             .unfinalized_batches
             .retain(|b| b.anchor_height < from_anchor);
 
+        // The reactor truncated to `from_anchor - 1`, deleting the anchor block
+        // itself, so redelivery must START at `from_anchor` — i.e. strictly after
+        // `from_anchor - 1`. Asking for `from_anchor` under the exclusive convention
+        // resumes one block too late and the anchor never comes back.
         self.executor
-            .replay_blocks_from(from_anchor)
+            .replay_blocks_after(from_anchor.saturating_sub(1))
             .await
             .context("Failed to send replay request")?;
         Ok(())

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -122,6 +122,121 @@ pub struct ObservationChannels {
     pub state_tx: mpsc::Sender<StateEvent>,
 }
 
+// --- Finality tracking ---
+
+/// The batch's txids that did NOT confirm on Bitcoin by its deadline.
+///
+/// Deliberately takes no tip: the verdict must be a function of the batch and the
+/// `blocks`/`transactions` tables alone. Testing only that `confirmed_height` is
+/// SET would make it a function of WHEN a node evaluates instead — `confirmed_height
+/// <= last_height` always holds (a block sets `last_height` before it executes), so
+/// a tx confirmed one block past the deadline reads missing to a node evaluating at
+/// the deadline and confirmed to one evaluating later. Two honest nodes then
+/// disagree about the same batch and one rolls back while the other finalizes it.
+async fn missing_txids(conn: &libsql::Connection, batch: &UnfinalizedBatch) -> Vec<Txid> {
+    let mut missing = Vec::new();
+    for txid in &batch.txids {
+        let confirmed = match get_transaction_by_txid(conn, &txid.to_string()).await {
+            Ok(Some(row)) => row.confirmed_height.is_some_and(|h| h <= batch.deadline),
+            _ => false,
+        };
+        if !confirmed {
+            missing.push(*txid);
+        }
+    }
+    missing
+}
+
+/// Decide what an at-deadline set means, given each batch's unconfirmed txids.
+/// Returns the events to emit and the batches that stay tracked.
+///
+/// `at_deadline` must be sorted by `(anchor_height, consensus_height)` and
+/// `missing_per_batch` index-aligned with it. Split out as a pure function so the
+/// partition — the part that decides whether nodes converge — is testable without
+/// a database or a live `ConsensusState`.
+fn build_finality_events(
+    at_deadline: &[UnfinalizedBatch],
+    missing_per_batch: &[Vec<Txid>],
+    still_pending: Vec<UnfinalizedBatch>,
+) -> (Vec<FinalityEvent>, Vec<UnfinalizedBatch>) {
+    debug_assert_eq!(at_deadline.len(), missing_per_batch.len());
+    let mut events = Vec::new();
+
+    let Some(first_fail) = missing_per_batch.iter().position(|m| !m.is_empty()) else {
+        for batch in at_deadline {
+            info!(
+                consensus_height = %batch.consensus_height,
+                anchor = batch.anchor_height,
+                "Batch finalized"
+            );
+            events.push(FinalityEvent::BatchFinalized {
+                consensus_height: batch.consensus_height,
+                anchor_height: batch.anchor_height,
+            });
+        }
+        return (events, still_pending);
+    };
+
+    // Only batches strictly ahead of the first failure finalize. Everything from it
+    // onward is replayed by this same rollback — the sort guarantees they all have
+    // anchor_height >= from_anchor — so they are invalidated whether or not their
+    // own txids confirmed. Finalizing one of them would announce a batch that is
+    // about to be torn out, and dropping it from tracking silently left convergence
+    // to an implicit replay invariant (#426).
+    for batch in &at_deadline[..first_fail] {
+        info!(
+            consensus_height = %batch.consensus_height,
+            anchor = batch.anchor_height,
+            "Batch finalized"
+        );
+        events.push(FinalityEvent::BatchFinalized {
+            consensus_height: batch.consensus_height,
+            anchor_height: batch.anchor_height,
+        });
+    }
+
+    let from_anchor = at_deadline[first_fail].anchor_height;
+    let mut invalidated: Vec<Height> = at_deadline[first_fail..]
+        .iter()
+        .map(|b| b.consensus_height)
+        .collect();
+
+    // The exclusion set must cover every batch the rollback replays, not just the
+    // first to fail: the replay reloads each one with its FULL certified content
+    // (`batch_txids` is append-only and the exclusion filter is in-memory), so a
+    // batch left out re-executes, re-arms the identical deadline, and rolls back
+    // again with the complementary set — a cycle that never converges.
+    let missing: Vec<Txid> = missing_per_batch[first_fail..]
+        .iter()
+        .flatten()
+        .copied()
+        .collect();
+
+    let mut surviving = Vec::new();
+    for pending in still_pending {
+        if pending.anchor_height >= from_anchor {
+            invalidated.push(pending.consensus_height);
+        } else {
+            surviving.push(pending);
+        }
+    }
+
+    warn!(
+        from_anchor,
+        invalidated = ?invalidated,
+        missing = missing.len(),
+        "Cascade invalidation triggered"
+    );
+
+    events.push(FinalityEvent::Rollback {
+        from_anchor,
+        invalidated_batches: invalidated,
+        missing_txids: missing,
+    });
+
+    (events, surviving)
+}
+
 impl ConsensusState {
     pub async fn new(
         conn: libsql::Connection,
@@ -275,8 +390,6 @@ impl ConsensusState {
         msgs
     }
 
-    // --- Finality tracking ---
-
     pub async fn check_finality(
         &mut self,
         conn: &libsql::Connection,
@@ -296,70 +409,23 @@ impl ConsensusState {
             }
         }
 
+        // `from_anchor` below is taken from the FIRST failing batch, which is the
+        // minimal failing anchor only because `anchor_height` is the PRIMARY sort
+        // key here. Re-sorting by `consensus_height` alone would silently break it.
         at_deadline.sort_by_key(|b| (b.anchor_height, b.consensus_height));
 
-        for (i, batch) in at_deadline.iter().enumerate() {
-            let mut missing = Vec::new();
-            for txid in &batch.txids {
-                let confirmed = match get_transaction_by_txid(conn, &txid.to_string()).await {
-                    Ok(Some(row)) => row.confirmed_height.is_some(),
-                    _ => false,
-                };
-                if !confirmed {
-                    missing.push(*txid);
-                }
-            }
-
-            if missing.is_empty() {
-                info!(
-                    consensus_height = %batch.consensus_height,
-                    anchor = batch.anchor_height,
-                    "Batch finalized"
-                );
-                events.push(FinalityEvent::BatchFinalized {
-                    consensus_height: batch.consensus_height,
-                    anchor_height: batch.anchor_height,
-                });
-            } else {
-                let from_anchor = batch.anchor_height;
-                let mut invalidated = vec![batch.consensus_height];
-
-                // Every remaining at-deadline batch shares this fate: the sort
-                // above orders by (anchor_height, consensus_height), so all of
-                // them have anchor_height >= from_anchor and are replayed by
-                // this same rollback. Fold them into the invalidated set
-                // explicitly — silently dropping them from tracking left
-                // convergence to an implicit replay invariant (#426).
-                invalidated.extend(at_deadline[i + 1..].iter().map(|b| b.consensus_height));
-
-                let mut surviving = Vec::new();
-                for pending in still_pending.drain(..) {
-                    if pending.anchor_height >= from_anchor {
-                        invalidated.push(pending.consensus_height);
-                    } else {
-                        surviving.push(pending);
-                    }
-                }
-                still_pending = surviving;
-
-                warn!(
-                    from_anchor,
-                    invalidated = ?invalidated,
-                    missing = missing.len(),
-                    "Cascade invalidation triggered"
-                );
-
-                events.push(FinalityEvent::Rollback {
-                    from_anchor,
-                    invalidated_batches: invalidated,
-                    missing_txids: missing,
-                });
-
-                break;
-            }
+        let mut missing_per_batch = Vec::with_capacity(at_deadline.len());
+        for batch in &at_deadline {
+            missing_per_batch.push(missing_txids(conn, batch).await);
         }
 
-        self.unfinalized_batches = still_pending;
+        let (built, surviving) = build_finality_events(
+            &at_deadline,
+            &missing_per_batch,
+            std::mem::take(&mut still_pending),
+        );
+        events.extend(built);
+        self.unfinalized_batches = surviving;
         events
     }
 
@@ -545,18 +611,29 @@ impl ConsensusState {
         last_height: u64,
     ) -> Option<(u64, HashSet<Txid>)> {
         let finality_events = self.check_finality(conn, last_height).await;
-        let mut result = None;
-        for event in &finality_events {
-            if let FinalityEvent::Rollback {
+        // At most one Rollback per pass — `check_finality` folds every failing
+        // at-deadline batch into a single event. Taking the FIRST rather than the
+        // last matters if that ever regresses: last-wins would keep the highest
+        // `from_anchor` and silently discard the lower ones' exclusions.
+        debug_assert!(
+            finality_events
+                .iter()
+                .filter(|e| matches!(e, FinalityEvent::Rollback { .. }))
+                .count()
+                <= 1,
+            "check_finality must emit at most one Rollback"
+        );
+        let result = finality_events.iter().find_map(|event| match event {
+            FinalityEvent::Rollback {
                 from_anchor,
                 missing_txids,
                 ..
-            } = event
-            {
+            } => {
                 let excluded: HashSet<Txid> = missing_txids.iter().copied().collect();
-                result = Some((*from_anchor, excluded));
+                Some((*from_anchor, excluded))
             }
-        }
+            _ => None,
+        });
         self.emit_finality_events(&finality_events);
         result
     }
@@ -605,5 +682,227 @@ impl ConsensusState {
             return Ok(Some("contains already-processed transactions"));
         }
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{UnfinalizedBatch, build_finality_events, missing_txids};
+    use crate::consensus::Height;
+    use crate::consensus::finality_types::FinalityEvent;
+    use crate::database::queries::{confirm_transaction, insert_block, insert_transaction};
+    use crate::test_utils::{new_mock_block_hash, new_test_db};
+    use bitcoin::hashes::Hash;
+    use bitcoin::{BlockHash, Txid};
+
+    fn txid(n: u8) -> Txid {
+        Txid::from_byte_array([n; 32])
+    }
+
+    /// A tracked batch at `anchor`, deadline `anchor + 6`, carrying `txids`.
+    fn batch(consensus_height: u64, anchor: u64, txids: &[u8]) -> UnfinalizedBatch {
+        UnfinalizedBatch {
+            consensus_height: Height::new(consensus_height),
+            anchor_height: anchor,
+            anchor_hash: BlockHash::all_zeros(),
+            txids: txids.iter().copied().map(txid).collect(),
+            deadline: anchor + 6,
+        }
+    }
+
+    fn rollback_of(events: &[FinalityEvent]) -> (u64, Vec<Height>, Vec<Txid>) {
+        let mut found = events.iter().filter_map(|e| match e {
+            FinalityEvent::Rollback {
+                from_anchor,
+                invalidated_batches,
+                missing_txids,
+            } => Some((
+                *from_anchor,
+                invalidated_batches.clone(),
+                missing_txids.clone(),
+            )),
+            _ => None,
+        });
+        let first = found.next().expect("expected a Rollback event");
+        assert!(found.next().is_none(), "expected exactly one Rollback");
+        first
+    }
+
+    fn finalized_heights(events: &[FinalityEvent]) -> Vec<Height> {
+        events
+            .iter()
+            .filter_map(|e| match e {
+                FinalityEvent::BatchFinalized {
+                    consensus_height, ..
+                } => Some(*consensus_height),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn all_confirmed_finalizes_every_batch_and_rolls_back_nothing() {
+        let at_deadline = vec![batch(1, 100, &[1]), batch(2, 100, &[2])];
+        let missing = vec![vec![], vec![]];
+        let pending = vec![batch(3, 105, &[3])];
+
+        let (events, surviving) = build_finality_events(&at_deadline, &missing, pending);
+
+        assert_eq!(
+            finalized_heights(&events),
+            vec![Height::new(1), Height::new(2)]
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, FinalityEvent::Rollback { .. }))
+        );
+        assert_eq!(surviving.len(), 1, "pending batch must stay tracked");
+    }
+
+    /// The #515 shape: two non-empty batches sharing one anchor, both failing.
+    /// A per-batch exclusion set would empty one and leave the other full, so the
+    /// replay re-arms the same deadline and the rollback never converges.
+    #[test]
+    fn exclusion_set_unions_every_failing_batch_in_the_band() {
+        let at_deadline = vec![batch(557, 312469, &[1, 2, 3]), batch(628, 312469, &[4, 5])];
+        let missing = vec![vec![txid(1), txid(2), txid(3)], vec![txid(4), txid(5)]];
+
+        let (events, _) = build_finality_events(&at_deadline, &missing, Vec::new());
+        let (from_anchor, invalidated, excluded) = rollback_of(&events);
+
+        assert_eq!(from_anchor, 312469);
+        assert_eq!(invalidated, vec![Height::new(557), Height::new(628)]);
+        assert_eq!(
+            excluded,
+            vec![txid(1), txid(2), txid(3), txid(4), txid(5)],
+            "both failing batches' txids must be excluded"
+        );
+    }
+
+    /// A batch that PASSES but sorts at or after the first failure is still torn
+    /// out by the rollback, so it must be invalidated rather than finalized —
+    /// announcing it as final would contradict the rollback in the same pass.
+    #[test]
+    fn passing_batch_after_the_first_failure_is_invalidated_not_finalized() {
+        let at_deadline = vec![
+            batch(10, 100, &[1]), // passes, before the failure
+            batch(11, 101, &[2]), // fails
+            batch(12, 102, &[3]), // passes, but after
+        ];
+        let missing = vec![vec![], vec![txid(2)], vec![]];
+
+        let (events, _) = build_finality_events(&at_deadline, &missing, Vec::new());
+        let (from_anchor, invalidated, _) = rollback_of(&events);
+        let finalized = finalized_heights(&events);
+
+        assert_eq!(from_anchor, 101);
+        assert_eq!(finalized, vec![Height::new(10)]);
+        assert_eq!(invalidated, vec![Height::new(11), Height::new(12)]);
+        for h in &finalized {
+            assert!(
+                !invalidated.contains(h),
+                "{h} was both finalized and invalidated"
+            );
+        }
+    }
+
+    /// `from_anchor` comes from the first FAILING batch, which is minimal among
+    /// failures only because `anchor_height` is the primary sort key.
+    #[test]
+    fn from_anchor_skips_passing_batches_at_lower_anchors() {
+        let at_deadline = vec![batch(20, 100, &[1]), batch(21, 101, &[2])];
+        let missing = vec![vec![], vec![txid(2)]];
+
+        let (events, _) = build_finality_events(&at_deadline, &missing, Vec::new());
+        let (from_anchor, _, _) = rollback_of(&events);
+
+        assert_eq!(from_anchor, 101, "the passing batch at 100 must survive");
+    }
+
+    #[test]
+    fn pending_batches_at_or_above_the_anchor_are_invalidated() {
+        let at_deadline = vec![batch(30, 200, &[1])];
+        let missing = vec![vec![txid(1)]];
+        let pending = vec![
+            batch(31, 199, &[2]),
+            batch(32, 200, &[3]),
+            batch(33, 201, &[4]),
+        ];
+
+        let (events, surviving) = build_finality_events(&at_deadline, &missing, pending);
+        let (_, invalidated, _) = rollback_of(&events);
+
+        assert_eq!(
+            surviving
+                .iter()
+                .map(|b| b.consensus_height)
+                .collect::<Vec<_>>(),
+            vec![Height::new(31)],
+            "only the batch anchored below from_anchor survives"
+        );
+        assert_eq!(
+            invalidated,
+            vec![Height::new(30), Height::new(32), Height::new(33)]
+        );
+    }
+
+    /// The determinism property: a tx confirmed AFTER the deadline must read as
+    /// missing no matter how far the tip has since advanced. Testing only that
+    /// `confirmed_height` is set would make the verdict depend on when a node
+    /// happens to evaluate, and two honest nodes would diverge.
+    #[tokio::test]
+    async fn confirmation_is_bounded_by_the_deadline() {
+        let (_reader, writer, _dir) = new_test_db().await.unwrap();
+        let conn = writer.connection();
+
+        // Batch anchored at 10 → deadline 16. One tx confirms at 16 (in time),
+        // the other at 17 (one block late).
+        for height in [10, 16, 17] {
+            insert_block(
+                &conn,
+                indexer_types::BlockRow::builder()
+                    .height(height)
+                    .hash(new_mock_block_hash(height as u32))
+                    .relevant(true)
+                    .build(),
+            )
+            .await
+            .unwrap();
+        }
+        for (n, confirmed_at) in [(1u8, 16u64), (2u8, 17u64)] {
+            insert_transaction(
+                &conn,
+                indexer_types::TransactionRow::builder()
+                    .height(10)
+                    .txid(txid(n).to_string())
+                    .build(),
+            )
+            .await
+            .unwrap();
+            confirm_transaction(&conn, &txid(n).to_string(), confirmed_at, 0)
+                .await
+                .unwrap();
+        }
+
+        let b = batch(500, 10, &[1, 2]);
+        assert_eq!(b.deadline, 16);
+        assert_eq!(
+            missing_txids(&conn, &b).await,
+            vec![txid(2)],
+            "the tx confirmed at deadline+1 must count as missing"
+        );
+
+        // The same batch against the same tables gives the same answer regardless
+        // of how far the chain has moved on — there is no tip input at all.
+        assert_eq!(missing_txids(&conn, &b).await, vec![txid(2)]);
+    }
+
+    #[tokio::test]
+    async fn a_txid_with_no_row_counts_as_missing() {
+        let (_reader, writer, _dir) = new_test_db().await.unwrap();
+        let conn = writer.connection();
+        let b = batch(500, 10, &[9]);
+        assert_eq!(missing_txids(&conn, &b).await, vec![txid(9)]);
     }
 }

--- a/core/indexer/src/reactor/executor.rs
+++ b/core/indexer/src/reactor/executor.rs
@@ -80,8 +80,10 @@ pub trait Executor {
         tx: &indexer_types::Transaction,
     ) -> Result<Vec<Vec<Option<anyhow::Error>>>>;
 
-    /// Signal the block source to re-deliver blocks starting from `height`.
-    async fn replay_blocks_from(&mut self, height: u64) -> Result<()>;
+    /// Signal the block source to re-deliver blocks strictly AFTER `after_height`.
+    /// Exclusive, matching the poller's rollback convention: a caller that has just
+    /// truncated to `h` asks for `h` so block `h` itself is re-delivered.
+    async fn replay_blocks_after(&mut self, after_height: u64) -> Result<()>;
 
     /// Parse a bitcoin::Transaction into an indexer_types::Transaction.
     fn parse_transaction(&self, tx: &bitcoin::Transaction) -> Option<indexer_types::Transaction>;
@@ -111,7 +113,7 @@ impl Executor for NoopExecutor {
     ) -> Result<Vec<Vec<Option<anyhow::Error>>>> {
         Ok(Vec::new())
     }
-    async fn replay_blocks_from(&mut self, _height: u64) -> Result<()> {
+    async fn replay_blocks_after(&mut self, _after_height: u64) -> Result<()> {
         Ok(())
     }
     fn parse_transaction(&self, _tx: &bitcoin::Transaction) -> Option<indexer_types::Transaction> {
@@ -276,9 +278,9 @@ impl Executor for RuntimeExecutor {
         }
         Ok(all)
     }
-    async fn replay_blocks_from(&mut self, height: u64) -> Result<()> {
+    async fn replay_blocks_after(&mut self, after_height: u64) -> Result<()> {
         if let Some(tx) = &self.replay_tx {
-            tx.send(height)
+            tx.send(after_height)
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to send replay request to poller: {e}"))?;
         }

--- a/core/indexer/src/reactor/lite_executor.rs
+++ b/core/indexer/src/reactor/lite_executor.rs
@@ -217,11 +217,11 @@ impl Executor for LiteExecutor {
         }
     }
 
-    async fn replay_blocks_from(&mut self, height: u64) -> anyhow::Result<()> {
+    async fn replay_blocks_after(&mut self, after_height: u64) -> anyhow::Result<()> {
         let events = self.mock_bitcoin.lock().unwrap().get_all_block_events();
         for event in events {
             if let crate::bitcoin_follower::event::BlockEvent::BlockInsert { block, .. } = &event
-                && block.height >= height
+                && block.height > after_height
             {
                 let _ = self.block_tx.send(event).await;
             }

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -495,7 +495,7 @@ impl<E: Executor> Reactor<E> {
                                 // `pending_blocks` is deliberately NOT cleared here (#430):
                                 // a finality rollback re-executes against the SAME Bitcoin
                                 // chain, so cached blocks are still the right data and make
-                                // this drain immediate — `replay_blocks_from` re-delivery is
+                                // this drain immediate — `replay_blocks_after` re-delivery is
                                 // only the fallback. The Bitcoin-reorg path (`BlockEvent::
                                 // Rollback`) clears them instead because there the blocks
                                 // themselves changed; the drain's block-hash check guards


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes core consensus finality, cascade rollback, and block replay paths where bugs cause divergent state or non-converging rollbacks; wasmtime patch is low impact by comparison.
> 
> **Overview**
> Fixes several **consensus finality and rollback replay** bugs that could let honest nodes diverge or rollbacks never converge.
> 
> **Finality verdicts** now treat a batch tx as confirmed only when `confirmed_height <= batch.deadline` (not merely “confirmed at all”), so the outcome does not depend on when a node runs the check. Rollback handling is refactored into testable `missing_txids` / `build_finality_events`: the **exclusion set unions missing txids from every failing at-deadline batch** in the band (not just the first failure), batches after the first failure are invalidated instead of finalized, and `run_finality_checks` takes the first rollback event only.
> 
> **Block redelivery** uses an exclusive `replay_blocks_after` API; after truncating to `from_anchor - 1`, replay requests `from_anchor - 1` so the anchor block is included again. The Bitcoin poller adds **`apply_replay`** (rewind-only, ignores stale forward requests) and drains replay messages with **`try_recv` during catch-up** so nodes behind the tip still honor replay while the reactor is blocked on send.
> 
> Also bumps workspace **`wasmtime`** from 46.0.1 to 46.0.2 (lockfile refresh).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e0a211d01b3e797c2d72e1097b6055aa0c6e3b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->