### PR TITLE
fix(consensus): durable finality tracking, deterministic verdicts, and a survivable rollback/replay pipeline

### DIFF
--- a/core/indexer/src/consensus/finality_types.rs
+++ b/core/indexer/src/consensus/finality_types.rs
@@ -4,6 +4,24 @@ use super::{Height, Value};
 
 pub const FINALITY_WINDOW: u64 = 6;
 
+/// Bitcoin height by which a batch anchored at `anchor_height` must have its
+/// transactions confirmed, or the batch is void and its anchor rolls back.
+pub const fn deadline_for(anchor_height: u64) -> u64 {
+    anchor_height + FINALITY_WINDOW
+}
+
+/// Lowest anchor height whose batches can still be awaiting a deadline at `tip`.
+/// Startup rehydration reloads exactly this band, so it introduces no new window —
+/// it reconstructs the set the running node already tracks.
+///
+/// Inclusive of the at-deadline anchor (`anchor >= floor`, not `>`): a batch whose
+/// deadline is exactly `tip` still needs its verdict, and dropping it on restart
+/// would silently skip the rollback a peer performs. The first `check_finality`
+/// after startup settles it.
+pub const fn tracking_floor(tip: u64) -> u64 {
+    tip.saturating_sub(FINALITY_WINDOW)
+}
+
 #[derive(Debug, Clone)]
 pub struct UnfinalizedBatch {
     pub consensus_height: Height,

--- a/core/indexer/src/consensus/finality_types.rs
+++ b/core/indexer/src/consensus/finality_types.rs
@@ -40,8 +40,19 @@ pub enum FinalityEvent {
     Rollback {
         from_anchor: u64,
         invalidated_batches: Vec<Height>,
-        missing_txids: Vec<Txid>,
+        /// Per DECISION, not flattened. Which batch a txid went missing from is what
+        /// lets the exclusion be recorded against that height alone — flattening it
+        /// is how a global ban gets built by accident.
+        missing: Vec<BatchExclusion>,
     },
+}
+
+/// The txids one decided batch failed to confirm by its own deadline.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BatchExclusion {
+    pub consensus_height: Height,
+    pub anchor_height: u64,
+    pub txids: Vec<Txid>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/core/indexer/src/database/queries/batches.rs
+++ b/core/indexer/src/database/queries/batches.rs
@@ -306,7 +306,7 @@ pub async fn select_unfinalized_batches(
         "SELECT b.consensus_height, b.anchor_height, b.anchor_hash, b.certificate, t.txid \
          FROM batches b INDEXED BY idx_batches_anchor_height \
          JOIN blocks bl ON bl.height = b.anchor_height AND bl.hash = b.anchor_hash \
-         JOIN transactions t ON t.batch_height = b.consensus_height \
+         JOIN executed_batch_txids t ON t.batch_height = b.consensus_height \
          WHERE b.anchor_height >= {from_anchor} AND b.is_block = 0 \
          ORDER BY b.consensus_height, t.id"
     );

--- a/core/indexer/src/database/queries/batches.rs
+++ b/core/indexer/src/database/queries/batches.rs
@@ -279,3 +279,58 @@ pub async fn select_unconfirmed_batch_tx(
         .map(|row| row.get::<Vec<u8>>(0))
         .transpose()?)
 }
+
+/// Executed, still-unfinalized batches anchored at or above `from_anchor`, with the
+/// txids this node ACTUALLY executed for each — for rebuilding finality tracking
+/// after a restart.
+///
+/// Sourced from `transactions`, deliberately NOT from `batch_txids`. The certified
+/// list is append-only (`INSERT OR IGNORE` on `(batch_height, position)`, no cascade),
+/// so once a replay has dropped excluded transactions from a batch the stored list
+/// still holds them, permanently. Rehydrating from it would re-arm a deadline on
+/// txids this node deliberately dropped and trigger a rollback no peer performs.
+/// The join also subsumes an "did we execute this batch" existence check: record-only
+/// batches write no `transactions` rows and rolled-back ones have theirs cascade-deleted.
+///
+/// The `blocks` join is load-bearing, not a filter refinement: it pins each batch to
+/// the anchor block CURRENTLY at that height, so a Bitcoin reorg cannot resurrect
+/// tracking for batches anchored to a block that no longer exists.
+///
+/// INDEXED BY: the planner picks a full scan of `batches` for this predicate even
+/// after ANALYZE, and production databases never run it.
+pub async fn select_unfinalized_batches(
+    conn: &Connection,
+    from_anchor: u64,
+) -> Result<Vec<BatchQueryResult>, Error> {
+    let sql = format!(
+        "SELECT b.consensus_height, b.anchor_height, b.anchor_hash, b.certificate, t.txid \
+         FROM batches b INDEXED BY idx_batches_anchor_height \
+         JOIN blocks bl ON bl.height = b.anchor_height AND bl.hash = b.anchor_hash \
+         JOIN transactions t ON t.batch_height = b.consensus_height \
+         WHERE b.anchor_height >= {from_anchor} AND b.is_block = 0 \
+         ORDER BY b.consensus_height, t.id"
+    );
+    let mut rows = conn.query(&sql, ()).await?;
+
+    let mut results: Vec<BatchQueryResult> = Vec::new();
+    while let Some(row) = rows.next().await? {
+        let consensus_height: u64 = row.get(0)?;
+        let txid: String = row.get(4)?;
+        if results
+            .last()
+            .is_some_and(|r| r.consensus_height == consensus_height)
+        {
+            results.last_mut().unwrap().txids.push(txid);
+        } else {
+            results.push(BatchQueryResult {
+                consensus_height,
+                anchor_height: row.get(1)?,
+                anchor_hash: row.get(2)?,
+                certificate: row.get(3)?,
+                is_block: false,
+                txids: vec![txid],
+            });
+        }
+    }
+    Ok(results)
+}

--- a/core/indexer/src/database/queries/batches.rs
+++ b/core/indexer/src/database/queries/batches.rs
@@ -292,31 +292,19 @@ pub async fn select_unconfirmed_batch_tx(
 /// The join also subsumes an "did we execute this batch" existence check: record-only
 /// batches write no `transactions` rows and rolled-back ones have theirs cascade-deleted.
 ///
-/// Txids a batch CERTIFIED but this node never EXECUTED, for every batch at or above
-/// `from_anchor`.
+/// Every txid a finality exclusion has ever dropped on this node.
 ///
-/// The difference is exactly what an earlier finality pass excluded. It has to be
-/// re-derived rather than remembered: `batch_txids` is append-only and a replay
-/// reloads the FULL certified list from it, so without carrying the difference
-/// forward each pass starts from a clean slate and can put back a transaction an
-/// earlier pass already proved never confirms. Two passes then alternate between the
-/// complementary halves and the tip oscillates forever.
-///
-/// Must be read BEFORE the rollback truncation — the `transactions` rows this
-/// depends on are cascade-deleted with their blocks.
-pub async fn select_previously_excluded_txids(
+/// Read at the start of a rollback and unioned into the pass's own exclusions, which
+/// makes the set MONOTONE across passes. Without that, a replay reloads each batch
+/// from the append-only `batch_txids` and can put back a transaction an earlier pass
+/// already proved never confirms; two passes then alternate between complementary
+/// halves and the tip oscillates forever.
+pub async fn select_excluded_batch_txids(
     conn: &Connection,
-    from_anchor: u64,
 ) -> Result<std::collections::HashSet<String>, Error> {
-    let sql = format!(
-        "SELECT bt.txid \
-         FROM batches b INDEXED BY idx_batches_anchor_height \
-         JOIN batch_txids bt ON bt.batch_height = b.consensus_height \
-         LEFT JOIN executed_batch_txids e \
-           ON e.batch_height = b.consensus_height AND e.txid = bt.txid \
-         WHERE b.anchor_height >= {from_anchor} AND b.is_block = 0 AND e.txid IS NULL"
-    );
-    let mut rows = conn.query(&sql, ()).await?;
+    let mut rows = conn
+        .query("SELECT txid FROM excluded_batch_txids", ())
+        .await?;
     let mut out = std::collections::HashSet::new();
     while let Some(row) = rows.next().await? {
         out.insert(row.get::<String>(0)?);
@@ -324,12 +312,19 @@ pub async fn select_previously_excluded_txids(
     Ok(out)
 }
 
-/// The `blocks` join is load-bearing, not a filter refinement: it pins each batch to
-/// the anchor block CURRENTLY at that height, so a Bitcoin reorg cannot resurrect
-/// tracking for batches anchored to a block that no longer exists.
-///
-/// INDEXED BY: the planner picks a full scan of `batches` for this predicate even
-/// after ANALYZE, and production databases never run it.
+/// Record txids dropped by a finality exclusion. Idempotent — the same tx can be
+/// excluded again by a later pass over the same batch.
+pub async fn insert_excluded_batch_txids(conn: &Connection, txids: &[String]) -> Result<(), Error> {
+    for txid in txids {
+        conn.execute(
+            "INSERT OR IGNORE INTO excluded_batch_txids (txid) VALUES (?)",
+            params![txid.clone()],
+        )
+        .await?;
+    }
+    Ok(())
+}
+
 pub async fn select_unfinalized_batches(
     conn: &Connection,
     from_anchor: u64,

--- a/core/indexer/src/database/queries/batches.rs
+++ b/core/indexer/src/database/queries/batches.rs
@@ -280,18 +280,6 @@ pub async fn select_unconfirmed_batch_tx(
         .transpose()?)
 }
 
-/// Executed, still-unfinalized batches anchored at or above `from_anchor`, with the
-/// txids this node ACTUALLY executed for each — for rebuilding finality tracking
-/// after a restart.
-///
-/// Sourced from `transactions`, deliberately NOT from `batch_txids`. The certified
-/// list is append-only (`INSERT OR IGNORE` on `(batch_height, position)`, no cascade),
-/// so once a replay has dropped excluded transactions from a batch the stored list
-/// still holds them, permanently. Rehydrating from it would re-arm a deadline on
-/// txids this node deliberately dropped and trigger a rollback no peer performs.
-/// The join also subsumes an "did we execute this batch" existence check: record-only
-/// batches write no `transactions` rows and rolled-back ones have theirs cascade-deleted.
-///
 /// Recorded exclusions that STILL HOLD, keyed by the consensus height they apply to.
 ///
 /// The stored row is a node-local fact: "we found T missing at H's deadline". The
@@ -352,6 +340,17 @@ pub async fn insert_excluded_batch_txids(
     Ok(())
 }
 
+/// Executed, still-unfinalized batches anchored at or above `from_anchor`, with the
+/// txids this node ACTUALLY executed for each — for rebuilding finality tracking
+/// after a restart.
+///
+/// Sourced from `transactions`, deliberately NOT from `batch_txids`. The certified
+/// list is append-only (`INSERT OR IGNORE` on `(batch_height, position)`, no cascade),
+/// so once a replay has dropped excluded transactions from a batch the stored list
+/// still holds them, permanently. Rehydrating from it would re-arm a deadline on
+/// txids this node deliberately dropped and trigger a rollback no peer performs.
+/// The join also subsumes an "did we execute this batch" existence check: record-only
+/// batches write no `transactions` rows and rolled-back ones have theirs cascade-deleted.
 pub async fn select_unfinalized_batches(
     conn: &Connection,
     from_anchor: u64,

--- a/core/indexer/src/database/queries/batches.rs
+++ b/core/indexer/src/database/queries/batches.rs
@@ -292,33 +292,60 @@ pub async fn select_unconfirmed_batch_tx(
 /// The join also subsumes an "did we execute this batch" existence check: record-only
 /// batches write no `transactions` rows and rolled-back ones have theirs cascade-deleted.
 ///
-/// Every txid a finality exclusion has ever dropped on this node.
+/// Recorded exclusions that STILL HOLD, keyed by the consensus height they apply to.
 ///
-/// Read at the start of a rollback and unioned into the pass's own exclusions, which
-/// makes the set MONOTONE across passes. Without that, a replay reloads each batch
-/// from the append-only `batch_txids` and can put back a transaction an earlier pass
-/// already proved never confirms; two passes then alternate between complementary
-/// halves and the tip oscillates forever.
-pub async fn select_excluded_batch_txids(
+/// The stored row is a node-local fact: "we found T missing at H's deadline". The
+/// `NOT EXISTS` is the shared, node-independent half — the same predicate
+/// `missing_txids` renders (I2) — and it is baked into the READ so that no caller can
+/// apply a row without re-verifying it. There is deliberately no DELETE: a replay can
+/// never manufacture a Bitcoin confirmation, so suppression can only ever come from
+/// the chain, and keeping the row lets a later reorg re-suppress or re-apply it.
+///
+/// The `batch_height` qualifier on the confirmation is load-bearing. Without it: T is
+/// excluded at H, re-batched and executed at H3, and confirms at or below H's
+/// deadline; a deep rollback replays both; the row is suppressed; H and H3 BOTH
+/// execute T, and `insert_transaction` is a plain INSERT against
+/// `transactions.txid UNIQUE` — the #515 collision from a new direction. A
+/// confirmation attributable to another batch's execution must not un-exclude here. A
+/// confirmation via the BLOCK path (`batch_height IS NULL`) must, and does: that is
+/// the reorg-healing case, and a peer syncing from genesis reaches the same answer.
+pub async fn select_applicable_exclusions(
     conn: &Connection,
-) -> Result<std::collections::HashSet<String>, Error> {
+) -> Result<std::collections::HashMap<u64, std::collections::HashSet<String>>, Error> {
     let mut rows = conn
-        .query("SELECT txid FROM excluded_batch_txids", ())
+        .query(
+            "SELECT e.batch_height, e.txid \
+             FROM excluded_batch_txids e \
+             WHERE NOT EXISTS ( \
+               SELECT 1 FROM transactions t \
+                WHERE t.txid = e.txid \
+                  AND t.confirmed_height IS NOT NULL \
+                  AND t.confirmed_height <= e.deadline \
+                  AND (t.batch_height IS NULL OR t.batch_height = e.batch_height))",
+            (),
+        )
         .await?;
-    let mut out = std::collections::HashSet::new();
+    let mut out: std::collections::HashMap<u64, std::collections::HashSet<String>> =
+        std::collections::HashMap::new();
     while let Some(row) = rows.next().await? {
-        out.insert(row.get::<String>(0)?);
+        out.entry(row.get::<u64>(0)?)
+            .or_default()
+            .insert(row.get::<String>(1)?);
     }
     Ok(out)
 }
 
-/// Record txids dropped by a finality exclusion. Idempotent — the same tx can be
-/// excluded again by a later pass over the same batch.
-pub async fn insert_excluded_batch_txids(conn: &Connection, txids: &[String]) -> Result<(), Error> {
-    for txid in txids {
+/// Record what a finality pass dropped, as `(consensus_height, txid, deadline)`.
+/// Idempotent — the same batch can be narrowed by more than one pass.
+pub async fn insert_excluded_batch_txids(
+    conn: &Connection,
+    rows: &[(u64, String, u64)],
+) -> Result<(), Error> {
+    for (batch_height, txid, deadline) in rows {
         conn.execute(
-            "INSERT OR IGNORE INTO excluded_batch_txids (txid) VALUES (?)",
-            params![txid.clone()],
+            "INSERT OR IGNORE INTO excluded_batch_txids (batch_height, txid, deadline) \
+             VALUES (?, ?, ?)",
+            params![*batch_height, txid.clone(), *deadline],
         )
         .await?;
     }

--- a/core/indexer/src/database/queries/batches.rs
+++ b/core/indexer/src/database/queries/batches.rs
@@ -292,6 +292,38 @@ pub async fn select_unconfirmed_batch_tx(
 /// The join also subsumes an "did we execute this batch" existence check: record-only
 /// batches write no `transactions` rows and rolled-back ones have theirs cascade-deleted.
 ///
+/// Txids a batch CERTIFIED but this node never EXECUTED, for every batch at or above
+/// `from_anchor`.
+///
+/// The difference is exactly what an earlier finality pass excluded. It has to be
+/// re-derived rather than remembered: `batch_txids` is append-only and a replay
+/// reloads the FULL certified list from it, so without carrying the difference
+/// forward each pass starts from a clean slate and can put back a transaction an
+/// earlier pass already proved never confirms. Two passes then alternate between the
+/// complementary halves and the tip oscillates forever.
+///
+/// Must be read BEFORE the rollback truncation — the `transactions` rows this
+/// depends on are cascade-deleted with their blocks.
+pub async fn select_previously_excluded_txids(
+    conn: &Connection,
+    from_anchor: u64,
+) -> Result<std::collections::HashSet<String>, Error> {
+    let sql = format!(
+        "SELECT bt.txid \
+         FROM batches b INDEXED BY idx_batches_anchor_height \
+         JOIN batch_txids bt ON bt.batch_height = b.consensus_height \
+         LEFT JOIN executed_batch_txids e \
+           ON e.batch_height = b.consensus_height AND e.txid = bt.txid \
+         WHERE b.anchor_height >= {from_anchor} AND b.is_block = 0 AND e.txid IS NULL"
+    );
+    let mut rows = conn.query(&sql, ()).await?;
+    let mut out = std::collections::HashSet::new();
+    while let Some(row) = rows.next().await? {
+        out.insert(row.get::<String>(0)?);
+    }
+    Ok(out)
+}
+
 /// The `blocks` join is load-bearing, not a filter refinement: it pins each batch to
 /// the anchor block CURRENTLY at that height, so a Bitcoin reorg cannot resurrect
 /// tracking for batches anchored to a block that no longer exists.

--- a/core/indexer/src/database/queries/blocks.rs
+++ b/core/indexer/src/database/queries/blocks.rs
@@ -24,9 +24,11 @@ pub async fn rollback_to_height(conn: &Connection, height: u64) -> Result<u64, E
     // `insert_transaction` sets `height == confirmed_height`, so if one survives the
     // cascade its confirmation is at or below the target too.
     //
-    // Restricted to batch rows so the existing partial index on `batch_height` bounds
-    // the scan; there is deliberately no index on `confirmed_height`, which would
-    // churn on every confirmation to serve only this path.
+    // Restricted to batch rows because they are the only ones affected. Note this
+    // does NOT bound the work by rollback depth: with no index on `confirmed_height`
+    // it walks every batch-executed transaction in history. Acceptable because
+    // rollbacks are rare and correctness here gates the finality verdict; an index
+    // on `confirmed_height` would churn on every confirmation to serve only this.
     conn.execute(
         "UPDATE transactions SET confirmed_height = NULL, tx_index = NULL \
          WHERE batch_height IS NOT NULL AND confirmed_height > ?",

--- a/core/indexer/src/database/queries/blocks.rs
+++ b/core/indexer/src/database/queries/blocks.rs
@@ -16,6 +16,24 @@ pub async fn insert_block(conn: &Connection, block: BlockRow) -> Result<i64, Err
 }
 
 pub async fn rollback_to_height(conn: &Connection, height: u64) -> Result<u64, Error> {
+    // Clear confirmations by blocks that are about to disappear. The cascade below
+    // keys on `height`, not `confirmed_height`, so a BATCH-executed row (whose
+    // `height` is its anchor, potentially at or below the target) survives while
+    // still pointing at a deleted block — and `confirmed_height` is exactly the
+    // predicate the finality verdict reads. Block-path rows cannot be affected:
+    // `insert_transaction` sets `height == confirmed_height`, so if one survives the
+    // cascade its confirmation is at or below the target too.
+    //
+    // Restricted to batch rows so the existing partial index on `batch_height` bounds
+    // the scan; there is deliberately no index on `confirmed_height`, which would
+    // churn on every confirmation to serve only this path.
+    conn.execute(
+        "UPDATE transactions SET confirmed_height = NULL, tx_index = NULL \
+         WHERE batch_height IS NOT NULL AND confirmed_height > ?",
+        [height],
+    )
+    .await?;
+
     let num_rows = conn
         .execute("DELETE FROM blocks WHERE height > ?", [height])
         .await?;

--- a/core/indexer/src/database/queries/blocks.rs
+++ b/core/indexer/src/database/queries/blocks.rs
@@ -24,13 +24,15 @@ pub async fn rollback_to_height(conn: &Connection, height: u64) -> Result<u64, E
     // `insert_transaction` sets `height == confirmed_height`, so if one survives the
     // cascade its confirmation is at or below the target too.
     //
-    // Restricted to batch rows because they are the only ones affected. Note this
-    // does NOT bound the work by rollback depth: with no index on `confirmed_height`
-    // it walks every batch-executed transaction in history. Acceptable because
-    // rollbacks are rare and correctness here gates the finality verdict; an index
-    // on `confirmed_height` would churn on every confirmation to serve only this.
+    // Restricted to batch rows because they are the only ones affected. The named
+    // partial index bounds the work by rollback depth (a range seek over
+    // confirmations above the target) instead of a walk of every batch-executed
+    // transaction in history; the same index serves the late-confirmation arm of
+    // `min_unsettled_batch_tx_height`, which is what tipped the churn-vs-scan
+    // trade in its favour.
     conn.execute(
-        "UPDATE transactions SET confirmed_height = NULL, tx_index = NULL \
+        "UPDATE transactions INDEXED BY idx_transactions_batch_confirmed \
+         SET confirmed_height = NULL, tx_index = NULL \
          WHERE batch_height IS NOT NULL AND confirmed_height > ?",
         [height],
     )

--- a/core/indexer/src/database/queries/tests.rs
+++ b/core/indexer/src/database/queries/tests.rs
@@ -4620,3 +4620,55 @@ async fn indexing_a_transaction_on_chain_drops_its_unconfirmed_raw_copy() -> Res
     );
     Ok(())
 }
+
+/// The difference between what a batch CERTIFIED and what this node EXECUTED is
+/// exactly what an earlier finality pass excluded, and it has to be re-derivable:
+/// `batch_txids` is append-only, so a replay reloads the full certified list and
+/// would otherwise put an excluded transaction back. Two passes then alternate
+/// between complementary halves and the tip oscillates forever — deterministically
+/// on every node, so a liveness halt rather than a divergence.
+#[tokio::test]
+async fn previously_excluded_txids_are_the_certified_minus_executed_difference() -> Result<()> {
+    let (_reader, writer, _temp_dir) = new_test_db().await?;
+    let conn = writer.connection();
+
+    let height: u64 = 100;
+    let hash = new_mock_block_hash(height as u32);
+    insert_block(&conn, BlockRow::builder().height(height).hash(hash).build()).await?;
+    insert_batch(&conn, 9, height, &hash.to_string(), b"cert9", false).await?;
+
+    let kept = "aa".repeat(32);
+    let excluded = "bb".repeat(32);
+    // Certified BOTH — that is what consensus decided.
+    insert_batch_txids(&conn, 9, &[kept.clone(), excluded.clone()]).await?;
+    // Executed only one: the other was dropped by a finality exclusion.
+    insert_transaction(
+        &conn,
+        TransactionRow::builder()
+            .height(height)
+            .batch_height(9)
+            .txid(kept.clone())
+            .build(),
+    )
+    .await?;
+
+    let previous = select_previously_excluded_txids(&conn, 0).await?;
+    assert!(
+        previous.contains(&excluded),
+        "a certified-but-unexecuted txid is a previous exclusion and must carry forward"
+    );
+    assert!(
+        !previous.contains(&kept),
+        "an executed txid was never excluded and must NOT be carried forward — \
+         doing so would drop a transaction that is executing fine"
+    );
+
+    // A batch below the replay band is not this rollback's business.
+    assert!(
+        select_previously_excluded_txids(&conn, height + 1)
+            .await?
+            .is_empty(),
+        "the band must be respected"
+    );
+    Ok(())
+}

--- a/core/indexer/src/database/queries/tests.rs
+++ b/core/indexer/src/database/queries/tests.rs
@@ -4624,14 +4624,18 @@ async fn indexing_a_transaction_on_chain_drops_its_unconfirmed_raw_copy() -> Res
 /// Exclusions must be RECORDED, never inferred from "certified but not executed".
 ///
 /// That predicate is equally true of a record-only batch — anchor-mismatched, so this
-/// node skipped it while its peers ran it — and of a batch narrowed to nothing by an
-/// exclusion. The two are indistinguishable in the database: both have `batch_txids`
-/// and no `transactions` rows. Inferring would strip a record-only batch's
-/// transactions from the replay, so this node would never execute what the rest of
-/// the network did. That is a state divergence, strictly worse than the replay
-/// non-convergence the carry-forward exists to prevent.
+/// node skipped it while its peers ran it — and of a batch narrowed by an exclusion.
+/// The two are indistinguishable in the database. Inferring strips a record-only
+/// batch's transactions from the replay, so this node never executes what the network
+/// did: a state divergence, strictly worse than the replay non-convergence the
+/// carry-forward exists to prevent.
+///
+/// Also pins the SCOPE. A row is keyed by the consensus height it applies to, so the
+/// same txid excluded at one height and re-decided at another is remembered
+/// separately — a txid-only key is a global ban, which is the same divergence by a
+/// different route.
 #[tokio::test]
-async fn only_recorded_exclusions_carry_forward() -> Result<()> {
+async fn exclusions_are_recorded_per_decision_and_never_inferred() -> Result<()> {
     let (_reader, writer, _temp_dir) = new_test_db().await?;
     let conn = writer.connection();
 
@@ -4643,28 +4647,89 @@ async fn only_recorded_exclusions_carry_forward() -> Result<()> {
     let record_only = "aa".repeat(32);
     insert_batch(&conn, 9, height, &hash.to_string(), b"cert9", false).await?;
     insert_batch_txids(&conn, 9, std::slice::from_ref(&record_only)).await?;
-
     assert!(
-        select_excluded_batch_txids(&conn).await?.is_empty(),
+        select_applicable_exclusions(&conn).await?.is_empty(),
         "a record-only batch excluded nothing — inferring otherwise would strip \
          transactions this node's peers executed"
     );
 
-    // An actual exclusion, recorded by the path that made it.
-    let excluded = "bb".repeat(32);
-    insert_excluded_batch_txids(&conn, std::slice::from_ref(&excluded)).await?;
-    let carried = select_excluded_batch_txids(&conn).await?;
+    // The same txid excluded at TWO different decisions, and one that is not.
+    let t = "bb".repeat(32);
+    insert_excluded_batch_txids(&conn, &[(10, t.clone(), 106), (12, t.clone(), 120)]).await?;
+    let applicable = select_applicable_exclusions(&conn).await?;
+    assert!(applicable[&10].contains(&t) && applicable[&12].contains(&t));
     assert!(
-        carried.contains(&excluded),
-        "a recorded exclusion must carry forward"
-    );
-    assert!(
-        !carried.contains(&record_only),
-        "and it must not drag the record-only batch along with it"
+        !applicable.contains_key(&9),
+        "the record-only height must have no exclusions"
     );
 
-    // Idempotent: the same batch can be narrowed by more than one pass.
-    insert_excluded_batch_txids(&conn, std::slice::from_ref(&excluded)).await?;
-    assert_eq!(select_excluded_batch_txids(&conn).await?.len(), 1);
+    // Idempotent — the same batch can be narrowed by more than one pass.
+    insert_excluded_batch_txids(&conn, &[(10, t.clone(), 106)]).await?;
+    assert_eq!(select_applicable_exclusions(&conn).await?[&10].len(), 1);
+    Ok(())
+}
+
+/// The read re-verifies every recorded row against the chain, so a stale exclusion
+/// cannot outlive the fact that produced it. The `batch_height` qualifier is the
+/// load-bearing part: a confirmation attributable to ANOTHER batch's execution must
+/// not un-exclude here, or both heights execute the tx and the plain INSERT in
+/// `insert_transaction` hits `transactions.txid UNIQUE` — #515's collision by a new
+/// route. A confirmation via the BLOCK path (`batch_height IS NULL`) must un-exclude:
+/// that is the reorg-healing case, and a peer syncing from genesis agrees.
+#[tokio::test]
+async fn a_recorded_exclusion_is_reverified_against_the_chain() -> Result<()> {
+    let (_reader, writer, _temp_dir) = new_test_db().await?;
+    let conn = writer.connection();
+    let hash = new_mock_block_hash(100);
+    insert_block(&conn, BlockRow::builder().height(100).hash(hash).build()).await?;
+    insert_batch(&conn, 10, 100, &hash.to_string(), b"c", false).await?;
+    // A second decided batch, so the "confirmed via another batch's execution" case
+    // below can set a real `batch_height` (transactions.batch_height is FK'd).
+    insert_batch(&conn, 12, 100, &hash.to_string(), b"c2", false).await?;
+
+    let t = "cc".repeat(32);
+    let applies = |conn: libsql::Connection| async move {
+        select_applicable_exclusions(&conn)
+            .await
+            .unwrap()
+            .get(&10)
+            .is_some_and(|s| s.contains(&"cc".repeat(32)))
+    };
+
+    insert_excluded_batch_txids(&conn, &[(10, t.clone(), 106)]).await?;
+    assert!(applies(conn.clone()).await, "no transactions row at all");
+
+    // Confirmed ABOVE the deadline: still missing as far as that verdict goes.
+    insert_transaction(
+        &conn,
+        TransactionRow::builder()
+            .height(100)
+            .tx_index(0)
+            .confirmed_height(107u64)
+            .txid(t.clone())
+            .build(),
+    )
+    .await?;
+    assert!(applies(conn.clone()).await, "confirmed past the deadline");
+
+    // Confirmed at or below it, via the BLOCK path — the exclusion no longer holds.
+    conn.execute(
+        "UPDATE transactions SET confirmed_height = 105 WHERE txid = ?",
+        libsql::params![t.clone()],
+    )
+    .await?;
+    assert!(!applies(conn.clone()).await, "confirmed by the deadline");
+
+    // Same confirmation, but attributable to a DIFFERENT batch's execution: the
+    // exclusion must stand, or this txid executes at both heights.
+    conn.execute(
+        "UPDATE transactions SET batch_height = 12 WHERE txid = ?",
+        libsql::params![t.clone()],
+    )
+    .await?;
+    assert!(
+        applies(conn.clone()).await,
+        "another batch's execution must not un-exclude this one"
+    );
     Ok(())
 }

--- a/core/indexer/src/database/queries/tests.rs
+++ b/core/indexer/src/database/queries/tests.rs
@@ -4621,54 +4621,50 @@ async fn indexing_a_transaction_on_chain_drops_its_unconfirmed_raw_copy() -> Res
     Ok(())
 }
 
-/// The difference between what a batch CERTIFIED and what this node EXECUTED is
-/// exactly what an earlier finality pass excluded, and it has to be re-derivable:
-/// `batch_txids` is append-only, so a replay reloads the full certified list and
-/// would otherwise put an excluded transaction back. Two passes then alternate
-/// between complementary halves and the tip oscillates forever — deterministically
-/// on every node, so a liveness halt rather than a divergence.
+/// Exclusions must be RECORDED, never inferred from "certified but not executed".
+///
+/// That predicate is equally true of a record-only batch — anchor-mismatched, so this
+/// node skipped it while its peers ran it — and of a batch narrowed to nothing by an
+/// exclusion. The two are indistinguishable in the database: both have `batch_txids`
+/// and no `transactions` rows. Inferring would strip a record-only batch's
+/// transactions from the replay, so this node would never execute what the rest of
+/// the network did. That is a state divergence, strictly worse than the replay
+/// non-convergence the carry-forward exists to prevent.
 #[tokio::test]
-async fn previously_excluded_txids_are_the_certified_minus_executed_difference() -> Result<()> {
+async fn only_recorded_exclusions_carry_forward() -> Result<()> {
     let (_reader, writer, _temp_dir) = new_test_db().await?;
     let conn = writer.connection();
 
     let height: u64 = 100;
     let hash = new_mock_block_hash(height as u32);
     insert_block(&conn, BlockRow::builder().height(height).hash(hash).build()).await?;
+
+    // A record-only batch: certified, never executed here, NOTHING excluded.
+    let record_only = "aa".repeat(32);
     insert_batch(&conn, 9, height, &hash.to_string(), b"cert9", false).await?;
+    insert_batch_txids(&conn, 9, std::slice::from_ref(&record_only)).await?;
 
-    let kept = "aa".repeat(32);
+    assert!(
+        select_excluded_batch_txids(&conn).await?.is_empty(),
+        "a record-only batch excluded nothing — inferring otherwise would strip \
+         transactions this node's peers executed"
+    );
+
+    // An actual exclusion, recorded by the path that made it.
     let excluded = "bb".repeat(32);
-    // Certified BOTH — that is what consensus decided.
-    insert_batch_txids(&conn, 9, &[kept.clone(), excluded.clone()]).await?;
-    // Executed only one: the other was dropped by a finality exclusion.
-    insert_transaction(
-        &conn,
-        TransactionRow::builder()
-            .height(height)
-            .batch_height(9)
-            .txid(kept.clone())
-            .build(),
-    )
-    .await?;
-
-    let previous = select_previously_excluded_txids(&conn, 0).await?;
+    insert_excluded_batch_txids(&conn, std::slice::from_ref(&excluded)).await?;
+    let carried = select_excluded_batch_txids(&conn).await?;
     assert!(
-        previous.contains(&excluded),
-        "a certified-but-unexecuted txid is a previous exclusion and must carry forward"
+        carried.contains(&excluded),
+        "a recorded exclusion must carry forward"
     );
     assert!(
-        !previous.contains(&kept),
-        "an executed txid was never excluded and must NOT be carried forward — \
-         doing so would drop a transaction that is executing fine"
+        !carried.contains(&record_only),
+        "and it must not drag the record-only batch along with it"
     );
 
-    // A batch below the replay band is not this rollback's business.
-    assert!(
-        select_previously_excluded_txids(&conn, height + 1)
-            .await?
-            .is_empty(),
-        "the band must be respected"
-    );
+    // Idempotent: the same batch can be narrowed by more than one pass.
+    insert_excluded_batch_txids(&conn, std::slice::from_ref(&excluded)).await?;
+    assert_eq!(select_excluded_batch_txids(&conn).await?.len(), 1);
     Ok(())
 }

--- a/core/indexer/src/database/queries/tests.rs
+++ b/core/indexer/src/database/queries/tests.rs
@@ -4569,3 +4569,54 @@ async fn test_unfinalized_batches_reachable_far_below_the_window() -> Result<()>
     );
     Ok(())
 }
+
+/// A record-only batch stores raw transactions but writes NO `transactions` row —
+/// it was never executed here. When those transactions later confirm on Bitcoin,
+/// `execute_block` finds no existing row and so takes its `insert_transaction`
+/// branch, never `confirm_transaction`. Only the latter dropped the raw copy, so
+/// the row survived its own transaction being indexed on-chain, forever.
+///
+/// That matters beyond disk: `load_raw_txs_if_unfinalized` no longer refuses
+/// anchors older than the finality window, so every surviving row is attached to
+/// the consensus height it belongs to on every sync — this node ships raw batch
+/// bodies to peers instead of txid lists, indefinitely. A node that lags (exactly
+/// what this PR hardens against) record-onlys every batch in that stretch.
+#[tokio::test]
+async fn indexing_a_transaction_on_chain_drops_its_unconfirmed_raw_copy() -> Result<()> {
+    let (_reader, writer, _temp_dir) = new_test_db().await?;
+    let conn = writer.connection();
+
+    let height: u64 = 100;
+    let hash = new_mock_block_hash(height as u32);
+    insert_block(&conn, BlockRow::builder().height(height).hash(hash).build()).await?;
+
+    // A record-only batch: the raw tx is kept for sync, with no `transactions` row.
+    let txid = "cc".repeat(32);
+    insert_batch(&conn, 7, height, &hash.to_string(), b"cert7", false).await?;
+    insert_unconfirmed_batch_tx(&conn, &txid, 7, b"raw-bytes").await?;
+    assert_eq!(
+        select_unconfirmed_batch_txs(&conn, 7).await?.len(),
+        1,
+        "setup: the record-only batch must have stored its raw tx"
+    );
+
+    // The transaction now confirms on Bitcoin and is indexed as a block tx —
+    // `execute_block`'s branch for a txid it has never seen before.
+    insert_transaction(
+        &conn,
+        TransactionRow::builder()
+            .height(height)
+            .tx_index(0)
+            .confirmed_height(height)
+            .txid(txid.clone())
+            .build(),
+    )
+    .await?;
+
+    assert!(
+        select_unconfirmed_batch_txs(&conn, 7).await?.is_empty(),
+        "the raw copy is redundant once the transaction is indexed on-chain — \
+         keeping it leaks a full transaction body per record-only batch forever"
+    );
+    Ok(())
+}

--- a/core/indexer/src/database/queries/tests.rs
+++ b/core/indexer/src/database/queries/tests.rs
@@ -4367,7 +4367,9 @@ async fn test_rollback_clears_confirmations_by_deleted_blocks() -> Result<()> {
 /// anchored to the chain it currently holds.
 #[tokio::test]
 async fn test_select_unfinalized_batches_sources_execution_not_certificate() -> Result<()> {
-    use crate::database::queries::{insert_batch_txids, select_unfinalized_batches};
+    use crate::database::queries::{
+        insert_batch_txids, min_unconfirmed_batch_tx_height, select_unfinalized_batches,
+    };
 
     let (_reader, writer, _temp_dir) = new_test_db().await?;
     let conn = writer.connection();
@@ -4444,5 +4446,70 @@ async fn test_select_unfinalized_batches_sources_execution_not_certificate() -> 
 
     // Below the band.
     assert!(select_unfinalized_batches(&conn, 11).await?.is_empty());
+
+    // The floor is what the caller extends when a deadline may still be unsettled —
+    // `min_unconfirmed_batch_tx_height` is how it finds how far down to reach.
+    assert_eq!(
+        min_unconfirmed_batch_tx_height(&conn).await?,
+        Some(10),
+        "the probe must reach the oldest unconfirmed batch tx, however old"
+    );
+    Ok(())
+}
+
+/// A batch whose deadline has already passed can still be owed a verdict: `advance`
+/// executes several blocks inside one drain before settling, so a crash in that
+/// window leaves the tip past a deadline no verdict was rendered on. The startup
+/// floor is extended down to the oldest unconfirmed batch transaction for exactly
+/// this case, so the batch must still be reachable from well below the window.
+#[tokio::test]
+async fn test_unfinalized_batches_reachable_far_below_the_window() -> Result<()> {
+    use crate::database::queries::{
+        insert_batch_txids, min_unconfirmed_batch_tx_height, select_unfinalized_batches,
+    };
+
+    let (_reader, writer, _temp_dir) = new_test_db().await?;
+    let conn = writer.connection();
+    for height in [10u64, 40] {
+        insert_block(
+            &conn,
+            BlockRow::builder()
+                .height(height)
+                .hash(new_mock_block_hash(height as u32))
+                .build(),
+        )
+        .await?;
+    }
+    let hash10 = new_mock_block_hash(10).to_string();
+    insert_batch(&conn, 1, 10, &hash10, b"c1", false).await?;
+    let stale = "ee".repeat(32);
+    insert_batch_txids(&conn, 1, std::slice::from_ref(&stale)).await?;
+    insert_transaction(
+        &conn,
+        TransactionRow::builder()
+            .height(10)
+            .batch_height(1)
+            .txid(stale.clone())
+            .build(),
+    )
+    .await?;
+
+    // Tip 40: the fixed window floor (40 - 6 = 34) misses it entirely.
+    assert!(
+        select_unfinalized_batches(&conn, 34).await?.is_empty(),
+        "the window floor alone loses a batch whose deadline already passed"
+    );
+
+    // The probe finds how far down to reach, and the batch comes back.
+    let floor = min_unconfirmed_batch_tx_height(&conn)
+        .await?
+        .expect("an unconfirmed batch tx exists");
+    assert_eq!(floor, 10);
+    let rows = select_unfinalized_batches(&conn, floor).await?;
+    assert_eq!(
+        rows.iter().map(|r| r.consensus_height).collect::<Vec<_>>(),
+        vec![1],
+        "extending the floor must recover the unsettled batch"
+    );
     Ok(())
 }

--- a/core/indexer/src/database/queries/tests.rs
+++ b/core/indexer/src/database/queries/tests.rs
@@ -4241,3 +4241,208 @@ async fn test_ensure_identity_idempotent() -> Result<()> {
 
     Ok(())
 }
+
+/// The `IN (?…)` list must be chunked: SQLite's SQLITE_MAX_VARIABLE_NUMBER is 32766
+/// and exceeding it fails at PREPARE, not at runtime. `make_value` passes the whole
+/// mempool pool, which nothing bounds, so an unchunked probe is a reachable crash.
+#[tokio::test]
+async fn test_select_transactions_by_txids_chunks_large_input() -> Result<()> {
+    use crate::database::queries::{select_existing_txids, select_transactions_by_txids};
+
+    let (_reader, writer, _temp_dir) = new_test_db().await?;
+    let conn = writer.connection();
+    insert_block(
+        &conn,
+        BlockRow::builder()
+            .height(10)
+            .hash(new_mock_block_hash(10))
+            .build(),
+    )
+    .await?;
+
+    // Three real rows, probed alongside 40k absent ones.
+    let present: Vec<String> = (0u32..3).map(|i| format!("{i:064x}")).collect();
+    for txid in &present {
+        insert_transaction(
+            &conn,
+            TransactionRow::builder()
+                .height(10)
+                .txid(txid.clone())
+                .build(),
+        )
+        .await?;
+    }
+    let mut probe = present.clone();
+    probe.extend((1000u32..41000).map(|i| format!("{i:064x}")));
+
+    let rows = select_transactions_by_txids(&conn, &probe).await?;
+    assert_eq!(rows.len(), 3);
+    for txid in &present {
+        assert_eq!(rows.get(txid).map(|r| r.height), Some(10));
+    }
+
+    // The set-returning wrapper stays consistent with the row-returning primitive.
+    let existing = select_existing_txids(&conn, &probe).await?;
+    assert_eq!(existing.len(), 3);
+
+    assert!(select_transactions_by_txids(&conn, &[]).await?.is_empty());
+    Ok(())
+}
+
+/// A rollback must clear confirmations by blocks it deletes. The cascade keys on
+/// `height`, so a batch row anchored at or below the target survives while still
+/// pointing at a deleted block — and `confirmed_height` is what the finality
+/// verdict reads.
+#[tokio::test]
+async fn test_rollback_clears_confirmations_by_deleted_blocks() -> Result<()> {
+    use crate::database::queries::{confirm_transaction, rollback_to_height};
+
+    let (_reader, writer, _temp_dir) = new_test_db().await?;
+    let conn = writer.connection();
+    for height in [10u64, 11, 12] {
+        insert_block(
+            &conn,
+            BlockRow::builder()
+                .height(height)
+                .hash(new_mock_block_hash(height as u32))
+                .build(),
+        )
+        .await?;
+    }
+    insert_batch(
+        &conn,
+        1,
+        10,
+        &new_mock_block_hash(10).to_string(),
+        b"c",
+        false,
+    )
+    .await?;
+
+    // Batch-executed row: height = anchor 10, later confirmed in block 12.
+    let batched = "aa".repeat(32);
+    insert_transaction(
+        &conn,
+        TransactionRow::builder()
+            .height(10)
+            .batch_height(1)
+            .txid(batched.clone())
+            .build(),
+    )
+    .await?;
+    confirm_transaction(&conn, &batched, 12, 0).await?;
+
+    // Block-path row at height 10 — survives, and its confirmation is at 10.
+    let onchain = "bb".repeat(32);
+    insert_transaction(
+        &conn,
+        TransactionRow::builder()
+            .height(10)
+            .confirmed_height(10)
+            .tx_index(0)
+            .txid(onchain.clone())
+            .build(),
+    )
+    .await?;
+
+    rollback_to_height(&conn, 11).await?;
+
+    let batched_row = get_transaction_by_txid(&conn, &batched).await?.unwrap();
+    assert_eq!(
+        batched_row.confirmed_height, None,
+        "confirmation by deleted block 12 must be cleared"
+    );
+    assert_eq!(batched_row.tx_index, None);
+
+    let onchain_row = get_transaction_by_txid(&conn, &onchain).await?.unwrap();
+    assert_eq!(
+        onchain_row.confirmed_height,
+        Some(10),
+        "a confirmation by a surviving block must be left alone"
+    );
+    Ok(())
+}
+
+/// Rehydration must reflect what this node EXECUTED, and only for batches still
+/// anchored to the chain it currently holds.
+#[tokio::test]
+async fn test_select_unfinalized_batches_sources_execution_not_certificate() -> Result<()> {
+    use crate::database::queries::{insert_batch_txids, select_unfinalized_batches};
+
+    let (_reader, writer, _temp_dir) = new_test_db().await?;
+    let conn = writer.connection();
+    for height in [10u64, 11, 12] {
+        insert_block(
+            &conn,
+            BlockRow::builder()
+                .height(height)
+                .hash(new_mock_block_hash(height as u32))
+                .build(),
+        )
+        .await?;
+    }
+    let hash10 = new_mock_block_hash(10).to_string();
+    let hash11 = new_mock_block_hash(11).to_string();
+
+    // Batch 1: certified with two txids, but a filtered replay executed only one.
+    // `batch_txids` is append-only so it still holds both — rehydrating from it
+    // would re-arm a deadline on a txid this node deliberately dropped.
+    insert_batch(&conn, 1, 10, &hash10, b"c1", false).await?;
+    let kept = "aa".repeat(32);
+    let excluded = "bb".repeat(32);
+    insert_batch_txids(&conn, 1, &[kept.clone(), excluded.clone()]).await?;
+    insert_transaction(
+        &conn,
+        TransactionRow::builder()
+            .height(10)
+            .batch_height(1)
+            .txid(kept.clone())
+            .build(),
+    )
+    .await?;
+
+    // Batch 2: record-only (certified, never executed here) — no transactions rows.
+    insert_batch(&conn, 2, 11, &hash11, b"c2", false).await?;
+    insert_batch_txids(&conn, 2, &["cc".repeat(32)]).await?;
+
+    // Batch 3: a block decision, not a batch.
+    insert_batch(&conn, 3, 11, &hash11, b"c3", true).await?;
+
+    // Batch 4: anchored to a hash that is NOT the block now at height 12 — the
+    // shape a Bitcoin reorg leaves behind.
+    insert_batch(
+        &conn,
+        4,
+        12,
+        &new_mock_block_hash(99).to_string(),
+        b"c4",
+        false,
+    )
+    .await?;
+    let reorged = "dd".repeat(32);
+    insert_transaction(
+        &conn,
+        TransactionRow::builder()
+            .height(12)
+            .batch_height(4)
+            .txid(reorged)
+            .build(),
+    )
+    .await?;
+
+    let rows = select_unfinalized_batches(&conn, 10).await?;
+    assert_eq!(
+        rows.iter().map(|r| r.consensus_height).collect::<Vec<_>>(),
+        vec![1],
+        "only the executed, still-anchored batch is tracked"
+    );
+    assert_eq!(
+        rows[0].txids,
+        vec![kept],
+        "txids come from the execution rows, not the immortal certified list"
+    );
+
+    // Below the band.
+    assert!(select_unfinalized_batches(&conn, 11).await?.is_empty());
+    Ok(())
+}

--- a/core/indexer/src/database/queries/tests.rs
+++ b/core/indexer/src/database/queries/tests.rs
@@ -4368,7 +4368,7 @@ async fn test_rollback_clears_confirmations_by_deleted_blocks() -> Result<()> {
 #[tokio::test]
 async fn test_select_unfinalized_batches_sources_execution_not_certificate() -> Result<()> {
     use crate::database::queries::{
-        insert_batch_txids, min_unconfirmed_batch_tx_height, select_unfinalized_batches,
+        insert_batch_txids, min_unsettled_batch_tx_height, select_unfinalized_batches,
     };
 
     let (_reader, writer, _temp_dir) = new_test_db().await?;
@@ -4448,12 +4448,68 @@ async fn test_select_unfinalized_batches_sources_execution_not_certificate() -> 
     assert!(select_unfinalized_batches(&conn, 11).await?.is_empty());
 
     // The floor is what the caller extends when a deadline may still be unsettled —
-    // `min_unconfirmed_batch_tx_height` is how it finds how far down to reach.
+    // `min_unsettled_batch_tx_height` is how it finds how far down to reach.
     assert_eq!(
-        min_unconfirmed_batch_tx_height(&conn).await?,
+        min_unsettled_batch_tx_height(&conn, 6).await?,
         Some(10),
         "the probe must reach the oldest unconfirmed batch tx, however old"
     );
+    Ok(())
+}
+
+/// The floor probe must use the SAME notion of "settled" the finality verdict does:
+/// confirmed BY THE DEADLINE, not merely confirmed. A transaction that lands one
+/// block late is still missing as far as finality is concerned, so a batch carrying
+/// one is still owed a rollback — and if the probe treats it as settled, that batch
+/// falls below the window on restart and is never tracked again.
+#[tokio::test]
+async fn test_min_unsettled_counts_a_late_confirmation_as_unsettled() -> Result<()> {
+    use crate::database::queries::{confirm_transaction, min_unsettled_batch_tx_height};
+
+    let (_reader, writer, _temp_dir) = new_test_db().await?;
+    let conn = writer.connection();
+    for height in [10u64, 16, 17] {
+        insert_block(
+            &conn,
+            BlockRow::builder()
+                .height(height)
+                .hash(new_mock_block_hash(height as u32))
+                .build(),
+        )
+        .await?;
+    }
+    insert_batch(
+        &conn,
+        1,
+        10,
+        &new_mock_block_hash(10).to_string(),
+        b"c",
+        false,
+    )
+    .await?;
+
+    // Anchored at 10, so the deadline is 16. This one confirms at 17 — one late.
+    let late = "ff".repeat(32);
+    insert_transaction(
+        &conn,
+        TransactionRow::builder()
+            .height(10)
+            .batch_height(1)
+            .txid(late.clone())
+            .build(),
+    )
+    .await?;
+    confirm_transaction(&conn, &late, 17, 0).await?;
+
+    assert_eq!(
+        min_unsettled_batch_tx_height(&conn, 6).await?,
+        Some(10),
+        "a confirmation past the deadline must still count as unsettled"
+    );
+
+    // In time is genuinely settled.
+    confirm_transaction(&conn, &late, 16, 0).await?;
+    assert_eq!(min_unsettled_batch_tx_height(&conn, 6).await?, None);
     Ok(())
 }
 
@@ -4465,7 +4521,7 @@ async fn test_select_unfinalized_batches_sources_execution_not_certificate() -> 
 #[tokio::test]
 async fn test_unfinalized_batches_reachable_far_below_the_window() -> Result<()> {
     use crate::database::queries::{
-        insert_batch_txids, min_unconfirmed_batch_tx_height, select_unfinalized_batches,
+        insert_batch_txids, min_unsettled_batch_tx_height, select_unfinalized_batches,
     };
 
     let (_reader, writer, _temp_dir) = new_test_db().await?;
@@ -4501,7 +4557,7 @@ async fn test_unfinalized_batches_reachable_far_below_the_window() -> Result<()>
     );
 
     // The probe finds how far down to reach, and the batch comes back.
-    let floor = min_unconfirmed_batch_tx_height(&conn)
+    let floor = min_unsettled_batch_tx_height(&conn, 6)
         .await?
         .expect("an unconfirmed batch tx exists");
     assert_eq!(floor, 10);

--- a/core/indexer/src/database/queries/transactions.rs
+++ b/core/indexer/src/database/queries/transactions.rs
@@ -127,30 +127,74 @@ pub async fn get_transactions_paginated(
     .await
 }
 
+/// Bound placeholders per `txid IN (?…)` statement. SQLite's compile-time
+/// `SQLITE_MAX_VARIABLE_NUMBER` is 32766 and exceeding it fails at PREPARE, so an
+/// unchunked list is a crash, not a slow query. The largest caller is `make_value`,
+/// which passes the entire mempool pool — bounded by bitcoind, not by anything
+/// Kontor controls — so the chunking has to live here rather than at a call site.
+const TXID_PROBE_CHUNK: usize = 900;
+
+/// Rows in the transactions table for any of `txids`, keyed by txid.
+///
+/// One statement per chunk; absent txids are simply absent from the map.
+pub async fn select_transactions_by_txids(
+    conn: &Connection,
+    txids: &[String],
+) -> Result<std::collections::HashMap<String, TransactionRow>, Error> {
+    let mut result = std::collections::HashMap::new();
+    for chunk in txids.chunks(TXID_PROBE_CHUNK) {
+        let placeholders: Vec<&str> = chunk.iter().map(|_| "?").collect();
+        let sql = format!(
+            "SELECT id, txid, height, confirmed_height, tx_index, batch_height \
+             FROM transactions WHERE txid IN ({})",
+            placeholders.join(", ")
+        );
+        let params: Vec<Value> = chunk.iter().map(|t| Value::from(t.clone())).collect();
+        let mut rows = conn
+            .query(&sql, libsql::params::Params::Positional(params))
+            .await?;
+        while let Some(row) = rows.next().await? {
+            let parsed: TransactionRow = from_row(&row)?;
+            result.insert(parsed.txid.clone(), parsed);
+        }
+    }
+    Ok(result)
+}
+
 /// Return the subset of `txids` that already exist in the transactions table.
 pub async fn select_existing_txids(
     conn: &Connection,
     txids: &[String],
 ) -> Result<std::collections::HashSet<String>, Error> {
-    if txids.is_empty() {
-        return Ok(std::collections::HashSet::new());
-    }
-    let placeholders: Vec<&str> = txids.iter().map(|_| "?").collect();
-    let sql = format!(
-        "SELECT txid FROM transactions WHERE txid IN ({})",
-        placeholders.join(", ")
-    );
-    let params: Vec<libsql::Value> = txids
-        .iter()
-        .map(|t| libsql::Value::from(t.clone()))
-        .collect();
-    let mut rows = conn
-        .query(&sql, libsql::params::Params::Positional(params))
-        .await?;
-    let mut result = std::collections::HashSet::new();
-    while let Some(row) = rows.next().await? {
-        let txid: String = row.get(0)?;
-        result.insert(txid);
-    }
-    Ok(result)
+    Ok(select_transactions_by_txids(conn, txids)
+        .await?
+        .into_keys()
+        .collect())
+}
+
+/// Lowest anchor height of a batch-executed transaction that has never confirmed.
+///
+/// A startup divergence probe. Below the finality window this is a transaction the
+/// rollback machinery can no longer act on: if it later confirms, this node takes
+/// `execute_block`'s dedup branch (confirm only) while a peer holding no row takes
+/// insert-and-execute at the confirming height, so the same operations land at
+/// different heights and the checkpoint chains fork permanently. Nothing else can
+/// detect that — a confirmed txid is never re-proposed, so it never reaches a
+/// consensus-level check.
+pub async fn min_unconfirmed_batch_tx_height(conn: &Connection) -> Result<Option<u64>, Error> {
+    Ok(
+        match conn
+            .query(
+                "SELECT MIN(height) FROM transactions \
+                 WHERE confirmed_height IS NULL AND batch_height IS NOT NULL",
+                params![],
+            )
+            .await?
+            .next()
+            .await?
+        {
+            Some(row) => row.get::<Option<u64>>(0)?,
+            None => None,
+        },
+    )
 }

--- a/core/indexer/src/database/queries/transactions.rs
+++ b/core/indexer/src/database/queries/transactions.rs
@@ -8,6 +8,8 @@ use super::pagination::{PageOptions, get_paginated};
 use crate::database::types::TransactionQuery;
 
 pub async fn insert_transaction(conn: &Connection, row: TransactionRow) -> Result<u64, Error> {
+    let txid = row.txid.clone();
+    let confirmed = row.confirmed_height.is_some();
     conn.execute(
         "INSERT INTO transactions (height, txid, confirmed_height, tx_index, batch_height) VALUES (?, ?, ?, ?, ?)",
         params![
@@ -19,7 +21,24 @@ pub async fn insert_transaction(conn: &Connection, row: TransactionRow) -> Resul
         ],
     )
     .await?;
-    Ok(conn.last_insert_rowid() as u64)
+    // Captured before the delete below. `last_insert_rowid` tracks INSERTs only, so a
+    // DELETE would not disturb it — but reading it first means that never has to be
+    // re-derived by whoever edits this next.
+    let tx_id = conn.last_insert_rowid() as u64;
+    // Inserted ALREADY CONFIRMED means the transaction is on chain and indexed, so
+    // the raw copy kept for sync is redundant — same rule `confirm_transaction`
+    // applies when it moves an existing row to confirmed. Without it a record-only
+    // batch (which stores raw txs but writes no `transactions` row) leaks one full
+    // transaction body per txid forever: the confirming block takes this branch, not
+    // `confirm_transaction`, so nothing ever deleted it.
+    //
+    // Gated on `confirmed_height`, not unconditional: the batch-execution path
+    // inserts with `confirmed_height = None`, and its raw copy is exactly what a
+    // replay or a syncing peer still needs.
+    if confirmed {
+        delete_unconfirmed_batch_tx(conn, &txid).await?;
+    }
+    Ok(tx_id)
 }
 
 pub async fn confirm_transaction(

--- a/core/indexer/src/database/queries/transactions.rs
+++ b/core/indexer/src/database/queries/transactions.rs
@@ -172,22 +172,29 @@ pub async fn select_existing_txids(
         .collect())
 }
 
-/// Lowest anchor height of a batch-executed transaction that has never confirmed.
+/// Lowest anchor height of a batch-executed transaction that is not SETTLED —
+/// meaning it did not confirm on Bitcoin by its batch's deadline.
 ///
-/// A startup divergence probe. Below the finality window this is a transaction the
-/// rollback machinery can no longer act on: if it later confirms, this node takes
-/// `execute_block`'s dedup branch (confirm only) while a peer holding no row takes
-/// insert-and-execute at the confirming height, so the same operations land at
-/// different heights and the checkpoint chains fork permanently. Nothing else can
-/// detect that — a confirmed txid is never re-proposed, so it never reaches a
-/// consensus-level check.
-pub async fn min_unconfirmed_batch_tx_height(conn: &Connection) -> Result<Option<u64>, Error> {
+/// "Settled" must mean exactly what the finality verdict means. Testing only for
+/// `confirmed_height IS NULL` would treat a LATE confirmation as settled, when
+/// finality still counts it missing and still owes that batch a rollback. A batch
+/// row's `height` IS its anchor, so its deadline is `height + finality_window` and
+/// no join is needed.
+///
+/// Two callers, both of which need the finality notion: the startup floor extension
+/// (how far below the window rehydration must reach to pick up a batch whose verdict
+/// was never rendered) and the divergence probe.
+pub async fn min_unsettled_batch_tx_height(
+    conn: &Connection,
+    finality_window: u64,
+) -> Result<Option<u64>, Error> {
     Ok(
         match conn
             .query(
                 "SELECT MIN(height) FROM transactions \
-                 WHERE confirmed_height IS NULL AND batch_height IS NOT NULL",
-                params![],
+                 WHERE batch_height IS NOT NULL \
+                   AND (confirmed_height IS NULL OR confirmed_height > height + ?)",
+                params![finality_window],
             )
             .await?
             .next()

--- a/core/indexer/src/database/queries/transactions.rs
+++ b/core/indexer/src/database/queries/transactions.rs
@@ -207,20 +207,41 @@ pub async fn min_unsettled_batch_tx_height(
     conn: &Connection,
     finality_window: u64,
 ) -> Result<Option<u64>, Error> {
-    Ok(
-        match conn
-            .query(
-                "SELECT MIN(height) FROM transactions \
-                 WHERE batch_height IS NOT NULL \
-                   AND (confirmed_height IS NULL OR confirmed_height > height + ?)",
-                params![finality_window],
-            )
-            .await?
-            .next()
-            .await?
-        {
-            Some(row) => row.get::<Option<u64>>(0)?,
-            None => None,
-        },
-    )
+    // Two arms instead of one OR so each can name its partial index: the OR form
+    // has no usable index and walks every batch-executed row in history. The
+    // unconfirmed arm is an O(1) seek on a band-sized index; the late-confirmation
+    // arm is an index-only scan of confirmed batch rows.
+    let unconfirmed = match conn
+        .query(
+            "SELECT MIN(height) FROM transactions \
+             INDEXED BY idx_transactions_unconfirmed_batch \
+             WHERE batch_height IS NOT NULL AND confirmed_height IS NULL",
+            (),
+        )
+        .await?
+        .next()
+        .await?
+    {
+        Some(row) => row.get::<Option<u64>>(0)?,
+        None => None,
+    };
+    let late_confirmed = match conn
+        .query(
+            "SELECT MIN(height) FROM transactions \
+             INDEXED BY idx_transactions_batch_confirmed \
+             WHERE batch_height IS NOT NULL AND confirmed_height IS NOT NULL \
+               AND confirmed_height > height + ?",
+            params![finality_window],
+        )
+        .await?
+        .next()
+        .await?
+    {
+        Some(row) => row.get::<Option<u64>>(0)?,
+        None => None,
+    };
+    Ok(match (unconfirmed, late_confirmed) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (a, b) => a.or(b),
+    })
 }

--- a/core/indexer/src/database/sql/schema.sql
+++ b/core/indexer/src/database/sql/schema.sql
@@ -275,21 +275,34 @@ CREATE TABLE IF NOT EXISTS unconfirmed_batch_txs (
 CREATE INDEX IF NOT EXISTS idx_unconfirmed_batch_txs_batch_height
   ON unconfirmed_batch_txs (batch_height);
 
--- Txids dropped by a finality exclusion, so a later replay cannot put them back.
+-- Txids a finality exclusion dropped, PER DECISION, so a later replay cannot put
+-- them back and oscillate forever.
 --
--- Must be RECORDED, not re-derived. "Certified but not executed" looks identical for
--- a tx we excluded and for one in a record-only batch (anchor mismatch — never
--- executed here, but its peers ran it), and treating the latter as excluded would
--- strip it from the replay and diverge this node's state from the network. Only the
--- exclusion path knows which is which, so only it writes here.
+-- Keyed by `batch_height` FIRST. The row answers "when executing consensus height H,
+-- which certified txids must not run?" — never "is this txid banned". A txid-only key
+-- is a global ban: the same tx can re-enter the mempool, be decided in a LATER batch
+-- against a fresh deadline, and execute legitimately, and a global ban would strip it
+-- there too. That is a state divergence, which is worse than the liveness stall this
+-- table exists to prevent.
 --
--- Node-local: no FK, because a survivor decision has no `batches` row yet. Grows only
--- on finality exclusions, which are rare, and an entry is permanent by design — the
--- tx never confirmed by its deadline, and that verdict does not change. If it later
--- confirms on chain it is executed through the BLOCK path, which never reads this.
+-- RECORDED, never derived. "Certified but not executed" is equally true of a
+-- record-only batch (anchor mismatch — skipped here, executed by peers), and the two
+-- are indistinguishable in the database. Only the exclusion path knows which is which.
+--
+-- `deadline` is denormalised rather than joined: a SURVIVOR decision has no `batches`
+-- row when its exclusion is written, so a join would be unevaluable for exactly those
+-- rows. It makes the re-verification predicate a self-contained single-table check.
+--
+-- NO foreign key, and DELIBERATELY NOT trimmed by `delete_unexecuted_batch_suffix`.
+-- That cleanup forgets decided-but-unexecuted heights so they re-sync; the exclusion
+-- for such a height must SURVIVE, or the crash window between the truncation and the
+-- replay reopens the oscillation. Do not "tidy" this into the cleanup.
 CREATE TABLE IF NOT EXISTS excluded_batch_txids (
-  txid TEXT NOT NULL PRIMARY KEY
-);
+  batch_height INTEGER NOT NULL,
+  txid TEXT NOT NULL,
+  deadline INTEGER NOT NULL,
+  PRIMARY KEY (batch_height, txid)
+) WITHOUT ROWID;
 
 -- Node-local operational state (NOT consensus state): a singleton key/value store.
 -- Deliberately has NO foreign key to blocks (a reorg must not cascade-delete or roll

--- a/core/indexer/src/database/sql/schema.sql
+++ b/core/indexer/src/database/sql/schema.sql
@@ -251,10 +251,19 @@ CREATE TABLE IF NOT EXISTS nonces (
   FOREIGN KEY (height) REFERENCES blocks (height) ON DELETE CASCADE
 );
 
+-- Keyed by (txid, batch_height), NOT txid alone. The same transaction genuinely
+-- belongs to more than one decided height: a batch this node recorded but never
+-- executed (record-only, or undrained at a reorg) keeps its body, and the same tx
+-- can then be re-batched at a later height. Under a txid-only key the writers'
+-- `INSERT OR IGNORE` bound the body to whichever height wrote FIRST — typically the
+-- abandoned one — and silently ignored the real batch, so sync served the later
+-- height a txid it had no body for. `delete_unconfirmed_batch_tx` deletes by txid,
+-- so confirmation still clears every binding at once.
 CREATE TABLE IF NOT EXISTS unconfirmed_batch_txs (
-  txid TEXT NOT NULL PRIMARY KEY,
+  txid TEXT NOT NULL,
   batch_height INTEGER NOT NULL,
   raw_tx BLOB NOT NULL,
+  PRIMARY KEY (txid, batch_height),
   FOREIGN KEY (batch_height) REFERENCES batches (consensus_height)
 );
 

--- a/core/indexer/src/database/sql/schema.sql
+++ b/core/indexer/src/database/sql/schema.sql
@@ -275,6 +275,22 @@ CREATE TABLE IF NOT EXISTS unconfirmed_batch_txs (
 CREATE INDEX IF NOT EXISTS idx_unconfirmed_batch_txs_batch_height
   ON unconfirmed_batch_txs (batch_height);
 
+-- Txids dropped by a finality exclusion, so a later replay cannot put them back.
+--
+-- Must be RECORDED, not re-derived. "Certified but not executed" looks identical for
+-- a tx we excluded and for one in a record-only batch (anchor mismatch — never
+-- executed here, but its peers ran it), and treating the latter as excluded would
+-- strip it from the replay and diverge this node's state from the network. Only the
+-- exclusion path knows which is which, so only it writes here.
+--
+-- Node-local: no FK, because a survivor decision has no `batches` row yet. Grows only
+-- on finality exclusions, which are rare, and an entry is permanent by design — the
+-- tx never confirmed by its deadline, and that verdict does not change. If it later
+-- confirms on chain it is executed through the BLOCK path, which never reads this.
+CREATE TABLE IF NOT EXISTS excluded_batch_txids (
+  txid TEXT NOT NULL PRIMARY KEY
+);
+
 -- Node-local operational state (NOT consensus state): a singleton key/value store.
 -- Deliberately has NO foreign key to blocks (a reorg must not cascade-delete or roll
 -- back local cursors) and is never touched by the checkpoint trigger (which fires

--- a/core/indexer/src/database/sql/schema.sql
+++ b/core/indexer/src/database/sql/schema.sql
@@ -25,6 +25,18 @@ CREATE TABLE IF NOT EXISTS batches (
 -- rows, ConsensusState::new) deletes children explicitly first, and FK
 -- enforcement failing LOUD there is the guard against any future deletion path
 -- forgetting to.
+--
+-- `height` MEANS TWO DIFFERENT THINGS depending on how the row was created, and
+-- several bugs have come from conflating them:
+--   * batch-executed row (`batch_height` set): the ANCHOR height the batch was
+--     decided against. `confirmed_height` is NULL until the tx lands on Bitcoin,
+--     and can end up ABOVE `height`.
+--   * block-indexed row (`batch_height` NULL): the block that contained the tx.
+--     `height == confirmed_height` always.
+-- Only `height` cascades. So a batch row can outlive the block named by its
+-- `confirmed_height` (the anchor is at or below a rollback target while the
+-- confirmation is above it) — `rollback_to_height` clears those explicitly. A
+-- block-indexed row cannot: if it survives the cascade, its confirmation did too.
 CREATE TABLE IF NOT EXISTS transactions (
   id INTEGER PRIMARY KEY,
   txid TEXT NOT NULL UNIQUE,
@@ -61,6 +73,19 @@ CREATE TABLE IF NOT EXISTS batch_txids (
   PRIMARY KEY (batch_height, position),
   FOREIGN KEY (batch_height) REFERENCES batches (consensus_height)
 );
+
+-- What this node ACTUALLY EXECUTED for a batch — the counterpart to the CERTIFIED
+-- list in `batch_txids` above, and NOT the same thing.
+--
+-- The two diverge permanently after a filtered replay: `batch_txids` is append-only
+-- (INSERT OR IGNORE on its PK, no cascade), so re-recording a reduced list cannot
+-- shrink it, while the `transactions` rows for excluded txs are gone. Ask
+-- `batch_txids` "what was decided?" and ask this "what did we run?". Reaching for
+-- the wrong one is silent — it returns a plausible answer — and has been the source
+-- of several bugs, which is the only reason this view exists rather than the join
+-- being written out each time.
+CREATE VIEW IF NOT EXISTS executed_batch_txids AS
+  SELECT batch_height, txid, id FROM transactions WHERE batch_height IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS contracts (
   id INTEGER PRIMARY KEY,

--- a/core/indexer/src/database/sql/schema.sql
+++ b/core/indexer/src/database/sql/schema.sql
@@ -259,9 +259,10 @@ CREATE TABLE IF NOT EXISTS unconfirmed_batch_txs (
 );
 
 -- Sync resolves raw txs per batch (`select_unconfirmed_batch_txs`). The table is
--- keyed by txid, so without this that lookup is a full scan — and the rows are
--- long-lived: they are removed only on confirmation or by the startup suffix
--- cleanup, so a record-only or finality-excluded tx leaves one indefinitely.
+-- keyed by txid, so without this that lookup is a full scan. A row is removed once
+-- its transaction is indexed on chain (both the confirm and the insert path drop it)
+-- or by the startup suffix cleanup — so what remains is the finality-excluded txs,
+-- which never confirm and are exactly what sync cannot resolve any other way.
 CREATE INDEX IF NOT EXISTS idx_unconfirmed_batch_txs_batch_height
   ON unconfirmed_batch_txs (batch_height);
 

--- a/core/indexer/src/database/sql/schema.sql
+++ b/core/indexer/src/database/sql/schema.sql
@@ -258,6 +258,13 @@ CREATE TABLE IF NOT EXISTS unconfirmed_batch_txs (
   FOREIGN KEY (batch_height) REFERENCES batches (consensus_height)
 );
 
+-- Sync resolves raw txs per batch (`select_unconfirmed_batch_txs`). The table is
+-- keyed by txid, so without this that lookup is a full scan — and the rows are
+-- long-lived: they are removed only on confirmation or by the startup suffix
+-- cleanup, so a record-only or finality-excluded tx leaves one indefinitely.
+CREATE INDEX IF NOT EXISTS idx_unconfirmed_batch_txs_batch_height
+  ON unconfirmed_batch_txs (batch_height);
+
 -- Node-local operational state (NOT consensus state): a singleton key/value store.
 -- Deliberately has NO foreign key to blocks (a reorg must not cascade-delete or roll
 -- back local cursors) and is never touched by the checkpoint trigger (which fires

--- a/core/indexer/src/database/sql/schema.sql
+++ b/core/indexer/src/database/sql/schema.sql
@@ -58,6 +58,23 @@ CREATE INDEX IF NOT EXISTS idx_batches_anchor_height ON batches (anchor_height);
 CREATE INDEX IF NOT EXISTS idx_transactions_batch_height ON transactions (batch_height)
   WHERE batch_height IS NOT NULL;
 
+-- Two history-wide predicates run against batch rows on hot-ish paths: the
+-- startup/reorg rehydration floor (`min_unsettled_batch_tx_height`, twice at
+-- every boot and once per Bitcoin reorg) and the rollback confirmation-clear in
+-- `rollback_to_height` (inside every rollback savepoint). Without these they
+-- walk every batch-executed transaction ever written — `transactions` is never
+-- pruned. Partial on batch rows so block-path rows (the bulk of the table)
+-- never touch them; both are named via INDEXED BY (no ANALYZE, see above).
+--   * unconfirmed arm: MIN(height) over currently-unconfirmed batch txs, a set
+--     roughly the size of the finality band — O(1) seek.
+--   * confirmed arm: range scan on confirmed_height bounds the rollback clear
+--     by depth; `height` makes the late-confirmation probe index-only.
+CREATE INDEX IF NOT EXISTS idx_transactions_unconfirmed_batch ON transactions (height)
+  WHERE batch_height IS NOT NULL AND confirmed_height IS NULL;
+CREATE INDEX IF NOT EXISTS idx_transactions_batch_confirmed
+  ON transactions (confirmed_height, height)
+  WHERE batch_height IS NOT NULL AND confirmed_height IS NOT NULL;
+
 -- The immutable decided txid list of each batch, written at decide time and
 -- kept for as long as the batch row exists. Sync must serve the CERTIFIED
 -- value for a consensus height regardless of whether this node executed the

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -327,12 +327,12 @@ impl<E: Executor> Reactor<E> {
     /// replay and unfinalized-batch sync resolve from). Written for executed
     /// AND record-only batches — the certificate covers both.
     ///
-    /// The two tables take DIFFERENT lists when a rollback has narrowed this
-    /// batch. `batch_txids` records what consensus DECIDED (`certified`, when the
-    /// caller has it), because a syncing peer re-derives the exclusions itself and
-    /// needs the full list to match the certificate. `unconfirmed_batch_txs` records
-    /// only what we still HOLD — an excluded transaction was dropped precisely
-    /// because it never confirmed, so there is no raw transaction to serve.
+    /// BOTH tables record the DECIDED list when a rollback has narrowed this
+    /// batch (`certified`, when the caller has it): `batch_txids` because that is
+    /// what the certificate covers and a syncing peer re-derives the exclusions
+    /// itself, and `unconfirmed_batch_txs` because an excluded transaction never
+    /// confirmed — this node's copy of its body is the only one a peer can ever
+    /// obtain, so dropping it leaves the height unresolvable.
     ///
     /// Note `insert_batch_txids` is `INSERT OR IGNORE` on `(batch_height, position)`,
     /// which protects an already-complete list from being overwritten — but only
@@ -413,8 +413,9 @@ impl<E: Executor> Reactor<E> {
             // original txids, and `batch_txids` records what consensus decided (I4) —
             // a peer syncing this height re-derives the exclusions itself, so it needs
             // that list. `certified` is None for a genuinely empty decided batch, which
-            // has nothing to record. `batch_txs` is empty either way, so this writes no
-            // `unconfirmed_batch_txs` rows.
+            // has nothing to record. `record_batch_txs` writes the DECIDED list to
+            // both tables, so an emptied batch still records its certified txids AND
+            // their raw bodies — the bodies of all-excluded txs exist nowhere else.
             if certified.is_some() {
                 self.record_batch_txs(&conn, consensus_height, batch_txs, certified)
                     .await
@@ -867,13 +868,6 @@ impl<E: Executor> Reactor<E> {
             .context("Failed to load replay batches for rollback")
     }
 
-    /// Install the replay decisions loaded by `load_replay_decisions` and kick
-    /// off block redelivery. Runs AFTER the DB truncation: the raw-tx
-    /// resolution below can touch bitcoind, and a transient failure here is
-    /// fatal-but-recoverable (the rollback already happened; on restart the
-    /// startup cleanup forgets the unexecuted suffix and the node re-syncs).
-    /// Before the truncation it would instead CANCEL a rollback that finality
-    /// already demanded.
     /// Pair each decision with the transactions it carries.
     ///
     /// Both sides of the replay merge must resolve the SAME way: the exclusion
@@ -896,6 +890,13 @@ impl<E: Executor> Reactor<E> {
         Ok(out)
     }
 
+    /// Install the replay decisions loaded by `load_replay_decisions` and kick
+    /// off block redelivery. Runs AFTER the DB truncation: the raw-tx
+    /// resolution can touch bitcoind, and a transient failure here is
+    /// fatal-but-recoverable (the rollback already happened; on restart the
+    /// startup cleanup forgets the unexecuted suffix and the node re-syncs).
+    /// Before the truncation it would instead CANCEL a rollback that finality
+    /// already demanded.
     pub(super) async fn prepare_replay(
         &mut self,
         from_anchor: u64,
@@ -910,14 +911,7 @@ impl<E: Executor> Reactor<E> {
             "Initiating rollback replay"
         );
 
-        // Resolve BOTH the replay set and whatever was already queued before
-        // excluding anything: the exclusion closure must see tx INPUTS to drop
-        // descendants of an excluded tx, and a descendant can perfectly well sit in
-        // a queued decision — it is queued because its anchor is HIGHER, which is
-        // exactly where a child of an earlier tx lives. Resolving only the replay
-        // set let such a child through to execute against state the rollback wiped
-        // (#427 in a second form). Resolution pulls from the same sources the drain
-        // would use later.
+        // BOTH sides resolve, not just the replay set — see `resolve_decisions`.
         let replayed = self.resolve_decisions(replay_batches).await?;
         let queued = std::mem::take(&mut self.consensus.deferred_decisions);
         let survivors = self.resolve_decisions(queued).await?;

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -1006,14 +1006,6 @@ impl<E: Executor> Reactor<E> {
         // an observer must not be told a rollback happened when it did not.
         self.check_rollback_depth(rollback_anchor.saturating_sub(1))
             .context("finality rollback too deep")?;
-        self.consensus.emit_finality_events(&events);
-
-        // Read replay decisions BEFORE the truncation — the query joins rows that
-        // are cascade-deleted with their blocks.
-        let replay = self
-            .load_replay_decisions(rollback_anchor)
-            .await
-            .context("load_replay_decisions failed")?;
 
         // Record this pass's exclusions BEFORE the truncation. The base set (which
         // txids went missing, and from which decision) is already known here — only
@@ -1039,6 +1031,13 @@ impl<E: Executor> Reactor<E> {
             .await
             .context("Failed to record this pass's finality exclusions")?;
 
+        // Read replay decisions BEFORE the truncation — the query joins rows that
+        // are cascade-deleted with their blocks.
+        let replay = self
+            .load_replay_decisions(rollback_anchor)
+            .await
+            .context("load_replay_decisions failed")?;
+
         // Everything still applicable, this pass's rows included. Per DECISION: a row
         // for height H filters H and nothing else, so a txid re-decided in a later
         // batch against a fresh deadline still executes there. Applying exclusions
@@ -1047,6 +1046,13 @@ impl<E: Executor> Reactor<E> {
         let applicable = select_applicable_exclusions(&conn)
             .await
             .context("Failed to load applicable finality exclusions")?;
+
+        // Announce ONLY now, after every step that can still abort the pass: each
+        // read/write above is fallible and `?`-propagates, and an observer told
+        // about a rollback that then never happens is wrong about reality (I6) —
+        // on restart a reorg can even re-render the verdict clean, making the
+        // announcement permanently false. The truncation below is the commit point.
+        self.consensus.emit_finality_events(&events);
 
         // Roll back to before the invalid anchor so all state at the anchor height
         // (including the invalid txs' effects) is wiped cleanly.

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -1094,12 +1094,21 @@ impl<E: Executor> Reactor<E> {
     /// Declining to execute stays correct — the block was reorged away and running
     /// it would bind the wrong block to this consensus height. We just write down
     /// that we declined.
-    async fn record_declined_block(&self, decision: &consensus_state::DeferredDecision) {
+    async fn record_declined_block(
+        &self,
+        decision: &consensus_state::DeferredDecision,
+    ) -> Result<()> {
         // Height and hash come from the decision itself — passing them alongside
         // invited a caller to record one block's decision under another's identity.
         let block_height = decision.value.block_height();
         let decided_hash = decision.value.block_hash();
-        if let Err(e) = insert_batch(
+        // FATAL on failure, deliberately. A declined decision that leaves no row is
+        // the unrefillable middle gap this function exists to prevent: once
+        // `current_height` moves past it, nothing re-decides the height and the
+        // startup cleanup trims only a suffix. Failing is recoverable — restart
+        // resumes consensus at this height, value sync re-delivers the decision,
+        // and it is re-declined and recorded. Swallowing the error is not.
+        insert_batch(
             &self.db_conn(),
             decision.consensus_height.as_u64(),
             block_height,
@@ -1108,16 +1117,13 @@ impl<E: Executor> Reactor<E> {
             true,
         )
         .await
-        {
-            // Best-effort: failing to record must not take the node down, but it
-            // does leave the hole this exists to prevent, so say so loudly.
-            warn!(
-                error = %e,
-                consensus_height = %decision.consensus_height,
-                block_height,
-                "Failed to record declined block decision — consensus history now has a gap"
-            );
-        }
+        .with_context(|| {
+            format!(
+                "Failed to record declined block decision at consensus height {} \
+                 (block {block_height})",
+                decision.consensus_height
+            )
+        })
     }
 
     pub(super) async fn drain_deferred_decisions(&mut self) -> Result<()> {
@@ -1185,7 +1191,7 @@ impl<E: Executor> Reactor<E> {
                                 // the startup cleanup trims an unexecuted SUFFIX,
                                 // never a hole in the middle. A height that leaves
                                 // no row can never be served to a syncing peer.
-                                self.record_declined_block(&decision).await;
+                                self.record_declined_block(&decision).await?;
                                 continue;
                             }
                             Err(e) => {
@@ -1218,7 +1224,7 @@ impl<E: Executor> Reactor<E> {
                                 "Dropping stale deferred block decision ahead of the tip — \
                                  the canonical chain has replaced it"
                             );
-                            self.record_declined_block(&decision).await;
+                            self.record_declined_block(&decision).await?;
                             continue;
                         }
                         // No buffered block, or the hashes match: the
@@ -1258,7 +1264,7 @@ impl<E: Executor> Reactor<E> {
                                 consensus_height = %decision.consensus_height,
                                 "Dropping stale deferred block decision — hash mismatch after rollback"
                             );
-                            self.record_declined_block(&decision).await;
+                            self.record_declined_block(&decision).await?;
                             self.consensus.pending_blocks.insert(bh, block);
                             continue;
                         }
@@ -1555,7 +1561,7 @@ impl<E: Executor> Reactor<E> {
                                 consensus_height = %certificate.height,
                                 "Dropping stale block decision — hash mismatch after rollback"
                             );
-                            self.record_declined_block(&decision).await;
+                            self.record_declined_block(&decision).await?;
                             // Back in the buffer: it is the canonical block for this
                             // height on the new chain and still needs a fresh decision.
                             self.consensus.pending_blocks.insert(*height, block);
@@ -1574,7 +1580,7 @@ impl<E: Executor> Reactor<E> {
                                     consensus_height = %certificate.height,
                                     "Ignoring stale block decision (post-rollback)"
                                 );
-                                self.record_declined_block(&decision).await;
+                                self.record_declined_block(&decision).await?;
                             } else {
                                 info!(
                                     block_height = height,

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -18,7 +18,7 @@ use crate::consensus::finality_types::{DecidedBatch, StateEvent, UnfinalizedBatc
 use crate::consensus::{CommitCertificate, Ctx, Height, ProposalData, Value};
 use crate::database::queries::{
     insert_batch, insert_batch_txids, insert_transaction, insert_unconfirmed_batch_tx,
-    select_block_at_height, select_existing_txids,
+    select_block_at_height, select_existing_txids, select_previously_excluded_txids,
 };
 use crate::metrics::{CONSENSUS_HEIGHT, ITEMS_INDEXED};
 
@@ -993,6 +993,35 @@ impl<E: Executor> Reactor<E> {
             .load_replay_decisions(rollback_anchor)
             .await
             .context("load_replay_decisions failed")?;
+
+        // Carry forward what earlier passes already excluded, for the same reason and
+        // from the same rows (also pre-truncation). The replay reloads each batch from
+        // the append-only `batch_txids`, so without this the exclusion set is rebuilt
+        // from scratch every pass: pass one drops Y and keeps X, a later reorg
+        // un-confirms X, pass two drops X and puts Y BACK — the transaction pass one
+        // already proved never confirms. The two passes then alternate forever and the
+        // tip oscillates with no progress, deterministically on every node, which is a
+        // network-wide liveness halt rather than a divergence. Unioning makes the set
+        // monotone, so a batch can only ever shrink and the replay terminates.
+        let mut excluded = excluded;
+        match select_previously_excluded_txids(&conn, rollback_anchor).await {
+            Ok(previous) => {
+                for txid in previous {
+                    if let Ok(parsed) = txid.parse::<Txid>() {
+                        excluded.insert(parsed);
+                    }
+                }
+            }
+            Err(e) => {
+                // Not fatal, but it removes the termination guarantee — say so.
+                warn!(
+                    error = %e,
+                    from_anchor = rollback_anchor,
+                    "Could not load previously excluded txids; replay may re-include a \
+                     transaction an earlier pass dropped"
+                );
+            }
+        }
 
         // Roll back to before the invalid anchor so all state at the anchor height
         // (including the invalid txs' effects) is wiped cleanly.

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -1411,6 +1411,44 @@ impl<E: Executor> Reactor<E> {
                         None
                     };
 
+                    // Being buffered at the right height is not the same as being the
+                    // DECIDED block. A rollback can leave a decision whose block was
+                    // reorged away, and the block now pending at that height belongs
+                    // to the new chain — executing it under the old decision binds the
+                    // wrong block to that consensus record. The deferred drain has
+                    // always checked this; this path did not, so the guard held only
+                    // when the decision happened to arrive late.
+                    // Set when the mismatch branch below has already settled this
+                    // decision. The `else` arm cannot detect this case on its own — it
+                    // asks the DB whether an EXECUTED block differs, and at
+                    // `last_height + 1` nothing is executed yet, so it would read
+                    // "not stale" and defer a decision we just declined.
+                    let mut declined_stale = false;
+                    let ready = match ready {
+                        Some(block) if block.hash != *hash => {
+                            warn!(
+                                block_height = height,
+                                decided = %hash,
+                                local = %block.hash,
+                                consensus_height = %certificate.height,
+                                "Dropping stale block decision — hash mismatch after rollback"
+                            );
+                            let declined = consensus_state::DeferredDecision {
+                                consensus_height: certificate.height,
+                                value: proposal.value.clone(),
+                                certificate: cert_bytes.clone(),
+                                certified_txids: None,
+                            };
+                            self.record_declined_block(&declined, *height, *hash).await;
+                            // Back in the buffer: it is the canonical block for this
+                            // height on the new chain and still needs a fresh decision.
+                            self.consensus.pending_blocks.insert(*height, block);
+                            declined_stale = true;
+                            None
+                        }
+                        other => other,
+                    };
+
                     if let Some(block) = ready {
                         info!(
                             block_height = height,
@@ -1427,7 +1465,7 @@ impl<E: Executor> Reactor<E> {
                                 certified_txids: None,
                             },
                         );
-                    } else {
+                    } else if !declined_stale {
                         let is_stale = match select_block_at_height(&conn, *height).await {
                             Ok(Some(row)) => row.hash != *hash,
                             _ => false,

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -869,13 +869,23 @@ impl<E: Executor> Reactor<E> {
             return Ok(false);
         }
         let conn = self.db_conn();
-        let Some((rollback_anchor, excluded)) = self
+        let (events, rollback) = self
             .consensus
             .run_finality_checks(&conn, self.last_height)
-            .await
-        else {
+            .await;
+        let Some((rollback_anchor, excluded)) = rollback else {
+            self.consensus.emit_finality_events(&events);
             return Ok(false);
         };
+
+        // Depth-check BEFORE announcing anything. Rehydration can re-arm a deadline
+        // whose anchor sits far below the tip — that is exactly the #515 residue this
+        // PR picks up — and truncating below the prune watermark would destroy state
+        // rather than restore it. Halting for a re-sync is the intended outcome, and
+        // an observer must not be told a rollback happened when it did not.
+        self.check_rollback_depth(rollback_anchor.saturating_sub(1))
+            .context("finality rollback too deep")?;
+        self.consensus.emit_finality_events(&events);
 
         // Read replay decisions BEFORE the truncation — the query joins rows that
         // are cascade-deleted with their blocks.
@@ -886,13 +896,6 @@ impl<E: Executor> Reactor<E> {
 
         // Roll back to before the invalid anchor so all state at the anchor height
         // (including the invalid txs' effects) is wiped cleanly.
-        //
-        // Depth-checked like the reorg path. Rehydration can re-arm a deadline whose
-        // anchor sits far below the tip — that is exactly the #515 residue this PR
-        // exists to pick up — and truncating below the prune watermark would destroy
-        // state rather than restore it. Halting for a re-sync is the intended outcome.
-        self.check_rollback_depth(rollback_anchor.saturating_sub(1))
-            .context("finality rollback too deep")?;
         self.rollback(rollback_anchor.saturating_sub(1))
             .await
             .context("rollback failed during finality rollback")?;

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -188,8 +188,10 @@ fn restore_waiting(
     }
 }
 
-/// Merge a rollback's replay set with the decisions already queued, ordered by
-/// consensus height.
+/// Assemble the post-rollback replay queue: merge the replay set with the decisions
+/// already queued, and drop excluded transactions — plus anything descending from
+/// them — from the batches in the result. Returns the queue and the full transitive
+/// exclusion set, which the caller also purges from the proposal pool.
 ///
 /// MERGE, not overwrite: the replay set comes from `select_batches_from_anchor`,
 /// which returns only heights that already have a `batches` row, while a queued
@@ -205,26 +207,54 @@ fn restore_waiting(
 /// precisely what raises the tip back up after a rollback, so a survivor ordered
 /// ahead of it can stall the decisions that would make that survivor ready.
 ///
-/// Anchor order makes this correct as well as safe: a survivor was deferred because
-/// its anchor was above the pre-rollback tip, while every replayed batch is at or
-/// below it. So survivors are never ready earlier than the replay set, whatever
-/// their consensus heights — and consensus heights alone are not a reliable guide,
-/// because anchors go non-monotone across a rollback.
-///
 /// The two inputs should be disjoint by height; where they are not, the replayed
-/// copy wins because it has been resolved and exclusion-filtered.
-fn merge_replay_queue(
-    replayed: VecDeque<consensus_state::DeferredDecision>,
-    queued: VecDeque<consensus_state::DeferredDecision>,
-) -> VecDeque<consensus_state::DeferredDecision> {
-    let replayed_heights: Vec<Height> = replayed.iter().map(|d| d.consensus_height).collect();
-    let mut merged = replayed;
-    merged.extend(
-        queued
-            .into_iter()
-            .filter(|d| !replayed_heights.contains(&d.consensus_height)),
-    );
-    merged
+/// copy wins because it was loaded from the decided record.
+fn build_replay_queue(
+    replayed: Vec<(consensus_state::DeferredDecision, Vec<bitcoin::Transaction>)>,
+    survivors: Vec<(consensus_state::DeferredDecision, Vec<bitcoin::Transaction>)>,
+    excluded_txids: &HashSet<Txid>,
+) -> (VecDeque<consensus_state::DeferredDecision>, HashSet<Txid>) {
+    let replayed_heights: Vec<Height> = replayed.iter().map(|(d, _)| d.consensus_height).collect();
+    let survivors: Vec<_> = survivors
+        .into_iter()
+        .filter(|(d, _)| !replayed_heights.contains(&d.consensus_height))
+        .collect();
+
+    // MERGE FIRST, then exclude. The closure has to run over the whole sequence that
+    // will actually execute: a descendant of an excluded tx can sit in a survivor,
+    // since a survivor is queued precisely because its anchor is HIGHER — which is
+    // where a child of an earlier transaction lives.
+    let merged: Vec<_> = replayed.into_iter().chain(survivors).collect();
+
+    if excluded_txids.is_empty() {
+        return (merged.into_iter().map(|(d, _)| d).collect(), HashSet::new());
+    }
+
+    let batches: Vec<Vec<bitcoin::Transaction>> =
+        merged.iter().map(|(_, txs)| txs.clone()).collect();
+    let excluded = transitive_exclusion(&batches, excluded_txids);
+
+    let queue = merged
+        .into_iter()
+        .map(|(mut decision, txs)| {
+            if let Value::Batch {
+                anchor_height,
+                anchor_hash,
+                ..
+            } = &decision.value
+            {
+                let (anchor_height, anchor_hash) = (*anchor_height, *anchor_hash);
+                let kept: Vec<bitcoin::Transaction> = txs
+                    .into_iter()
+                    .filter(|tx| !excluded.contains(&tx.compute_txid()))
+                    .collect();
+                decision.value = Value::new_batch_raw(anchor_height, anchor_hash, kept);
+            }
+            decision
+        })
+        .collect();
+
+    (queue, excluded)
 }
 
 /// What `process_decided_batch` did with a decided batch. Callers must not
@@ -745,50 +775,42 @@ impl<E: Executor> Reactor<E> {
             "Initiating rollback replay"
         );
 
-        let mut deferred: std::collections::VecDeque<consensus_state::DeferredDecision> =
-            replay_batches.into();
-        if !excluded_txids.is_empty() {
-            // Resolve every replay batch to raw transactions first: exclusion
-            // must see tx INPUTS to also drop descendants of excluded txs — the
-            // DB-loaded decisions carry only txids, and filtering a parent out
-            // while keeping its child would break the dependency order the
-            // batch was decided under (#427). Resolution pulls from the same
-            // sources the deferred drain would use later.
-            let mut resolved: Vec<Vec<bitcoin::Transaction>> = Vec::with_capacity(deferred.len());
-            for decision in &deferred {
-                match &decision.value {
-                    Value::Batch { txs, .. } => resolved.push(self.resolve_batch_txs(txs).await?),
-                    Value::Block { .. } => resolved.push(Vec::new()),
-                }
-            }
-            let excluded = transitive_exclusion(&resolved, &excluded_txids);
-            for (decision, txs) in deferred.iter_mut().zip(resolved) {
-                if let Value::Batch {
-                    anchor_height,
-                    anchor_hash,
-                    ..
-                } = &decision.value
-                {
-                    let (anchor_height, anchor_hash) = (*anchor_height, *anchor_hash);
-                    let kept: Vec<bitcoin::Transaction> = txs
-                        .into_iter()
-                        .filter(|tx| !excluded.contains(&tx.compute_txid()))
-                        .collect();
-                    decision.value = Value::new_batch_raw(anchor_height, anchor_hash, kept);
-                }
-            }
-            // The excluded txids must also leave the proposal pool, or the next
-            // make_value re-proposes the very txs whose missing confirmations
-            // caused this rollback — repeating the same finality failure in a
-            // loop with no forward progress.
-            for txid in &excluded {
-                self.consensus.pending_transactions.remove(txid);
-            }
+        // Resolve BOTH the replay set and whatever was already queued before
+        // excluding anything: the exclusion closure must see tx INPUTS to drop
+        // descendants of an excluded tx, and a descendant can perfectly well sit in
+        // a queued decision — it is queued because its anchor is HIGHER, which is
+        // exactly where a child of an earlier tx lives. Resolving only the replay
+        // set let such a child through to execute against state the rollback wiped
+        // (#427 in a second form). Resolution pulls from the same sources the drain
+        // would use later.
+        let mut replayed = Vec::with_capacity(replay_batches.len());
+        for decision in replay_batches {
+            let txs = match &decision.value {
+                Value::Batch { txs, .. } => self.resolve_batch_txs(txs).await?,
+                Value::Block { .. } => Vec::new(),
+            };
+            replayed.push((decision, txs));
         }
-        self.consensus.deferred_decisions = merge_replay_queue(
-            deferred,
-            std::mem::take(&mut self.consensus.deferred_decisions),
-        );
+        let queued = std::mem::take(&mut self.consensus.deferred_decisions);
+        let mut survivors = Vec::with_capacity(queued.len());
+        for decision in queued {
+            let txs = match &decision.value {
+                Value::Batch { txs, .. } => self.resolve_batch_txs(txs).await?,
+                Value::Block { .. } => Vec::new(),
+            };
+            survivors.push((decision, txs));
+        }
+
+        let (queue, excluded) = build_replay_queue(replayed, survivors, &excluded_txids);
+        self.consensus.deferred_decisions = queue;
+
+        // The excluded txids must also leave the proposal pool, or the next
+        // make_value re-proposes the very txs whose missing confirmations caused
+        // this rollback — repeating the same finality failure with no progress.
+        for txid in &excluded {
+            self.consensus.pending_transactions.remove(txid);
+        }
+
         self.consensus
             .unfinalized_batches
             .retain(|b| b.anchor_height < from_anchor);
@@ -1254,7 +1276,7 @@ impl<E: Executor> Reactor<E> {
 #[cfg(test)]
 mod tests {
     use super::{
-        batch_is_ordered, dependency_sort, merge_replay_queue, restore_waiting,
+        batch_is_ordered, build_replay_queue, dependency_sort, restore_waiting,
         transitive_exclusion,
     };
     use crate::consensus::{Height, Value};
@@ -1391,72 +1413,113 @@ mod tests {
         q.iter().map(|d| d.consensus_height.as_u64()).collect()
     }
 
+    /// Pair a decision with the transactions it carries, as `prepare_replay` does
+    /// after resolving them.
+    fn carrying(
+        consensus_height: u64,
+        txs: Vec<Transaction>,
+    ) -> (DeferredDecision, Vec<Transaction>) {
+        let mut d = decision(consensus_height);
+        d.value = Value::new_batch_raw(0, bitcoin::BlockHash::all_zeros(), txs.clone());
+        (d, txs)
+    }
+
+    fn empty(consensus_height: u64) -> (DeferredDecision, Vec<Transaction>) {
+        (decision(consensus_height), Vec::new())
+    }
+
+    fn queue_of(
+        replayed: Vec<(DeferredDecision, Vec<Transaction>)>,
+        survivors: Vec<(DeferredDecision, Vec<Transaction>)>,
+    ) -> VecDeque<DeferredDecision> {
+        build_replay_queue(replayed, survivors, &HashSet::new()).0
+    }
+
+    /// THE regression this function exists for. A rollback excludes transaction X
+    /// because it never confirmed. A batch that was QUEUED (not yet executed, so it
+    /// has no `batches` row and is not in the replay set) carries Y, which spends
+    /// X's output. If the exclusion pass only sees the replay set, Y survives and
+    /// later executes against state the rollback wiped — while a peer that had
+    /// already executed that batch does drop Y, because for that peer it IS in the
+    /// replay set. Same consensus height, different transactions executed.
+    #[test]
+    fn build_replay_queue_excludes_descendants_carried_by_survivors() {
+        let parent = tx(&[OutPoint::null()], 1);
+        let child = tx(&[spend(&parent)], 2);
+        let unrelated = tx(&[OutPoint::null()], 3);
+
+        let excluded: HashSet<Txid> = [parent.compute_txid()].into();
+        let (queue, closure) = build_replay_queue(
+            vec![carrying(10, vec![parent.clone()])],
+            vec![carrying(14, vec![child.clone(), unrelated.clone()])],
+            &excluded,
+        );
+
+        assert!(
+            closure.contains(&child.compute_txid()),
+            "the closure must reach a descendant carried by a survivor"
+        );
+        let survivor_txs = queue[1].value.batch_raw_txs();
+        assert_eq!(
+            survivor_txs.len(),
+            1,
+            "survivor must keep only the unrelated tx, got {survivor_txs:?}"
+        );
+        assert_eq!(survivor_txs[0].compute_txid(), unrelated.compute_txid());
+    }
+
     /// A queued decision BELOW the replay set's max must SURVIVE. Anchors go
     /// non-monotone across a rollback, so height H can defer on a high anchor while
     /// H+1 executes on a lower one and gets a `batches` row — putting H below the
     /// replay set. H has no row, so dropping it leaves a permanent, unrefillable
     /// gap in the consensus-height sequence.
     #[test]
-    fn merge_replay_queue_keeps_a_queued_decision_below_the_replay_set() {
-        let replayed: VecDeque<_> = [decision(11), decision(12)].into();
-        let queued: VecDeque<_> = [decision(10), decision(13)].into();
-        let merged = merge_replay_queue(replayed, queued);
-        let mut present = heights(&merged);
+    fn build_replay_queue_keeps_a_queued_decision_below_the_replay_set() {
+        let queue = queue_of(vec![empty(11), empty(12)], vec![empty(10), empty(13)]);
+        let mut present = heights(&queue);
         present.sort_unstable();
         assert_eq!(present, vec![10, 11, 12, 13], "nothing may be dropped");
     }
 
-    /// …but it must survive BEHIND the replay set, not ahead of it.
-    /// `drain_deferred_decisions` parks on the first entry whose anchor exceeds the
-    /// tip and stops. A survivor was deferred precisely because its anchor was above
-    /// the pre-rollback tip, so putting it first parks the queue on an anchor that
-    /// only the replay set — now stuck behind it — could ever reach.
+    /// …but behind the replay set, not ahead of it. A survivor BLOCK decision whose
+    /// block has not arrived parks the drain, and the replay set — stuck behind it —
+    /// is what would have delivered that block.
     #[test]
-    fn merge_replay_queue_never_orders_a_survivor_ahead_of_the_replay_set() {
-        let replayed: VecDeque<_> = [decision(11), decision(12)].into();
-        let queued: VecDeque<_> = [decision(10), decision(13)].into();
+    fn build_replay_queue_never_orders_a_survivor_ahead_of_the_replay_set() {
         assert_eq!(
-            heights(&merge_replay_queue(replayed, queued)),
+            heights(&queue_of(
+                vec![empty(11), empty(12)],
+                vec![empty(10), empty(13)]
+            )),
             vec![11, 12, 10, 13],
-            "replay set first, survivors after in their original order"
         );
     }
 
     #[test]
-    fn merge_replay_queue_preserves_relative_order_within_each_side() {
-        let replayed: VecDeque<_> = [decision(5), decision(9)].into();
-        let queued: VecDeque<_> = [decision(6), decision(7)].into();
+    fn build_replay_queue_preserves_relative_order_within_each_side() {
         assert_eq!(
-            heights(&merge_replay_queue(replayed, queued)),
+            heights(&queue_of(
+                vec![empty(5), empty(9)],
+                vec![empty(6), empty(7)]
+            )),
             vec![5, 9, 6, 7]
         );
     }
 
     #[test]
-    fn merge_replay_queue_prefers_the_replayed_copy_of_a_shared_height() {
-        // Distinguishable by certificate: the replayed copy has been resolved and
-        // exclusion-filtered, so it must win.
+    fn build_replay_queue_prefers_the_replayed_copy_of_a_shared_height() {
         let mut replayed_copy = decision(4);
         replayed_copy.certificate = vec![0xAA];
-        let replayed: VecDeque<_> = [replayed_copy].into();
-        let queued: VecDeque<_> = [decision(4)].into();
-
-        let merged = merge_replay_queue(replayed, queued);
-        assert_eq!(heights(&merged), vec![4]);
-        assert_eq!(merged[0].certificate, vec![0xAA]);
+        let queue = queue_of(vec![(replayed_copy, Vec::new())], vec![empty(4)]);
+        assert_eq!(heights(&queue), vec![4]);
+        assert_eq!(queue[0].certificate, vec![0xAA]);
     }
 
     #[test]
-    fn merge_replay_queue_handles_either_side_empty() {
-        assert_eq!(
-            heights(&merge_replay_queue(VecDeque::new(), [decision(3)].into())),
-            vec![3]
-        );
-        assert_eq!(
-            heights(&merge_replay_queue([decision(3)].into(), VecDeque::new())),
-            vec![3]
-        );
-        assert!(merge_replay_queue(VecDeque::new(), VecDeque::new()).is_empty());
+    fn build_replay_queue_handles_either_side_empty() {
+        assert_eq!(heights(&queue_of(Vec::new(), vec![empty(3)])), vec![3]);
+        assert_eq!(heights(&queue_of(vec![empty(3)], Vec::new())), vec![3]);
+        assert!(queue_of(Vec::new(), Vec::new()).is_empty());
     }
 
     /// Batches held during a drain pass go back at the FRONT, in their original

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -555,8 +555,20 @@ impl<E: Executor> Reactor<E> {
         let last_height = self.last_height;
         let last_hash = self.last_hash.unwrap_or(BlockHash::all_zeros());
 
-        // If blocks are pending, always propose the next one first
-        if let Some((&height, block)) = self.consensus.pending_blocks.first_key_value() {
+        // If blocks are pending, always propose the next one first.
+        //
+        // Range-bounded, not `first_key_value`: an entry at or below the tip is
+        // already applied, and proposing it stops the chain — peers vote it valid
+        // (they still hold the block), it is decided, the finalize gate rejects it
+        // as out of order, and it stays the minimum forever so no newer block is
+        // ever proposed. The insert side refuses to buffer those now; this makes
+        // the proposer independently unable to emit one.
+        if let Some((&height, block)) = self
+            .consensus
+            .pending_blocks
+            .range(last_height + 1..)
+            .next()
+        {
             return Ok(Some(Value::new_block(height, block.hash)));
         }
 

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -251,8 +251,14 @@ fn build_replay_queue(
                     .collect();
                 // Narrowing what we execute must not narrow what we record as
                 // decided — see `DeferredDecision::certified_txids`.
+                //
+                // `get_or_insert`, not assignment: a batch can be narrowed by more
+                // than one rollback, and on the second pass `txs` is already the
+                // first pass's survivors. Recomputing from them would quietly drop
+                // whatever the first pass excluded. The earliest list is the decided
+                // one; later passes only ever remove more.
                 if kept.len() != decided.len() {
-                    decision.certified_txids = Some(decided);
+                    decision.certified_txids.get_or_insert(decided);
                 }
                 decision.value = Value::new_batch_raw(anchor_height, anchor_hash, kept);
             }
@@ -1601,6 +1607,47 @@ mod tests {
             survivor.certified_txids.as_deref(),
             Some(&[child.compute_txid(), kept.compute_txid()][..]),
             "the DECIDED list must be preserved in full for the record"
+        );
+    }
+
+    /// A batch can be narrowed by MORE THAN ONE rollback. On the second pass the
+    /// carried transactions are already the first pass's survivors, so recomputing
+    /// the decided list from them would silently drop whatever the first pass
+    /// excluded — and `batch_txids` would stop matching the certificate. The first
+    /// decided list is the true one and must win.
+    #[test]
+    fn build_replay_queue_keeps_the_first_decided_list_across_repeated_filtering() {
+        let first = tx(&[OutPoint::null()], 1);
+        let second = tx(&[OutPoint::null()], 2);
+        let survivor_tx = tx(&[OutPoint::null()], 3);
+        let decided_all = vec![
+            first.compute_txid(),
+            second.compute_txid(),
+            survivor_tx.compute_txid(),
+        ];
+
+        // Pass one already ran: `first` was excluded, and the decision carries the
+        // full decided list alongside the narrowed transactions.
+        let (mut decision, _) = carrying(14, vec![second.clone(), survivor_tx.clone()]);
+        decision.certified_txids = Some(decided_all.clone());
+
+        // Pass two excludes `second`.
+        let excluded: HashSet<Txid> = [second.compute_txid()].into();
+        let (queue, _) = build_replay_queue(
+            Vec::new(),
+            vec![(decision, vec![second.clone(), survivor_tx.clone()])],
+            &excluded,
+        );
+
+        assert_eq!(
+            queue[0].value.batch_raw_txs().len(),
+            1,
+            "only the untouched tx should remain executable"
+        );
+        assert_eq!(
+            queue[0].certified_txids.as_deref(),
+            Some(&decided_all[..]),
+            "the ORIGINAL decided list must survive a second narrowing"
         );
     }
 

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -916,6 +916,51 @@ impl<E: Executor> Reactor<E> {
         Ok(true)
     }
 
+    /// Record a decided block this node will NOT execute.
+    ///
+    /// `batches` is the decided sequence and the only copy of it — Malachite asks
+    /// US for decided values (`GetDecidedValues`), it does not keep them. So a
+    /// consensus height left without a row is a hole in the record, and one that
+    /// cannot be repaired: the startup cleanup trims an unexecuted SUFFIX, never a
+    /// gap in the middle.
+    ///
+    /// Batches have always done this — the anchor gate records a batch it cannot
+    /// apply and returns `RecordedOnly`. Block decisions did not, and the asymmetry
+    /// was an oversight rather than a decision: the row costs nothing to write
+    /// (`batches` has no foreign keys, so naming a block we do not hold is legal,
+    /// and nothing references a block decision's row), while the batch case that
+    /// DID get built also has to write `batch_txids` and `unconfirmed_batch_txs`.
+    ///
+    /// Declining to execute stays correct — the block was reorged away and running
+    /// it would bind the wrong block to this consensus height. We just write down
+    /// that we declined.
+    async fn record_declined_block(
+        &self,
+        decision: &consensus_state::DeferredDecision,
+        block_height: u64,
+        decided_hash: BlockHash,
+    ) {
+        if let Err(e) = insert_batch(
+            &self.db_conn(),
+            decision.consensus_height.as_u64(),
+            block_height,
+            &decided_hash.to_string(),
+            &decision.certificate,
+            true,
+        )
+        .await
+        {
+            // Best-effort: failing to record must not take the node down, but it
+            // does leave the hole this exists to prevent, so say so loudly.
+            warn!(
+                error = %e,
+                consensus_height = %decision.consensus_height,
+                block_height,
+                "Failed to record declined block decision — consensus history now has a gap"
+            );
+        }
+    }
+
     pub(super) async fn drain_deferred_decisions(&mut self) -> Result<()> {
         // Batches whose anchor block has not arrived yet. Held ASIDE rather than
         // stopping the drain: a waiting batch can only ever be unblocked by a
@@ -968,6 +1013,8 @@ impl<E: Executor> Reactor<E> {
                                 consensus_height = %decision.consensus_height,
                                 "Dropping stale deferred block decision — hash mismatch after rollback"
                             );
+                            self.record_declined_block(&decision, bh, decided_hash)
+                                .await;
                             self.consensus.pending_blocks.insert(bh, block);
                             continue;
                         }
@@ -1000,6 +1047,8 @@ impl<E: Executor> Reactor<E> {
                                     consensus_height = %decision.consensus_height,
                                     "Dropping deferred block decision — height already executed"
                                 );
+                                self.record_declined_block(&decision, bh, decided_hash)
+                                    .await;
                                 continue;
                             }
                             Ok(None) => {}
@@ -1247,8 +1296,19 @@ impl<E: Executor> Reactor<E> {
                             warn!(
                                 block_height = height,
                                 block_hash = %hash,
+                                consensus_height = %certificate.height,
                                 "Ignoring stale block decision (post-rollback)"
                             );
+                            self.record_declined_block(
+                                &consensus_state::DeferredDecision {
+                                    consensus_height: certificate.height,
+                                    value: proposal.value.clone(),
+                                    certificate: cert_bytes.clone(),
+                                },
+                                *height,
+                                *hash,
+                            )
+                            .await;
                         }
                     }
                 }

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -893,10 +893,16 @@ impl<E: Executor> Reactor<E> {
         // for. Restored to the front, in order, whenever a block executes and at
         // exit, so a batch is re-evaluated the moment its anchor lands.
         //
-        // Batches are never reordered relative to each other: once one is held,
-        // later ones are held unevaluated. And the tip can never overshoot a held
-        // anchor, because blocks apply strictly sequentially — the only block that
-        // can execute is `tip + 1`, while a held batch waits for `anchor > tip`.
+        // Every batch is judged ONLY on its own anchor — never held because an
+        // earlier one is waiting. Holding a ready batch for queue order strands it:
+        // the tip keeps climbing past its anchor while it sits here, and the
+        // execution gate demands an exact `anchor == tip` match, so it would come
+        // back as record-only and its transactions would never run even though
+        // peers ran them.
+        //
+        // That costs no ordering guarantee, because a batch can only ever execute
+        // at exactly its own anchor. Anchor order therefore fixes execution order
+        // on every node, whatever position a decision happens to occupy here.
         let mut waiting: VecDeque<consensus_state::DeferredDecision> = VecDeque::new();
 
         loop {
@@ -986,7 +992,7 @@ impl<E: Executor> Reactor<E> {
                     txs,
                     ..
                 } => {
-                    if !waiting.is_empty() || *anchor_height > self.last_height {
+                    if *anchor_height > self.last_height {
                         info!(
                             anchor_height = *anchor_height,
                             last_height = self.last_height,

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -18,7 +18,7 @@ use crate::consensus::finality_types::{DecidedBatch, StateEvent, UnfinalizedBatc
 use crate::consensus::{CommitCertificate, Ctx, Height, ProposalData, Value};
 use crate::database::queries::{
     insert_batch, insert_batch_txids, insert_excluded_batch_txids, insert_transaction,
-    insert_unconfirmed_batch_tx, select_block_at_height, select_excluded_batch_txids,
+    insert_unconfirmed_batch_tx, select_applicable_exclusions, select_block_at_height,
     select_existing_txids,
 };
 use crate::metrics::{CONSENSUS_HEIGHT, ITEMS_INDEXED};
@@ -210,11 +210,20 @@ fn restore_waiting(
 ///
 /// The two inputs should be disjoint by height; where they are not, the replayed
 /// copy wins because it was loaded from the decided record.
+/// The replay queue, every txid dropped this pass (for pool eviction), and the
+/// DESCENDANT exclusions to record against the decisions they were removed from.
+type ReplayPlan = (
+    VecDeque<consensus_state::DeferredDecision>,
+    HashSet<Txid>,
+    Vec<(u64, String, u64)>,
+);
+
 fn build_replay_queue(
     replayed: Vec<(consensus_state::DeferredDecision, Vec<bitcoin::Transaction>)>,
     survivors: Vec<(consensus_state::DeferredDecision, Vec<bitcoin::Transaction>)>,
-    excluded_txids: &HashSet<Txid>,
-) -> (VecDeque<consensus_state::DeferredDecision>, HashSet<Txid>) {
+    // Exclusions PER consensus height, already re-verified against the chain.
+    applicable: &HashMap<u64, HashSet<String>>,
+) -> ReplayPlan {
     let replayed_heights: Vec<Height> = replayed.iter().map(|(d, _)| d.consensus_height).collect();
     let survivors: Vec<_> = survivors
         .into_iter()
@@ -227,50 +236,86 @@ fn build_replay_queue(
     // where a child of an earlier transaction lives.
     let merged: Vec<_> = replayed.into_iter().chain(survivors).collect();
 
-    if excluded_txids.is_empty() {
-        return (merged.into_iter().map(|(d, _)| d).collect(), HashSet::new());
-    }
+    let dropped_at = |decision: &consensus_state::DeferredDecision, txid: &Txid| -> bool {
+        applicable
+            .get(&decision.consensus_height.as_u64())
+            .is_some_and(|s| s.contains(&txid.to_string()))
+    };
 
-    let batches: Vec<Vec<bitcoin::Transaction>> =
-        merged.iter().map(|(_, txs)| txs.clone()).collect();
-    let excluded = transitive_exclusion(&batches, excluded_txids);
-
-    let queue = merged
-        .into_iter()
-        .map(|(mut decision, txs)| {
-            if let Value::Batch {
-                anchor_height,
-                anchor_hash,
-                ..
-            } = &decision.value
-            {
-                let (anchor_height, anchor_hash) = (*anchor_height, *anchor_hash);
-                let kept: Vec<bitcoin::Transaction> = txs
-                    .iter()
-                    .filter(|tx| !excluded.contains(&tx.compute_txid()))
-                    .cloned()
-                    .collect();
-                let decided = txs;
-                // Narrowing what we execute must not narrow what we record as
-                // decided — see `DeferredDecision::certified_txs`. The BODIES are
-                // retained, not just the txids: an excluded tx never confirmed, so
-                // this is the only copy left and a peer can get it nowhere else.
-                //
-                // `get_or_insert`, not assignment: a batch can be narrowed by more
-                // than one rollback, and on the second pass `txs` is already the
-                // first pass's survivors. Recomputing from them would quietly drop
-                // whatever the first pass excluded. The earliest list is the decided
-                // one; later passes only ever remove more.
-                if kept.len() != decided.len() {
-                    decision.certified_txs.get_or_insert(decided);
-                }
-                decision.value = Value::new_batch_raw(anchor_height, anchor_hash, kept);
-            }
-            decision
+    // A txid KEPT by any decision in this queue must not seed the descendant closure.
+    // It is executing legitimately somewhere — excluded from one height but re-decided
+    // at another against a fresh deadline — so treating it as excluded would strip its
+    // children from batches that should run them.
+    let kept_anywhere: HashSet<Txid> = merged
+        .iter()
+        .flat_map(|(d, txs)| {
+            txs.iter()
+                .filter(move |t| !dropped_at(d, &t.compute_txid()))
         })
+        .map(|t| t.compute_txid())
         .collect();
 
-    (queue, excluded)
+    let seed: HashSet<Txid> = applicable
+        .values()
+        .flatten()
+        .filter_map(|t| t.parse::<Txid>().ok())
+        .filter(|t| !kept_anywhere.contains(t))
+        .collect();
+
+    // Descendants only — the seed itself is already handled per decision above, and
+    // folding it back in would re-globalise exactly what the per-height scope fixes.
+    let batches: Vec<Vec<bitcoin::Transaction>> =
+        merged.iter().map(|(_, txs)| txs.clone()).collect();
+    let descendants: HashSet<Txid> = transitive_exclusion(&batches, &seed)
+        .difference(&seed)
+        .copied()
+        .collect();
+
+    let mut all_excluded: HashSet<Txid> = HashSet::new();
+    let mut closure_rows: Vec<(u64, String, u64)> = Vec::new();
+    let mut queue = VecDeque::with_capacity(merged.len());
+
+    for (mut decision, txs) in merged {
+        if let Value::Batch {
+            anchor_height,
+            anchor_hash,
+            ..
+        } = &decision.value
+        {
+            let (anchor_height, anchor_hash) = (*anchor_height, *anchor_hash);
+            let height = decision.consensus_height.as_u64();
+            let mut kept = Vec::with_capacity(txs.len());
+            for tx in &txs {
+                let txid = tx.compute_txid();
+                if dropped_at(&decision, &txid) {
+                    all_excluded.insert(txid);
+                } else if descendants.contains(&txid) {
+                    // Newly discovered this pass — record it so a later replay does
+                    // not have to rediscover it (and cannot skip it if it does not).
+                    all_excluded.insert(txid);
+                    closure_rows.push((height, txid.to_string(), deadline_for(anchor_height)));
+                } else {
+                    kept.push(tx.clone());
+                }
+            }
+            // Narrowing what we execute must not narrow what we record as decided —
+            // see `DeferredDecision::certified_txs`. The BODIES are retained, not just
+            // the txids: an excluded tx never confirmed, so this is the only copy left
+            // and a peer can get it nowhere else.
+            //
+            // `get_or_insert`, not assignment: a batch can be narrowed by more than
+            // one rollback, and on the second pass `txs` is already the first pass's
+            // survivors for a SURVIVOR decision (a replayed one is reloaded from the
+            // certified list each pass). The earliest list is the decided one.
+            if kept.len() != txs.len() {
+                decision.certified_txs.get_or_insert(txs);
+            }
+            decision.value = Value::new_batch_raw(anchor_height, anchor_hash, kept);
+        }
+        queue.push_back(decision);
+    }
+
+    (queue, all_excluded, closure_rows)
 }
 
 /// What `process_decided_batch` did with a decided batch. Callers must not
@@ -889,12 +934,13 @@ impl<E: Executor> Reactor<E> {
         &mut self,
         from_anchor: u64,
         replay_batches: Vec<consensus_state::DeferredDecision>,
-        excluded_txids: HashSet<Txid>,
+        // Per consensus height — see `select_applicable_exclusions`.
+        applicable: HashMap<u64, HashSet<String>>,
     ) -> Result<()> {
         info!(
             from_anchor,
             replay_batches = replay_batches.len(),
-            excluded = excluded_txids.len(),
+            excluded = applicable.values().map(|s| s.len()).sum::<usize>(),
             "Initiating rollback replay"
         );
 
@@ -910,17 +956,20 @@ impl<E: Executor> Reactor<E> {
         let queued = std::mem::take(&mut self.consensus.deferred_decisions);
         let survivors = self.resolve_decisions(queued).await?;
 
-        let (queue, excluded) = build_replay_queue(replayed, survivors, &excluded_txids);
+        let (queue, excluded, closure_rows) = build_replay_queue(replayed, survivors, &applicable);
         self.consensus.deferred_decisions = queue;
 
-        // Record what this pass dropped, so a later pass cannot reload it from the
-        // append-only certified list and execute it again.
-        let dropped: Vec<String> = excluded.iter().map(|t| t.to_string()).collect();
-        if let Err(e) = insert_excluded_batch_txids(&self.db_conn(), &dropped).await {
+        // The DESCENDANT closure, attributed to the decisions it actually removed
+        // from. Best-effort and post-truncation, unlike the base set written before
+        // the rollback: losing these degrades to one extra rollback pass (the base
+        // rows survive, so the next pass re-derives the same closure), never to a
+        // wrong execution.
+        if let Err(e) = insert_excluded_batch_txids(&self.db_conn(), &closure_rows).await {
             warn!(
                 error = %e,
-                count = dropped.len(),
-                "Failed to record this pass's exclusions; a later replay may re-include them"
+                count = closure_rows.len(),
+                "Failed to record this pass's descendant exclusions; the next pass will \
+                 re-derive them"
             );
         }
 
@@ -993,7 +1042,7 @@ impl<E: Executor> Reactor<E> {
             .consensus
             .run_finality_checks(&conn, self.last_height)
             .await?;
-        let Some((rollback_anchor, excluded)) = rollback else {
+        let Some((rollback_anchor, missing)) = rollback else {
             self.consensus.emit_finality_events(&events);
             return Ok(false);
         };
@@ -1014,36 +1063,38 @@ impl<E: Executor> Reactor<E> {
             .await
             .context("load_replay_decisions failed")?;
 
-        // Carry forward what earlier passes already excluded (pre-truncation, like the
-        // load above). The replay reloads each batch from the append-only
-        // `batch_txids`, so without this the exclusion set is rebuilt from scratch
-        // every pass: pass one drops Y and keeps X, a later reorg un-confirms X, pass
-        // two drops X and puts Y BACK — the transaction pass one already proved never
-        // confirms. The two alternate forever and the tip oscillates with no progress,
-        // deterministically on every node. Unioning makes the set monotone.
+        // Record this pass's exclusions BEFORE the truncation. The base set (which
+        // txids went missing, and from which decision) is already known here — only
+        // the descendant closure needs the resolved raw txs, and that part is
+        // re-derivable. Writing after the rollback, as an earlier attempt did, leaves
+        // a window where the truncation is durable and the reason for it is not: the
+        // replay then reloads the full certified list and the oscillation returns.
         //
-        // Read from the RECORD of what we excluded, never re-derived as "certified but
-        // not executed": that predicate is also true of a record-only batch, whose txs
-        // its peers DID run, and excluding those would diverge this node's state from
-        // the network — a worse failure than the one being fixed.
-        let mut excluded = excluded;
-        match select_excluded_batch_txids(&conn).await {
-            Ok(previous) => {
-                for txid in previous {
-                    if let Ok(parsed) = txid.parse::<Txid>() {
-                        excluded.insert(parsed);
-                    }
-                }
-            }
-            Err(e) => {
-                // Not fatal, but it removes the termination guarantee — say so.
-                warn!(
-                    error = %e,
-                    "Could not load previously excluded txids; replay may re-include a \
-                     transaction an earlier pass dropped"
-                );
-            }
-        }
+        // FATAL on failure, unlike the best-effort records elsewhere. Without this row
+        // the pass is simply the original bug, and doing the rollback anyway would
+        // commit to a truncation we can no longer justify on the next pass.
+        let base_rows: Vec<(u64, String, u64)> = missing
+            .iter()
+            .flat_map(|m| {
+                let (height, deadline) =
+                    (m.consensus_height.as_u64(), deadline_for(m.anchor_height));
+                m.txids
+                    .iter()
+                    .map(move |t| (height, t.to_string(), deadline))
+            })
+            .collect();
+        insert_excluded_batch_txids(&conn, &base_rows)
+            .await
+            .context("Failed to record this pass's finality exclusions")?;
+
+        // Everything still applicable, this pass's rows included. Per DECISION: a row
+        // for height H filters H and nothing else, so a txid re-decided in a later
+        // batch against a fresh deadline still executes there. Applying exclusions
+        // globally would skip a transaction the network ran — a divergence, and worse
+        // than the stall this prevents.
+        let applicable = select_applicable_exclusions(&conn)
+            .await
+            .context("Failed to load applicable finality exclusions")?;
 
         // Roll back to before the invalid anchor so all state at the anchor height
         // (including the invalid txs' effects) is wiped cleanly.
@@ -1053,7 +1104,7 @@ impl<E: Executor> Reactor<E> {
 
         // Fallible raw-tx resolution/filtering only after the truncation is durable:
         // a failure here must not cancel a rollback finality already demanded.
-        self.prepare_replay(rollback_anchor, replay, excluded)
+        self.prepare_replay(rollback_anchor, replay, applicable)
             .await
             .context("prepare_replay failed")?;
 
@@ -1613,6 +1664,7 @@ mod tests {
     use bitcoin::hashes::Hash;
     use bitcoin::transaction::Version;
     use bitcoin::{Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness};
+    use std::collections::HashMap;
     use std::collections::HashSet;
     use std::collections::VecDeque;
 
@@ -1757,11 +1809,20 @@ mod tests {
         (decision(consensus_height), Vec::new())
     }
 
+    /// Exclusions attributed to the decision they were dropped from.
+    fn excl(pairs: &[(u64, Txid)]) -> HashMap<u64, HashSet<String>> {
+        let mut m: HashMap<u64, HashSet<String>> = HashMap::new();
+        for (height, txid) in pairs {
+            m.entry(*height).or_default().insert(txid.to_string());
+        }
+        m
+    }
+
     fn queue_of(
         replayed: Vec<(DeferredDecision, Vec<Transaction>)>,
         survivors: Vec<(DeferredDecision, Vec<Transaction>)>,
     ) -> VecDeque<DeferredDecision> {
-        build_replay_queue(replayed, survivors, &HashSet::new()).0
+        build_replay_queue(replayed, survivors, &HashMap::new()).0
     }
 
     /// THE regression this function exists for. A rollback excludes transaction X
@@ -1777,8 +1838,8 @@ mod tests {
         let child = tx(&[spend(&parent)], 2);
         let unrelated = tx(&[OutPoint::null()], 3);
 
-        let excluded: HashSet<Txid> = [parent.compute_txid()].into();
-        let (queue, closure) = build_replay_queue(
+        let excluded = excl(&[(10, parent.compute_txid())]);
+        let (queue, closure, _) = build_replay_queue(
             vec![carrying(10, vec![parent.clone()])],
             vec![carrying(14, vec![child.clone(), unrelated.clone()])],
             &excluded,
@@ -1810,8 +1871,8 @@ mod tests {
         let child = tx(&[spend(&parent)], 2);
         let kept = tx(&[OutPoint::null()], 3);
 
-        let excluded: HashSet<Txid> = [parent.compute_txid()].into();
-        let (queue, _) = build_replay_queue(
+        let excluded = excl(&[(10, parent.compute_txid())]);
+        let (queue, _, _) = build_replay_queue(
             vec![carrying(10, vec![parent.clone()])],
             vec![carrying(14, vec![child.clone(), kept.clone()])],
             &excluded,
@@ -1843,8 +1904,8 @@ mod tests {
         let child_a = tx(&[spend(&parent)], 2);
         let child_b = tx(&[spend(&parent)], 3);
 
-        let excluded: HashSet<Txid> = [parent.compute_txid()].into();
-        let (queue, _) = build_replay_queue(
+        let excluded = excl(&[(10, parent.compute_txid())]);
+        let (queue, _, _) = build_replay_queue(
             vec![carrying(10, vec![parent.clone()])],
             vec![carrying(14, vec![child_a.clone(), child_b.clone()])],
             &excluded,
@@ -1860,6 +1921,105 @@ mod tests {
             vec![child_a.compute_txid(), child_b.compute_txid()],
             "an emptied batch still has a decided list, and it must survive"
         );
+    }
+
+    /// THE regression for attempt 2. An exclusion belongs to the DECISION it was made
+    /// in, not to the transaction. A tx dropped at one height can re-enter the
+    /// mempool, be decided in a LATER batch against a fresh deadline, and execute
+    /// there legitimately — a global ban strips it from that batch too, so this node
+    /// skips a transaction the network ran. That is a state divergence, worse than the
+    /// oscillation the carry-forward exists to prevent.
+    #[test]
+    fn build_replay_queue_does_not_exclude_a_txid_at_a_different_height() {
+        let t = tx(&[OutPoint::null()], 1);
+        let other = tx(&[OutPoint::null()], 2);
+
+        let (queue, _, _) = build_replay_queue(
+            vec![carrying(10, vec![t.clone()])],
+            vec![carrying(14, vec![t.clone(), other.clone()])],
+            &excl(&[(10, t.compute_txid())]),
+        );
+
+        assert!(
+            queue[0].value.batch_raw_txs().is_empty(),
+            "the decision it was excluded from must drop it"
+        );
+        let later: Vec<Txid> = queue[1]
+            .value
+            .batch_raw_txs()
+            .iter()
+            .map(|x| x.compute_txid())
+            .collect();
+        assert!(
+            later.contains(&t.compute_txid()),
+            "a DIFFERENT decision carrying the same txid must still execute it"
+        );
+    }
+
+    /// The descendant closure must not be seeded by a tx that is executing fine
+    /// somewhere. If P is excluded at one height but kept at another, its child C is
+    /// not orphaned — stripping C would skip a transaction whose parent the network
+    /// executed.
+    #[test]
+    fn build_replay_queue_keeps_a_child_whose_parent_is_kept_elsewhere() {
+        let parent = tx(&[OutPoint::null()], 1);
+        let child = tx(&[spend(&parent)], 2);
+
+        let (queue, _, _) = build_replay_queue(
+            vec![carrying(10, vec![parent.clone()])],
+            vec![
+                carrying(14, vec![parent.clone()]),
+                carrying(15, vec![child.clone()]),
+            ],
+            &excl(&[(10, parent.compute_txid())]),
+        );
+
+        assert!(
+            !queue[2].value.batch_raw_txs().is_empty(),
+            "the child must survive — its parent executes at another height"
+        );
+    }
+
+    /// But a child whose parent is excluded and appears NOWHERE else must still drop:
+    /// it would execute against state the rollback wiped (#427). The `kept_anywhere`
+    /// guard must not be widened into "never seed the closure".
+    #[test]
+    fn build_replay_queue_still_drops_a_child_of_an_absent_parent() {
+        let parent = tx(&[OutPoint::null()], 1);
+        let child = tx(&[spend(&parent)], 2);
+
+        let (queue, _, closure_rows) = build_replay_queue(
+            vec![carrying(10, vec![parent.clone()])],
+            vec![carrying(14, vec![child.clone()])],
+            &excl(&[(10, parent.compute_txid())]),
+        );
+
+        assert!(
+            queue[1].value.batch_raw_txs().is_empty(),
+            "a descendant of an excluded, otherwise-absent parent must not execute"
+        );
+        assert!(
+            closure_rows
+                .iter()
+                .any(|(h, t, _)| *h == 14 && t == &child.compute_txid().to_string()),
+            "and the closure must be RECORDED against the height it was removed from, \
+             so a later pass does not have to rediscover it"
+        );
+    }
+
+    /// An unmarked decision is untouched — the record-only case, which has certified
+    /// txids and no execution and must NOT be mistaken for an exclusion.
+    #[test]
+    fn build_replay_queue_leaves_an_unmarked_decision_intact() {
+        let a = tx(&[OutPoint::null()], 1);
+        let b = tx(&[OutPoint::null()], 2);
+        let (queue, excluded, rows) = build_replay_queue(
+            vec![carrying(10, vec![a.clone(), b.clone()])],
+            Vec::new(),
+            &HashMap::new(),
+        );
+        assert_eq!(queue[0].value.batch_raw_txs().len(), 2);
+        assert!(excluded.is_empty() && rows.is_empty());
     }
 
     /// Narrowing must not destroy the EXCLUDED transactions' bodies.
@@ -1878,8 +2038,8 @@ mod tests {
         let child = tx(&[spend(&parent)], 2);
         let kept = tx(&[OutPoint::null()], 3);
 
-        let excluded: HashSet<Txid> = [parent.compute_txid()].into();
-        let (queue, _) = build_replay_queue(
+        let excluded = excl(&[(10, parent.compute_txid())]);
+        let (queue, _, _) = build_replay_queue(
             vec![carrying(10, vec![parent.clone()])],
             vec![carrying(14, vec![child.clone(), kept.clone()])],
             &excluded,
@@ -1923,8 +2083,8 @@ mod tests {
         decision.certified_txs = Some(decided_all.clone());
 
         // Pass two excludes `second`.
-        let excluded: HashSet<Txid> = [second.compute_txid()].into();
-        let (queue, _) = build_replay_queue(
+        let excluded = excl(&[(14, second.compute_txid())]);
+        let (queue, _, _) = build_replay_queue(
             Vec::new(),
             vec![(decision, vec![second.clone(), survivor_tx.clone()])],
             &excluded,
@@ -1947,10 +2107,10 @@ mod tests {
     #[test]
     fn build_replay_queue_leaves_certified_txs_unset_when_nothing_is_filtered() {
         let a = tx(&[OutPoint::null()], 1);
-        let (queue, _) = build_replay_queue(
+        let (queue, _, _) = build_replay_queue(
             vec![carrying(10, vec![a.clone()])],
             Vec::new(),
-            &HashSet::new(),
+            &HashMap::new(),
         );
         assert!(queue[0].certified_txs.is_none());
     }

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -153,8 +153,8 @@ fn restore_waiting(
 
 /// Assemble the post-rollback replay queue: merge the replay set with the decisions
 /// already queued, and drop excluded transactions — plus anything descending from
-/// them — from the batches in the result. Returns the queue and the full transitive
-/// exclusion set, which the caller also purges from the proposal pool.
+/// them — from the batches in the result. Returns the queue and every txid dropped
+/// this pass, which the caller also purges from the proposal pool.
 ///
 /// MERGE, not overwrite: the replay set comes from `select_batches_from_anchor`,
 /// which returns only heights that already have a `batches` row, while a queued
@@ -172,20 +172,12 @@ fn restore_waiting(
 ///
 /// The two inputs should be disjoint by height; where they are not, the replayed
 /// copy wins because it was loaded from the decided record.
-/// The replay queue, every txid dropped this pass (for pool eviction), and the
-/// DESCENDANT exclusions to record against the decisions they were removed from.
-type ReplayPlan = (
-    VecDeque<consensus_state::DeferredDecision>,
-    HashSet<Txid>,
-    Vec<(u64, String, u64)>,
-);
-
 fn build_replay_queue(
     replayed: Vec<(consensus_state::DeferredDecision, Vec<bitcoin::Transaction>)>,
     survivors: Vec<(consensus_state::DeferredDecision, Vec<bitcoin::Transaction>)>,
     // Exclusions PER consensus height, already re-verified against the chain.
     applicable: &HashMap<u64, HashSet<String>>,
-) -> ReplayPlan {
+) -> (VecDeque<consensus_state::DeferredDecision>, HashSet<Txid>) {
     let replayed_heights: Vec<Height> = replayed.iter().map(|(d, _)| d.consensus_height).collect();
     let survivors: Vec<_> = survivors
         .into_iter()
@@ -232,7 +224,6 @@ fn build_replay_queue(
         .collect();
 
     let mut all_excluded: HashSet<Txid> = HashSet::new();
-    let mut closure_rows: Vec<(u64, String, u64)> = Vec::new();
     let mut queue = VecDeque::with_capacity(merged.len());
 
     for (mut decision, txs) in merged {
@@ -243,7 +234,6 @@ fn build_replay_queue(
         } = &decision.value
         {
             let (anchor_height, anchor_hash) = (*anchor_height, *anchor_hash);
-            let height = decision.consensus_height.as_u64();
             let mut kept = Vec::with_capacity(txs.len());
             for tx in &txs {
                 let txid = tx.compute_txid();
@@ -255,11 +245,17 @@ fn build_replay_queue(
                     .iter()
                     .any(|i| unavailable.contains(&i.previous_output.txid))
                 {
-                    // A descendant of a tx that is missing AT THIS POSITION — newly
-                    // discovered this pass, so record it: a later replay must not
-                    // have to rediscover it (and cannot skip it if it does not).
+                    // A descendant of a tx that is missing AT THIS POSITION. Dropped
+                    // in memory, deliberately NOT recorded in `excluded_batch_txids`:
+                    // a descendant's drop is only justified while its parent stays
+                    // excluded, and a durable row outlives that justification — the
+                    // read predicate re-checks the CHILD's confirmation, never the
+                    // parent's recovery, so a recorded child would stay dropped after
+                    // a reorg heals the parent while every fresh syncer executes it.
+                    // Re-deriving from the durable base rows each pass costs at most
+                    // one extra rollback (a leaked child re-arms its own deadline and
+                    // becomes a base row); a wrong durable drop is a divergence.
                     all_excluded.insert(txid);
-                    closure_rows.push((height, txid.to_string(), deadline_for(anchor_height)));
                     unavailable.insert(txid);
                 } else {
                     kept.push(tx.clone());
@@ -285,7 +281,7 @@ fn build_replay_queue(
         queue.push_back(decision);
     }
 
-    (queue, all_excluded, closure_rows)
+    (queue, all_excluded)
 }
 
 /// What `process_decided_batch` did with a decided batch. Callers must not
@@ -926,22 +922,8 @@ impl<E: Executor> Reactor<E> {
         let queued = std::mem::take(&mut self.consensus.deferred_decisions);
         let survivors = self.resolve_decisions(queued).await?;
 
-        let (queue, excluded, closure_rows) = build_replay_queue(replayed, survivors, &applicable);
+        let (queue, excluded) = build_replay_queue(replayed, survivors, &applicable);
         self.consensus.deferred_decisions = queue;
-
-        // The DESCENDANT closure, attributed to the decisions it actually removed
-        // from. Best-effort and post-truncation, unlike the base set written before
-        // the rollback: losing these degrades to one extra rollback pass (the base
-        // rows survive, so the next pass re-derives the same closure), never to a
-        // wrong execution.
-        if let Err(e) = insert_excluded_batch_txids(&self.db_conn(), &closure_rows).await {
-            warn!(
-                error = %e,
-                count = closure_rows.len(),
-                "Failed to record this pass's descendant exclusions; the next pass will \
-                 re-derive them"
-            );
-        }
 
         // The excluded txids must also leave the proposal pool, or the next
         // make_value re-proposes the very txs whose missing confirmations caused
@@ -1772,7 +1754,7 @@ mod tests {
         let unrelated = tx(&[OutPoint::null()], 3);
 
         let excluded = excl(&[(10, parent.compute_txid())]);
-        let (queue, closure, _) = build_replay_queue(
+        let (queue, closure) = build_replay_queue(
             vec![carrying(10, vec![parent.clone()])],
             vec![carrying(14, vec![child.clone(), unrelated.clone()])],
             &excluded,
@@ -1805,7 +1787,7 @@ mod tests {
         let kept = tx(&[OutPoint::null()], 3);
 
         let excluded = excl(&[(10, parent.compute_txid())]);
-        let (queue, _, _) = build_replay_queue(
+        let (queue, _) = build_replay_queue(
             vec![carrying(10, vec![parent.clone()])],
             vec![carrying(14, vec![child.clone(), kept.clone()])],
             &excluded,
@@ -1838,7 +1820,7 @@ mod tests {
         let child_b = tx(&[spend(&parent)], 3);
 
         let excluded = excl(&[(10, parent.compute_txid())]);
-        let (queue, _, _) = build_replay_queue(
+        let (queue, _) = build_replay_queue(
             vec![carrying(10, vec![parent.clone()])],
             vec![carrying(14, vec![child_a.clone(), child_b.clone()])],
             &excluded,
@@ -1867,7 +1849,7 @@ mod tests {
         let t = tx(&[OutPoint::null()], 1);
         let other = tx(&[OutPoint::null()], 2);
 
-        let (queue, _, _) = build_replay_queue(
+        let (queue, _) = build_replay_queue(
             vec![carrying(10, vec![t.clone()])],
             vec![carrying(14, vec![t.clone(), other.clone()])],
             &excl(&[(10, t.compute_txid())]),
@@ -1898,7 +1880,7 @@ mod tests {
         let parent = tx(&[OutPoint::null()], 1);
         let child = tx(&[spend(&parent)], 2);
 
-        let (queue, _, _) = build_replay_queue(
+        let (queue, _) = build_replay_queue(
             vec![carrying(10, vec![parent.clone()])],
             vec![
                 carrying(14, vec![parent.clone()]),
@@ -1923,7 +1905,7 @@ mod tests {
         let parent = tx(&[OutPoint::null()], 1);
         let child = tx(&[spend(&parent)], 2);
 
-        let (queue, _, closure_rows) = build_replay_queue(
+        let (queue, dropped) = build_replay_queue(
             vec![carrying(10, vec![parent.clone()])],
             vec![
                 carrying(14, vec![child.clone()]),
@@ -1937,12 +1919,7 @@ mod tests {
             "the child executes before the parent's re-decide rebuilds its output, \
              so it must drop"
         );
-        assert!(
-            closure_rows
-                .iter()
-                .any(|(h, t, _)| *h == 14 && t == &child.compute_txid().to_string()),
-            "and the drop must be recorded against the child's own decision"
-        );
+        assert!(dropped.contains(&child.compute_txid()));
         assert_eq!(
             queue[2].value.batch_raw_txs().len(),
             1,
@@ -1960,7 +1937,7 @@ mod tests {
         let parent = tx(&[OutPoint::null()], 1);
         let child = tx(&[spend(&parent)], 2);
 
-        let (queue, _, closure_rows) = build_replay_queue(
+        let (queue, dropped) = build_replay_queue(
             vec![
                 carrying(5, vec![child.clone()]),
                 carrying(10, vec![parent.clone()]),
@@ -1975,7 +1952,7 @@ mod tests {
             "the child ran before the parent in the original sequence, so the \
              parent's exclusion cannot retroactively orphan it"
         );
-        assert!(closure_rows.is_empty());
+        assert!(!dropped.contains(&child.compute_txid()));
     }
 
     /// A parent excluded at a height that is NOT in the queue was excluded below
@@ -1987,7 +1964,7 @@ mod tests {
         let parent = tx(&[OutPoint::null()], 1);
         let child = tx(&[spend(&parent)], 2);
 
-        let (queue, _, closure_rows) = build_replay_queue(
+        let (queue, dropped) = build_replay_queue(
             vec![carrying(10, vec![child.clone()])],
             Vec::new(),
             &excl(&[(3, parent.compute_txid())]),
@@ -1997,11 +1974,7 @@ mod tests {
             queue[0].value.batch_raw_txs().is_empty(),
             "the parent's exclusion below the replay window still orphans the child"
         );
-        assert!(
-            closure_rows
-                .iter()
-                .any(|(h, t, _)| *h == 10 && t == &child.compute_txid().to_string()),
-        );
+        assert!(dropped.contains(&child.compute_txid()));
     }
 
     /// A within-batch dependency chain collapses transitively from the excluded
@@ -2013,7 +1986,7 @@ mod tests {
         let grandchild = tx(&[spend(&child)], 3);
         let independent = tx(&[OutPoint::null()], 4);
 
-        let (queue, excluded, _) = build_replay_queue(
+        let (queue, excluded) = build_replay_queue(
             vec![carrying(
                 10,
                 vec![
@@ -2053,7 +2026,7 @@ mod tests {
         let parent = tx(&[OutPoint::null()], 1);
         let child = tx(&[spend(&parent)], 2);
 
-        let (queue, _, closure_rows) = build_replay_queue(
+        let (queue, dropped) = build_replay_queue(
             vec![carrying(10, vec![parent.clone()])],
             vec![carrying(14, vec![child.clone()])],
             &excl(&[(10, parent.compute_txid())]),
@@ -2063,13 +2036,7 @@ mod tests {
             queue[1].value.batch_raw_txs().is_empty(),
             "a descendant of an excluded, otherwise-absent parent must not execute"
         );
-        assert!(
-            closure_rows
-                .iter()
-                .any(|(h, t, _)| *h == 14 && t == &child.compute_txid().to_string()),
-            "and the closure must be RECORDED against the height it was removed from, \
-             so a later pass does not have to rediscover it"
-        );
+        assert!(dropped.contains(&child.compute_txid()));
     }
 
     /// An unmarked decision is untouched — the record-only case, which has certified
@@ -2078,13 +2045,13 @@ mod tests {
     fn build_replay_queue_leaves_an_unmarked_decision_intact() {
         let a = tx(&[OutPoint::null()], 1);
         let b = tx(&[OutPoint::null()], 2);
-        let (queue, excluded, rows) = build_replay_queue(
+        let (queue, excluded) = build_replay_queue(
             vec![carrying(10, vec![a.clone(), b.clone()])],
             Vec::new(),
             &HashMap::new(),
         );
         assert_eq!(queue[0].value.batch_raw_txs().len(), 2);
-        assert!(excluded.is_empty() && rows.is_empty());
+        assert!(excluded.is_empty());
     }
 
     /// Narrowing must not destroy the EXCLUDED transactions' bodies.
@@ -2104,7 +2071,7 @@ mod tests {
         let kept = tx(&[OutPoint::null()], 3);
 
         let excluded = excl(&[(10, parent.compute_txid())]);
-        let (queue, _, _) = build_replay_queue(
+        let (queue, _) = build_replay_queue(
             vec![carrying(10, vec![parent.clone()])],
             vec![carrying(14, vec![child.clone(), kept.clone()])],
             &excluded,
@@ -2149,7 +2116,7 @@ mod tests {
 
         // Pass two excludes `second`.
         let excluded = excl(&[(14, second.compute_txid())]);
-        let (queue, _, _) = build_replay_queue(
+        let (queue, _) = build_replay_queue(
             Vec::new(),
             vec![(decision, vec![second.clone(), survivor_tx.clone()])],
             &excluded,
@@ -2172,7 +2139,7 @@ mod tests {
     #[test]
     fn build_replay_queue_leaves_certified_txs_unset_when_nothing_is_filtered() {
         let a = tx(&[OutPoint::null()], 1);
-        let (queue, _, _) = build_replay_queue(
+        let (queue, _) = build_replay_queue(
             vec![carrying(10, vec![a.clone()])],
             Vec::new(),
             &HashMap::new(),

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -244,10 +244,16 @@ fn build_replay_queue(
             } = &decision.value
             {
                 let (anchor_height, anchor_hash) = (*anchor_height, *anchor_hash);
+                let decided: Vec<Txid> = txs.iter().map(|tx| tx.compute_txid()).collect();
                 let kept: Vec<bitcoin::Transaction> = txs
                     .into_iter()
                     .filter(|tx| !excluded.contains(&tx.compute_txid()))
                     .collect();
+                // Narrowing what we execute must not narrow what we record as
+                // decided — see `DeferredDecision::certified_txids`.
+                if kept.len() != decided.len() {
+                    decision.certified_txids = Some(decided);
+                }
                 decision.value = Value::new_batch_raw(anchor_height, anchor_hash, kept);
             }
             decision
@@ -299,16 +305,32 @@ impl<E: Executor> Reactor<E> {
     /// consensus height) and the raw txs (`unconfirmed_batch_txs`, what
     /// replay and unfinalized-batch sync resolve from). Written for executed
     /// AND record-only batches — the certificate covers both.
+    ///
+    /// The two tables take DIFFERENT lists when a rollback has narrowed this
+    /// batch. `batch_txids` records what consensus DECIDED (`certified`, when the
+    /// caller has it), because a syncing peer re-derives the exclusions itself and
+    /// needs the full list to match the certificate. `unconfirmed_batch_txs` records
+    /// only what we still HOLD — an excluded transaction was dropped precisely
+    /// because it never confirmed, so there is no raw transaction to serve.
+    ///
+    /// Note `insert_batch_txids` is `INSERT OR IGNORE` on `(batch_height, position)`,
+    /// which protects an already-complete list from being overwritten — but only
+    /// where rows already exist. A node where this batch was never executed has
+    /// none, so what we pass here is what becomes the record.
     async fn record_batch_txs(
         &self,
         conn: &libsql::Connection,
         consensus_height: Height,
         batch_txs: &[bitcoin::Transaction],
+        certified: Option<&[Txid]>,
     ) -> Result<()> {
-        let txids: Vec<String> = batch_txs
-            .iter()
-            .map(|tx| tx.compute_txid().to_string())
-            .collect();
+        let txids: Vec<String> = match certified {
+            Some(decided) => decided.iter().map(|t| t.to_string()).collect(),
+            None => batch_txs
+                .iter()
+                .map(|tx| tx.compute_txid().to_string())
+                .collect(),
+        };
         insert_batch_txids(conn, consensus_height.as_u64(), &txids)
             .await
             .context("Failed to insert batch txids")?;
@@ -334,6 +356,9 @@ impl<E: Executor> Reactor<E> {
         consensus_height: Height,
         certificate: &[u8],
         batch_txs: &[bitcoin::Transaction],
+        // The DECIDED txid list, when a rollback exclusion has narrowed
+        // `batch_txs`. Recorded instead of the executed set — see `record_batch_txs`.
+        certified: Option<&[Txid]>,
     ) -> Result<BatchOutcome> {
         let started_at = Instant::now();
         let conn = self.db_conn();
@@ -410,7 +435,7 @@ impl<E: Executor> Reactor<E> {
             // Persist the certified content too (idempotent): a skipped batch
             // must still be servable to syncing peers with its real txs, and
             // the batch_txids/unconfirmed rows are what the sync path reads.
-            self.record_batch_txs(&conn, consensus_height, batch_txs)
+            self.record_batch_txs(&conn, consensus_height, batch_txs, certified)
                 .await?;
             return Ok(BatchOutcome::RecordedOnly);
         }
@@ -458,7 +483,7 @@ impl<E: Executor> Reactor<E> {
         .context("Failed to insert batch")?;
 
         // Store the certified txid list + raw txs for replay/sync recovery
-        self.record_batch_txs(&conn, consensus_height, batch_txs)
+        self.record_batch_txs(&conn, consensus_height, batch_txs, certified)
             .await?;
 
         for t in &parsed_txs {
@@ -1101,6 +1126,7 @@ impl<E: Executor> Reactor<E> {
                             decision.consensus_height,
                             &decision.certificate,
                             &resolved_txs,
+                            decision.certified_txids.as_deref(),
                         )
                         .await
                         .context("process_decided_batch failed in deferred drain")?;
@@ -1231,6 +1257,7 @@ impl<E: Executor> Reactor<E> {
                                 consensus_height: certificate.height,
                                 value: proposal.value.clone(),
                                 certificate: cert_bytes,
+                                certified_txids: None,
                             },
                         );
                     } else {
@@ -1245,6 +1272,8 @@ impl<E: Executor> Reactor<E> {
                                 certificate.height,
                                 &cert_bytes,
                                 &full_txs,
+                                // Freshly decided — never narrowed by a replay.
+                                None,
                             )
                             .await
                             .context("process_decided_batch failed in Finalized handler")?;
@@ -1271,6 +1300,7 @@ impl<E: Executor> Reactor<E> {
                                 consensus_height: certificate.height,
                                 value: proposal.value.clone(),
                                 certificate: cert_bytes.clone(),
+                                certified_txids: None,
                             },
                         );
                     } else {
@@ -1290,6 +1320,7 @@ impl<E: Executor> Reactor<E> {
                                     consensus_height: certificate.height,
                                     value: proposal.value.clone(),
                                     certificate: cert_bytes.clone(),
+                                    certified_txids: None,
                                 },
                             );
                         } else {
@@ -1304,6 +1335,7 @@ impl<E: Executor> Reactor<E> {
                                     consensus_height: certificate.height,
                                     value: proposal.value.clone(),
                                     certificate: cert_bytes.clone(),
+                                    certified_txids: None,
                                 },
                                 *height,
                                 *hash,
@@ -1476,6 +1508,7 @@ mod tests {
             consensus_height: Height::new(consensus_height),
             value: Value::new_batch_raw(0, bitcoin::BlockHash::all_zeros(), vec![]),
             certificate: Vec::new(),
+            certified_txids: None,
         }
     }
 
@@ -1536,6 +1569,52 @@ mod tests {
             "survivor must keep only the unrelated tx, got {survivor_txs:?}"
         );
         assert_eq!(survivor_txs[0].compute_txid(), unrelated.compute_txid());
+    }
+
+    /// Filtering must narrow what we EXECUTE without losing what was DECIDED.
+    ///
+    /// `batch_txids` records consensus's decision, and a peer syncing that height
+    /// re-derives the exclusions itself by applying the same deadline rules — so it
+    /// needs the full list. A node where this batch was a survivor has no rows yet,
+    /// so whatever it records lands as if certified; recording the narrowed list
+    /// would leave it serving a value that no longer matches its own certificate.
+    #[test]
+    fn build_replay_queue_preserves_the_decided_txids_when_it_filters() {
+        let parent = tx(&[OutPoint::null()], 1);
+        let child = tx(&[spend(&parent)], 2);
+        let kept = tx(&[OutPoint::null()], 3);
+
+        let excluded: HashSet<Txid> = [parent.compute_txid()].into();
+        let (queue, _) = build_replay_queue(
+            vec![carrying(10, vec![parent.clone()])],
+            vec![carrying(14, vec![child.clone(), kept.clone()])],
+            &excluded,
+        );
+
+        let survivor = &queue[1];
+        assert_eq!(
+            survivor.value.batch_raw_txs().len(),
+            1,
+            "the descendant must not execute"
+        );
+        assert_eq!(
+            survivor.certified_txids.as_deref(),
+            Some(&[child.compute_txid(), kept.compute_txid()][..]),
+            "the DECIDED list must be preserved in full for the record"
+        );
+    }
+
+    /// Nothing excluded means nothing to preserve — the value is already the
+    /// decided content and a redundant copy would just be a second answer.
+    #[test]
+    fn build_replay_queue_leaves_certified_txids_unset_when_nothing_is_filtered() {
+        let a = tx(&[OutPoint::null()], 1);
+        let (queue, _) = build_replay_queue(
+            vec![carrying(10, vec![a.clone()])],
+            Vec::new(),
+            &HashSet::new(),
+        );
+        assert!(queue[0].certified_txids.is_none());
     }
 
     /// A queued decision BELOW the replay set's max must SURVIVE. Anchors go

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -14,9 +14,7 @@ use prost::Message;
 use tracing::{info, warn};
 
 use crate::consensus::codec::encode_commit_certificate;
-use crate::consensus::finality_types::{
-    DecidedBatch, FINALITY_WINDOW, StateEvent, UnfinalizedBatch,
-};
+use crate::consensus::finality_types::{DecidedBatch, StateEvent, UnfinalizedBatch, deadline_for};
 use crate::consensus::{CommitCertificate, Ctx, Height, ProposalData, Value};
 use crate::database::queries::{
     insert_batch, insert_batch_txids, insert_transaction, insert_unconfirmed_batch_tx,
@@ -190,6 +188,31 @@ pub(super) enum BatchOutcome {
     RecordedOnly,
 }
 
+impl BatchOutcome {
+    /// The txids to announce as processed for this outcome.
+    ///
+    /// An exhaustive match rather than `== Executed` at each call site: a future
+    /// variant added without revisiting them would silently take the "nothing
+    /// happened" branch, dropping the `BatchProcessed` heartbeat that drives the
+    /// info publisher and therefore API availability.
+    fn announced_txids(&self, batch_txs: &[bitcoin::Transaction]) -> Option<Vec<String>> {
+        match self {
+            BatchOutcome::Executed => Some(
+                batch_txs
+                    .iter()
+                    .map(|tx| tx.compute_txid().to_string())
+                    .collect(),
+            ),
+            // Empty batches still announce (with no txids): BatchProcessed is the
+            // "chain moved" heartbeat, and on a quiet chain empty deadline batches
+            // are the only events produced. A non-empty record-only skip stays
+            // silent — nothing executed, and claiming otherwise is the audit bug.
+            BatchOutcome::RecordedOnly if batch_txs.is_empty() => Some(Vec::new()),
+            BatchOutcome::RecordedOnly => None,
+        }
+    }
+}
+
 impl<E: Executor> Reactor<E> {
     /// Persist a decided batch's certified content, idempotently: the
     /// immutable txid list (`batch_txids`, what sync serves for this
@@ -334,7 +357,7 @@ impl<E: Executor> Reactor<E> {
             anchor_height,
             anchor_hash,
             txids,
-            deadline: anchor_height + FINALITY_WINDOW,
+            deadline: deadline_for(anchor_height),
         });
 
         self.runtime
@@ -712,6 +735,20 @@ impl<E: Executor> Reactor<E> {
                 self.consensus.pending_transactions.remove(txid);
             }
         }
+        // SPLICE, don't assign. The replay set comes from `select_batches_from_anchor`,
+        // which only returns heights that already have a `batches` row — but a queued
+        // decision is queued precisely BECAUSE its anchor was unprocessed, so it has
+        // no row yet. Overwriting the queue drops it permanently: `current_height` has
+        // already advanced past it and `delete_unexecuted_batch_suffix` can only trim
+        // a suffix, so the gap is unrefillable locally or by sync. Survivors keep
+        // their order and follow the replayed set, which is strictly below them.
+        let last_replayed = deferred.back().map(|d| d.consensus_height);
+        let survivors: Vec<consensus_state::DeferredDecision> =
+            std::mem::take(&mut self.consensus.deferred_decisions)
+                .into_iter()
+                .filter(|d| last_replayed.is_none_or(|last| d.consensus_height > last))
+                .collect();
+        deferred.extend(survivors);
         self.consensus.deferred_decisions = deferred;
         self.consensus
             .unfinalized_batches
@@ -726,6 +763,86 @@ impl<E: Executor> Reactor<E> {
             .await
             .context("Failed to send replay request")?;
         Ok(())
+    }
+
+    /// Apply everything the current tip makes possible: drain decisions that were
+    /// waiting on it, then settle any finality deadline it crossed, repeating while
+    /// a rollback keeps changing the tip.
+    ///
+    /// The single funnel for a RISING `last_height`. Previously the finality check
+    /// hung off one arm of the consensus-message handler, so a node whose tip
+    /// advanced any other way — notably a lagging node receiving blocks via
+    /// `BlockEvent::BlockInsert` — walked past deadlines without ever evaluating
+    /// them, and diverged from peers that did. Routing both call sites through here
+    /// makes "the tip never moves without a finality check" structural rather than
+    /// something each call site has to remember.
+    ///
+    /// Terminates: a rollback moves `last_height` strictly BELOW every deadline it
+    /// just settled, so the next pass has strictly fewer at-deadline batches.
+    pub(super) async fn advance(&mut self) -> Result<()> {
+        loop {
+            self.drain_deferred_decisions()
+                .await
+                .context("drain_deferred_decisions failed")?;
+            if !self.settle_finality().await? {
+                return Ok(());
+            }
+        }
+    }
+
+    /// Whether any tracked batch has reached its deadline at the current tip.
+    /// In-memory, bounded by the batches decided inside one finality window — no
+    /// database work on the per-block path.
+    fn finality_due(&self) -> bool {
+        self.consensus
+            .unfinalized_batches
+            .iter()
+            .any(|b| b.deadline <= self.last_height)
+    }
+
+    /// Run finality checks if any deadline has passed, performing the rollback and
+    /// replay they demand. Returns whether a rollback happened (so `advance` knows
+    /// the tip moved and it must drain again).
+    async fn settle_finality(&mut self) -> Result<bool> {
+        if !self.finality_due() {
+            return Ok(false);
+        }
+        let conn = self.db_conn();
+        let Some((rollback_anchor, excluded)) = self
+            .consensus
+            .run_finality_checks(&conn, self.last_height)
+            .await
+        else {
+            return Ok(false);
+        };
+
+        // Read replay decisions BEFORE the truncation — the query joins rows that
+        // are cascade-deleted with their blocks.
+        let replay = self
+            .load_replay_decisions(rollback_anchor)
+            .await
+            .context("load_replay_decisions failed")?;
+
+        // Roll back to before the invalid anchor so all state at the anchor height
+        // (including the invalid txs' effects) is wiped cleanly.
+        self.rollback(rollback_anchor.saturating_sub(1))
+            .await
+            .context("rollback failed during finality rollback")?;
+
+        // Fallible raw-tx resolution/filtering only after the truncation is durable:
+        // a failure here must not cancel a rollback finality already demanded.
+        self.prepare_replay(rollback_anchor, replay, excluded)
+            .await
+            .context("prepare_replay failed")?;
+
+        let checkpoint = self.consensus.get_checkpoint(&conn).await;
+        self.consensus
+            .emit_state_event(StateEvent::RollbackExecuted {
+                to_anchor: rollback_anchor,
+                entries_removed: 0,
+                checkpoint,
+            });
+        Ok(true)
     }
 
     pub(super) async fn drain_deferred_decisions(&mut self) -> Result<()> {
@@ -834,28 +951,11 @@ impl<E: Executor> Reactor<E> {
                             )
                             .await
                             .context("process_decided_batch failed in deferred drain")?;
-                        // Executed batches announce their txids; EMPTY batches
-                        // announce with no txids — BatchProcessed is the
-                        // "chain moved" heartbeat the info publisher (and so
-                        // API availability) is driven by, and empty deadline
-                        // batches are the only events a quiet chain produces.
-                        // Only a non-empty record-only skip stays silent:
-                        // nothing executed, and claiming its txids were
-                        // processed is exactly the audit bug.
-                        if (outcome == BatchOutcome::Executed || resolved_txs.is_empty())
+                        if let Some(txids) = outcome.announced_txids(&resolved_txs)
                             && let Some(tx) = &self.event_tx
+                            && tx.send(Event::BatchProcessed { txids }).await.is_err()
                         {
-                            let txids: Vec<String> = if outcome == BatchOutcome::Executed {
-                                resolved_txs
-                                    .iter()
-                                    .map(|tx| tx.compute_txid().to_string())
-                                    .collect()
-                            } else {
-                                Vec::new()
-                            };
-                            if tx.send(Event::BatchProcessed { txids }).await.is_err() {
-                                warn!("Event receiver dropped, cannot send BatchProcessed event");
-                            }
+                            warn!("Event receiver dropped, cannot send BatchProcessed event");
                         }
                     } else {
                         info!(
@@ -1005,23 +1105,8 @@ impl<E: Executor> Reactor<E> {
                             )
                             .await
                             .context("process_decided_batch failed in Finalized handler")?;
-                        // Executed batches announce their txids; EMPTY batches
-                        // announce with no txids — BatchProcessed is the "chain
-                        // moved" heartbeat driving the info publisher and
-                        // therefore API availability, and empty deadline
-                        // batches are the only events a quiet chain produces.
-                        // Only a non-empty record-only skip stays silent.
-                        if outcome == BatchOutcome::Executed || full_txs.is_empty() {
-                            result = consensus_state::ConsensusResult::BatchProcessed {
-                                txids: if outcome == BatchOutcome::Executed {
-                                    full_txs
-                                        .iter()
-                                        .map(|tx| tx.compute_txid().to_string())
-                                        .collect()
-                                } else {
-                                    Vec::new()
-                                },
-                            };
+                        if let Some(txids) = outcome.announced_txids(&full_txs) {
+                            result = consensus_state::ConsensusResult::BatchProcessed { txids };
                         }
                     }
                 }

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -886,6 +886,13 @@ impl<E: Executor> Reactor<E> {
 
         // Roll back to before the invalid anchor so all state at the anchor height
         // (including the invalid txs' effects) is wiped cleanly.
+        //
+        // Depth-checked like the reorg path. Rehydration can re-arm a deadline whose
+        // anchor sits far below the tip — that is exactly the #515 residue this PR
+        // exists to pick up — and truncating below the prune watermark would destroy
+        // state rather than restore it. Halting for a re-sync is the intended outcome.
+        self.check_rollback_depth(rollback_anchor.saturating_sub(1))
+            .context("finality rollback too deep")?;
         self.rollback(rollback_anchor.saturating_sub(1))
             .await
             .context("rollback failed during finality rollback")?;

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -177,6 +177,17 @@ pub(super) fn batch_is_ordered(txs: &[bitcoin::Transaction]) -> bool {
     true
 }
 
+/// Put batches held during a drain pass back at the FRONT of the queue, in their
+/// original order, so nothing is reordered relative to what follows them.
+fn restore_waiting(
+    queue: &mut VecDeque<consensus_state::DeferredDecision>,
+    waiting: &mut VecDeque<consensus_state::DeferredDecision>,
+) {
+    while let Some(decision) = waiting.pop_back() {
+        queue.push_front(decision);
+    }
+}
+
 /// Merge a rollback's replay set with the decisions already queued, ordered by
 /// consensus height.
 ///
@@ -875,6 +886,19 @@ impl<E: Executor> Reactor<E> {
     }
 
     pub(super) async fn drain_deferred_decisions(&mut self) -> Result<()> {
+        // Batches whose anchor block has not arrived yet. Held ASIDE rather than
+        // stopping the drain: a waiting batch can only ever be unblocked by a
+        // block, and the block decisions that would deliver it sit behind it in
+        // this same queue — so parking on one could stall the very thing it waits
+        // for. Restored to the front, in order, whenever a block executes and at
+        // exit, so a batch is re-evaluated the moment its anchor lands.
+        //
+        // Batches are never reordered relative to each other: once one is held,
+        // later ones are held unevaluated. And the tip can never overshoot a held
+        // anchor, because blocks apply strictly sequentially — the only block that
+        // can execute is `tip + 1`, while a held batch waits for `anchor > tip`.
+        let mut waiting: VecDeque<consensus_state::DeferredDecision> = VecDeque::new();
+
         loop {
             let cs = &mut self.consensus;
             let Some(decision) = cs.deferred_decisions.pop_front() else {
@@ -918,6 +942,8 @@ impl<E: Executor> Reactor<E> {
                         self.handle_block_with_decision(block, &decision)
                             .await
                             .context("handle_block_with_decision failed in deferred drain")?;
+                        // The tip moved — anything held may now be ready.
+                        restore_waiting(&mut self.consensus.deferred_decisions, &mut waiting);
                     } else {
                         // No pending block at this height. Before parking the
                         // queue on it, check whether the height was already
@@ -960,46 +986,45 @@ impl<E: Executor> Reactor<E> {
                     txs,
                     ..
                 } => {
-                    if *anchor_height <= self.last_height {
-                        info!(
-                            anchor_height = *anchor_height,
-                            consensus_height = %decision.consensus_height,
-                            num_txs = txs.len(),
-                            "Draining deferred batch decision"
-                        );
-                        let anchor_height = *anchor_height;
-                        let anchor_hash = *anchor_hash;
-                        let resolved_txs = self.resolve_batch_txs(txs).await?;
-                        let outcome = self
-                            .process_decided_batch(
-                                anchor_height,
-                                anchor_hash,
-                                decision.consensus_height,
-                                &decision.certificate,
-                                &resolved_txs,
-                            )
-                            .await
-                            .context("process_decided_batch failed in deferred drain")?;
-                        if let Some(txids) = outcome.announced_txids(&resolved_txs)
-                            && let Some(tx) = &self.event_tx
-                            && tx.send(Event::BatchProcessed { txids }).await.is_err()
-                        {
-                            warn!("Event receiver dropped, cannot send BatchProcessed event");
-                        }
-                    } else {
+                    if !waiting.is_empty() || *anchor_height > self.last_height {
                         info!(
                             anchor_height = *anchor_height,
                             last_height = self.last_height,
                             consensus_height = %decision.consensus_height,
-                            "Deferred batch still waiting for anchor"
+                            "Deferred batch still waiting for anchor — holding aside"
                         );
-                        let cs = &mut self.consensus;
-                        cs.deferred_decisions.push_front(decision);
-                        break;
+                        waiting.push_back(decision);
+                        continue;
+                    }
+                    info!(
+                        anchor_height = *anchor_height,
+                        consensus_height = %decision.consensus_height,
+                        num_txs = txs.len(),
+                        "Draining deferred batch decision"
+                    );
+                    let anchor_height = *anchor_height;
+                    let anchor_hash = *anchor_hash;
+                    let resolved_txs = self.resolve_batch_txs(txs).await?;
+                    let outcome = self
+                        .process_decided_batch(
+                            anchor_height,
+                            anchor_hash,
+                            decision.consensus_height,
+                            &decision.certificate,
+                            &resolved_txs,
+                        )
+                        .await
+                        .context("process_decided_batch failed in deferred drain")?;
+                    if let Some(txids) = outcome.announced_txids(&resolved_txs)
+                        && let Some(tx) = &self.event_tx
+                        && tx.send(Event::BatchProcessed { txids }).await.is_err()
+                    {
+                        warn!("Event receiver dropped, cannot send BatchProcessed event");
                     }
                 }
             }
         }
+        restore_waiting(&mut self.consensus.deferred_decisions, &mut waiting);
         Ok(())
     }
 
@@ -1220,7 +1245,10 @@ impl<E: Executor> Reactor<E> {
 
 #[cfg(test)]
 mod tests {
-    use super::{batch_is_ordered, dependency_sort, merge_replay_queue, transitive_exclusion};
+    use super::{
+        batch_is_ordered, dependency_sort, merge_replay_queue, restore_waiting,
+        transitive_exclusion,
+    };
     use crate::consensus::{Height, Value};
     use crate::reactor::consensus_state::DeferredDecision;
     use bitcoin::absolute::LockTime;
@@ -1421,6 +1449,29 @@ mod tests {
             vec![3]
         );
         assert!(merge_replay_queue(VecDeque::new(), VecDeque::new()).is_empty());
+    }
+
+    /// Batches held during a drain pass go back at the FRONT, in their original
+    /// order. Anything still queued behind them was already ordered after them, so
+    /// restoring out of order — or after the queue instead of before it — would
+    /// reorder decisions relative to each other.
+    #[test]
+    fn restore_waiting_puts_held_batches_back_in_front_in_order() {
+        let mut queue: VecDeque<_> = [decision(30), decision(31)].into();
+        let mut waiting: VecDeque<_> = [decision(10), decision(11), decision(12)].into();
+
+        restore_waiting(&mut queue, &mut waiting);
+
+        assert_eq!(heights(&queue), vec![10, 11, 12, 30, 31]);
+        assert!(waiting.is_empty(), "held set must be drained");
+    }
+
+    #[test]
+    fn restore_waiting_is_a_noop_when_nothing_was_held() {
+        let mut queue: VecDeque<_> = [decision(7)].into();
+        let mut waiting: VecDeque<_> = VecDeque::new();
+        restore_waiting(&mut queue, &mut waiting);
+        assert_eq!(heights(&queue), vec![7]);
     }
 
     #[test]

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -105,44 +105,6 @@ fn dependency_sort(txs: &[bitcoin::Transaction]) -> Vec<usize> {
     ordered
 }
 
-/// Expand a set of excluded txids to every batch tx that (transitively) spends
-/// an excluded tx's output. Rollback replay filters excluded txids out of
-/// replayed batches; dropping a parent while keeping its child would execute
-/// the child against missing UTXOs and commit its deterministic failure —
-/// silent state divergence (#427). Operates over the ordered replay sequence,
-/// since a child may sit in a later batch than its parent. Iterates the
-/// forward pass to a true fixed point rather than assuming parents always
-/// precede children across batches — decided order makes that overwhelmingly
-/// likely, but no consensus rule ENFORCES the cross-batch direction, and the
-/// loop costs one extra no-growth pass in the normal case.
-fn transitive_exclusion(
-    batches: &[Vec<bitcoin::Transaction>],
-    excluded: &HashSet<Txid>,
-) -> HashSet<Txid> {
-    let mut excluded = excluded.clone();
-    loop {
-        let before = excluded.len();
-        for txs in batches {
-            for tx in txs {
-                let txid = tx.compute_txid();
-                if excluded.contains(&txid) {
-                    continue;
-                }
-                if tx
-                    .input
-                    .iter()
-                    .any(|i| excluded.contains(&i.previous_output.txid))
-                {
-                    excluded.insert(txid);
-                }
-            }
-        }
-        if excluded.len() == before {
-            return excluded;
-        }
-    }
-}
-
 /// Check that a batch's transactions are in a valid dependency order:
 /// every tx that spends another batch tx's output appears *after* that
 /// producer.
@@ -242,33 +204,31 @@ fn build_replay_queue(
             .is_some_and(|s| s.contains(&txid.to_string()))
     };
 
-    // A txid KEPT by any decision in this queue must not seed the descendant closure.
-    // It is executing legitimately somewhere — excluded from one height but re-decided
-    // at another against a fresh deadline — so treating it as excluded would strip its
-    // children from batches that should run them.
-    let kept_anywhere: HashSet<Txid> = merged
+    // Outputs the ORIGINAL execution had produced by each queue position that this
+    // replay will NOT have: every excluded tx, from the position it was dropped at,
+    // until (if ever) a later decision re-decides and keeps it. The queue order IS
+    // the execution order, so availability is a positional fact, not a global one:
+    //
+    // - A keep re-creates the parent's outputs only from its own position onward.
+    //   A child sitting BETWEEN an excluded parent and its re-decided copy executes
+    //   before the parent is rebuilt, so it drops — an order-blind "kept anywhere"
+    //   guard let exactly that child through (#427 through the re-decide door).
+    // - Conversely, a child ordered BEFORE its parent's position never saw the
+    //   parent's effects in the original execution either, so it keeps; the replay
+    //   reproduces the original sequence position by position.
+    //
+    // Exclusions recorded at heights not in this queue happened below `from_anchor`
+    // — before every position here — so they are unavailable from the start: the
+    // rollback wiped the parent's effects and nothing in the queue rebuilds them
+    // (#427's original shape).
+    let queued_heights: HashSet<u64> = merged
         .iter()
-        .flat_map(|(d, txs)| {
-            txs.iter()
-                .filter(move |t| !dropped_at(d, &t.compute_txid()))
-        })
-        .map(|t| t.compute_txid())
+        .map(|(d, _)| d.consensus_height.as_u64())
         .collect();
-
-    let seed: HashSet<Txid> = applicable
-        .values()
-        .flatten()
-        .filter_map(|t| t.parse::<Txid>().ok())
-        .filter(|t| !kept_anywhere.contains(t))
-        .collect();
-
-    // Descendants only — the seed itself is already handled per decision above, and
-    // folding it back in would re-globalise exactly what the per-height scope fixes.
-    let batches: Vec<Vec<bitcoin::Transaction>> =
-        merged.iter().map(|(_, txs)| txs.clone()).collect();
-    let descendants: HashSet<Txid> = transitive_exclusion(&batches, &seed)
-        .difference(&seed)
-        .copied()
+    let mut unavailable: HashSet<Txid> = applicable
+        .iter()
+        .filter(|(height, _)| !queued_heights.contains(height))
+        .flat_map(|(_, txids)| txids.iter().filter_map(|t| t.parse::<Txid>().ok()))
         .collect();
 
     let mut all_excluded: HashSet<Txid> = HashSet::new();
@@ -289,13 +249,23 @@ fn build_replay_queue(
                 let txid = tx.compute_txid();
                 if dropped_at(&decision, &txid) {
                     all_excluded.insert(txid);
-                } else if descendants.contains(&txid) {
-                    // Newly discovered this pass — record it so a later replay does
-                    // not have to rediscover it (and cannot skip it if it does not).
+                    unavailable.insert(txid);
+                } else if tx
+                    .input
+                    .iter()
+                    .any(|i| unavailable.contains(&i.previous_output.txid))
+                {
+                    // A descendant of a tx that is missing AT THIS POSITION — newly
+                    // discovered this pass, so record it: a later replay must not
+                    // have to rediscover it (and cannot skip it if it does not).
                     all_excluded.insert(txid);
                     closure_rows.push((height, txid.to_string(), deadline_for(anchor_height)));
+                    unavailable.insert(txid);
                 } else {
                     kept.push(tx.clone());
+                    // A re-decided copy of a previously excluded tx: from here on
+                    // its outputs exist again, so later children survive.
+                    unavailable.remove(&txid);
                 }
             }
             // Narrowing what we execute must not narrow what we record as decided —
@@ -1654,10 +1624,7 @@ impl<E: Executor> Reactor<E> {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        batch_is_ordered, build_replay_queue, dependency_sort, restore_waiting,
-        transitive_exclusion,
-    };
+    use super::{batch_is_ordered, build_replay_queue, dependency_sort, restore_waiting};
     use crate::consensus::{Height, Value};
     use crate::reactor::consensus_state::DeferredDecision;
     use bitcoin::absolute::LockTime;
@@ -1744,40 +1711,6 @@ mod tests {
         let b = tx(&[OutPoint::null()], 2);
         let c = tx(&[OutPoint::null()], 3);
         assert_eq!(dependency_sort(&[a, b, c]), vec![0, 1, 2]);
-    }
-
-    #[test]
-    fn transitive_exclusion_drops_descendants_within_a_batch() {
-        let parent = tx(&[OutPoint::null()], 1);
-        let child = tx(&[spend(&parent)], 2);
-        let grandchild = tx(&[spend(&child)], 3);
-        let independent = tx(&[OutPoint::null()], 4);
-
-        let excluded: HashSet<Txid> = [parent.compute_txid()].into();
-        let batch = vec![
-            parent.clone(),
-            child.clone(),
-            grandchild.clone(),
-            independent.clone(),
-        ];
-        let result = transitive_exclusion(&[batch], &excluded);
-
-        assert!(result.contains(&parent.compute_txid()));
-        assert!(result.contains(&child.compute_txid()));
-        assert!(result.contains(&grandchild.compute_txid()));
-        assert!(!result.contains(&independent.compute_txid()));
-    }
-
-    #[test]
-    fn transitive_exclusion_crosses_batch_boundaries() {
-        let parent = tx(&[OutPoint::null()], 1);
-        let child = tx(&[spend(&parent)], 2);
-        let excluded: HashSet<Txid> = [parent.compute_txid()].into();
-
-        // Parent in batch 0, child in batch 1 — the closure must follow the
-        // dependency across the replay sequence.
-        let result = transitive_exclusion(&[vec![parent.clone()], vec![child.clone()]], &excluded);
-        assert!(result.contains(&child.compute_txid()));
     }
 
     /// Decisions are identified by consensus height, not by position.
@@ -1980,9 +1913,141 @@ mod tests {
         );
     }
 
+    /// The keep guard is POSITIONAL. A parent excluded at one height and re-decided
+    /// at a LATER queue position only re-creates its outputs from that position
+    /// onward — a child sitting BETWEEN the exclusion and the re-decide executes
+    /// before the parent is rebuilt, so it must still drop (#427). An order-blind
+    /// "kept anywhere" guard let exactly this child through.
+    #[test]
+    fn build_replay_queue_drops_a_child_ordered_before_its_parents_re_decide() {
+        let parent = tx(&[OutPoint::null()], 1);
+        let child = tx(&[spend(&parent)], 2);
+
+        let (queue, _, closure_rows) = build_replay_queue(
+            vec![carrying(10, vec![parent.clone()])],
+            vec![
+                carrying(14, vec![child.clone()]),
+                carrying(20, vec![parent.clone()]),
+            ],
+            &excl(&[(10, parent.compute_txid())]),
+        );
+
+        assert!(
+            queue[1].value.batch_raw_txs().is_empty(),
+            "the child executes before the parent's re-decide rebuilds its output, \
+             so it must drop"
+        );
+        assert!(
+            closure_rows
+                .iter()
+                .any(|(h, t, _)| *h == 14 && t == &child.compute_txid().to_string()),
+            "and the drop must be recorded against the child's own decision"
+        );
+        assert_eq!(
+            queue[2].value.batch_raw_txs().len(),
+            1,
+            "the re-decided parent itself still executes at its own height"
+        );
+    }
+
+    /// The positional rule cuts the other way too: a child ordered BEFORE its
+    /// parent's position never saw the parent's effects in the ORIGINAL execution
+    /// either (the parent had not run yet), so the replay must reproduce that and
+    /// keep it. Dropping it would diverge from every node that executed the
+    /// original sequence.
+    #[test]
+    fn build_replay_queue_keeps_a_child_ordered_before_its_parents_exclusion() {
+        let parent = tx(&[OutPoint::null()], 1);
+        let child = tx(&[spend(&parent)], 2);
+
+        let (queue, _, closure_rows) = build_replay_queue(
+            vec![
+                carrying(5, vec![child.clone()]),
+                carrying(10, vec![parent.clone()]),
+            ],
+            Vec::new(),
+            &excl(&[(10, parent.compute_txid())]),
+        );
+
+        assert_eq!(
+            queue[0].value.batch_raw_txs().len(),
+            1,
+            "the child ran before the parent in the original sequence, so the \
+             parent's exclusion cannot retroactively orphan it"
+        );
+        assert!(closure_rows.is_empty());
+    }
+
+    /// A parent excluded at a height that is NOT in the queue was excluded below
+    /// `from_anchor` — before every queue position — so its outputs are missing
+    /// from the start and its in-queue children must drop (#427). Pins the
+    /// out-of-queue seeding the positional walk must not lose.
+    #[test]
+    fn build_replay_queue_drops_a_child_of_a_parent_excluded_outside_the_queue() {
+        let parent = tx(&[OutPoint::null()], 1);
+        let child = tx(&[spend(&parent)], 2);
+
+        let (queue, _, closure_rows) = build_replay_queue(
+            vec![carrying(10, vec![child.clone()])],
+            Vec::new(),
+            &excl(&[(3, parent.compute_txid())]),
+        );
+
+        assert!(
+            queue[0].value.batch_raw_txs().is_empty(),
+            "the parent's exclusion below the replay window still orphans the child"
+        );
+        assert!(
+            closure_rows
+                .iter()
+                .any(|(h, t, _)| *h == 10 && t == &child.compute_txid().to_string()),
+        );
+    }
+
+    /// A within-batch dependency chain collapses transitively from the excluded
+    /// parent down, while an independent tx in the same batch survives.
+    #[test]
+    fn build_replay_queue_drops_a_whole_chain_within_one_batch() {
+        let parent = tx(&[OutPoint::null()], 1);
+        let child = tx(&[spend(&parent)], 2);
+        let grandchild = tx(&[spend(&child)], 3);
+        let independent = tx(&[OutPoint::null()], 4);
+
+        let (queue, excluded, _) = build_replay_queue(
+            vec![carrying(
+                10,
+                vec![
+                    parent.clone(),
+                    child.clone(),
+                    grandchild.clone(),
+                    independent.clone(),
+                ],
+            )],
+            Vec::new(),
+            &excl(&[(10, parent.compute_txid())]),
+        );
+
+        let kept: Vec<Txid> = queue[0]
+            .value
+            .batch_raw_txs()
+            .iter()
+            .map(|t| t.compute_txid())
+            .collect();
+        assert_eq!(kept, vec![independent.compute_txid()]);
+        assert_eq!(
+            excluded,
+            [
+                parent.compute_txid(),
+                child.compute_txid(),
+                grandchild.compute_txid()
+            ]
+            .into()
+        );
+    }
+
     /// But a child whose parent is excluded and appears NOWHERE else must still drop:
-    /// it would execute against state the rollback wiped (#427). The `kept_anywhere`
-    /// guard must not be widened into "never seed the closure".
+    /// it would execute against state the rollback wiped (#427). The re-decide keep
+    /// must not be widened into "never treat an excluded parent as missing".
     #[test]
     fn build_replay_queue_still_drops_a_child_of_an_absent_parent() {
         let parent = tx(&[OutPoint::null()], 1);
@@ -2192,15 +2257,4 @@ mod tests {
         assert_eq!(heights(&queue), vec![7]);
     }
 
-    #[test]
-    fn transitive_exclusion_leaves_unrelated_batches_untouched() {
-        let a = tx(&[OutPoint::null()], 1);
-        let b = tx(&[OutPoint::null()], 2);
-        let excluded: HashSet<Txid> = [tx(&[OutPoint::null()], 9).compute_txid()].into();
-
-        let result = transitive_exclusion(&[vec![a.clone()], vec![b.clone()]], &excluded);
-        assert!(!result.contains(&a.compute_txid()));
-        assert!(!result.contains(&b.compute_txid()));
-        assert_eq!(result.len(), 1);
-    }
 }

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -187,10 +187,19 @@ pub(super) fn batch_is_ordered(txs: &[bitcoin::Transaction]) -> bool {
 /// past it and `delete_unexecuted_batch_suffix` can only trim a SUFFIX, so the gap
 /// is unrefillable locally or by sync.
 ///
-/// Ordered by height rather than appended, because a queued decision can sit BELOW
-/// a replayed one: anchors go non-monotone across a rollback, so height H can defer
-/// on a high anchor while H+1 executes on a lower one and gets recorded. Appending
-/// survivors after the replay set would drop H for the same unrefillable reason.
+/// The replay set goes FIRST and survivors keep their relative order behind it —
+/// deliberately NOT sorted by consensus height. `drain_deferred_decisions` is
+/// strictly ordered and parks on the first entry whose anchor exceeds the tip, so
+/// anything unready at the front stalls everything behind it. The replay set is
+/// precisely what raises the tip back up after a rollback; putting a survivor ahead
+/// of it wedges the drain permanently, since the block decisions that would advance
+/// the tip are themselves queued behind the parked entry.
+///
+/// Anchor order makes this correct as well as safe: a survivor was deferred because
+/// its anchor was above the pre-rollback tip, while every replayed batch is at or
+/// below it. So survivors are never ready earlier than the replay set, whatever
+/// their consensus heights — and consensus heights alone are not a reliable guide,
+/// because anchors go non-monotone across a rollback.
 ///
 /// The two inputs should be disjoint by height; where they are not, the replayed
 /// copy wins because it has been resolved and exclusion-filtered.
@@ -198,13 +207,14 @@ fn merge_replay_queue(
     replayed: VecDeque<consensus_state::DeferredDecision>,
     queued: VecDeque<consensus_state::DeferredDecision>,
 ) -> VecDeque<consensus_state::DeferredDecision> {
-    let mut merged: Vec<consensus_state::DeferredDecision> = replayed.into();
-    merged.extend(queued);
-    // Stable sort + dedup keeps the replayed copy of any shared height, since it
-    // was pushed first.
-    merged.sort_by_key(|d| d.consensus_height);
-    merged.dedup_by_key(|d| d.consensus_height);
-    merged.into()
+    let replayed_heights: Vec<Height> = replayed.iter().map(|d| d.consensus_height).collect();
+    let mut merged = replayed;
+    merged.extend(
+        queued
+            .into_iter()
+            .filter(|d| !replayed_heights.contains(&d.consensus_height)),
+    );
+    merged
 }
 
 /// What `process_decided_batch` did with a decided batch. Callers must not
@@ -1345,7 +1355,7 @@ mod tests {
         q.iter().map(|d| d.consensus_height.as_u64()).collect()
     }
 
-    /// A queued decision BELOW the replay set's max must survive. Anchors go
+    /// A queued decision BELOW the replay set's max must SURVIVE. Anchors go
     /// non-monotone across a rollback, so height H can defer on a high anchor while
     /// H+1 executes on a lower one and gets a `batches` row — putting H below the
     /// replay set. H has no row, so dropping it leaves a permanent, unrefillable
@@ -1354,19 +1364,35 @@ mod tests {
     fn merge_replay_queue_keeps_a_queued_decision_below_the_replay_set() {
         let replayed: VecDeque<_> = [decision(11), decision(12)].into();
         let queued: VecDeque<_> = [decision(10), decision(13)].into();
+        let merged = merge_replay_queue(replayed, queued);
+        let mut present = heights(&merged);
+        present.sort_unstable();
+        assert_eq!(present, vec![10, 11, 12, 13], "nothing may be dropped");
+    }
+
+    /// …but it must survive BEHIND the replay set, not ahead of it.
+    /// `drain_deferred_decisions` parks on the first entry whose anchor exceeds the
+    /// tip and stops. A survivor was deferred precisely because its anchor was above
+    /// the pre-rollback tip, so putting it first parks the queue on an anchor that
+    /// only the replay set — now stuck behind it — could ever reach.
+    #[test]
+    fn merge_replay_queue_never_orders_a_survivor_ahead_of_the_replay_set() {
+        let replayed: VecDeque<_> = [decision(11), decision(12)].into();
+        let queued: VecDeque<_> = [decision(10), decision(13)].into();
         assert_eq!(
             heights(&merge_replay_queue(replayed, queued)),
-            vec![10, 11, 12, 13]
+            vec![11, 12, 10, 13],
+            "replay set first, survivors after in their original order"
         );
     }
 
     #[test]
-    fn merge_replay_queue_orders_by_consensus_height() {
+    fn merge_replay_queue_preserves_relative_order_within_each_side() {
         let replayed: VecDeque<_> = [decision(5), decision(9)].into();
         let queued: VecDeque<_> = [decision(6), decision(7)].into();
         assert_eq!(
             heights(&merge_replay_queue(replayed, queued)),
-            vec![5, 6, 7, 9]
+            vec![5, 9, 6, 7]
         );
     }
 

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -389,6 +389,20 @@ impl<E: Executor> Reactor<E> {
             )
             .await
             .context("Failed to insert empty batch")?;
+
+            // Empty to EXECUTE is not empty as DECIDED. A rollback can narrow a batch
+            // until nothing is left to run while its certificate still certifies the
+            // original txids, and `batch_txids` records what consensus decided (I4) —
+            // a peer syncing this height re-derives the exclusions itself, so it needs
+            // that list. `certified` is None for a genuinely empty decided batch, which
+            // has nothing to record. `batch_txs` is empty either way, so this writes no
+            // `unconfirmed_batch_txs` rows.
+            if certified.is_some() {
+                self.record_batch_txs(&conn, consensus_height, batch_txs, certified)
+                    .await
+                    .context("Failed to record the decided txids of an emptied batch")?;
+            }
+
             gauge!(CONSENSUS_HEIGHT).set(consensus_height.as_u64() as f64);
 
             let checkpoint = self.consensus.get_checkpoint(&conn).await;
@@ -952,7 +966,7 @@ impl<E: Executor> Reactor<E> {
         let (events, rollback) = self
             .consensus
             .run_finality_checks(&conn, self.last_height)
-            .await;
+            .await?;
         let Some((rollback_anchor, excluded)) = rollback else {
             self.consensus.emit_finality_events(&events);
             return Ok(false);
@@ -1781,6 +1795,38 @@ mod tests {
             survivor.certified_txids.as_deref(),
             Some(&[child.compute_txid(), kept.compute_txid()][..]),
             "the DECIDED list must be preserved in full for the record"
+        );
+    }
+
+    /// The narrowing can take a batch all the way to EMPTY — every transaction it
+    /// carried descends from an excluded one. That combination (no txs to execute,
+    /// but a decided list to record) is the input `process_decided_batch` must not
+    /// mistake for an ordinary empty batch: the certificate still certifies those
+    /// txids, and a peer syncing this height re-derives the exclusions itself, so it
+    /// needs the decided content. Pinning it here because it is the only place the
+    /// combination is produced.
+    #[test]
+    fn build_replay_queue_narrows_a_batch_to_empty_but_keeps_its_decided_list() {
+        let parent = tx(&[OutPoint::null()], 1);
+        let child_a = tx(&[spend(&parent)], 2);
+        let child_b = tx(&[spend(&parent)], 3);
+
+        let excluded: HashSet<Txid> = [parent.compute_txid()].into();
+        let (queue, _) = build_replay_queue(
+            vec![carrying(10, vec![parent.clone()])],
+            vec![carrying(14, vec![child_a.clone(), child_b.clone()])],
+            &excluded,
+        );
+
+        let survivor = &queue[1];
+        assert!(
+            survivor.value.batch_raw_txs().is_empty(),
+            "every tx descends from the excluded parent, so nothing may execute"
+        );
+        assert_eq!(
+            survivor.certified_txids.as_deref(),
+            Some(&[child_a.compute_txid(), child_b.compute_txid()][..]),
+            "an emptied batch still has a decided list, and it must survive"
         );
     }
 

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -1028,12 +1028,11 @@ impl<E: Executor> Reactor<E> {
     /// Declining to execute stays correct — the block was reorged away and running
     /// it would bind the wrong block to this consensus height. We just write down
     /// that we declined.
-    async fn record_declined_block(
-        &self,
-        decision: &consensus_state::DeferredDecision,
-        block_height: u64,
-        decided_hash: BlockHash,
-    ) {
+    async fn record_declined_block(&self, decision: &consensus_state::DeferredDecision) {
+        // Height and hash come from the decision itself — passing them alongside
+        // invited a caller to record one block's decision under another's identity.
+        let block_height = decision.value.block_height();
+        let decided_hash = decision.value.block_hash();
         if let Err(e) = insert_batch(
             &self.db_conn(),
             decision.consensus_height.as_u64(),
@@ -1120,8 +1119,7 @@ impl<E: Executor> Reactor<E> {
                                 // the startup cleanup trims an unexecuted SUFFIX,
                                 // never a hole in the middle. A height that leaves
                                 // no row can never be served to a syncing peer.
-                                self.record_declined_block(&decision, bh, decided_hash)
-                                    .await;
+                                self.record_declined_block(&decision).await;
                                 continue;
                             }
                             Err(e) => {
@@ -1168,8 +1166,7 @@ impl<E: Executor> Reactor<E> {
                                 consensus_height = %decision.consensus_height,
                                 "Dropping stale deferred block decision — hash mismatch after rollback"
                             );
-                            self.record_declined_block(&decision, bh, decided_hash)
-                                .await;
+                            self.record_declined_block(&decision).await;
                             self.consensus.pending_blocks.insert(bh, block);
                             continue;
                         }
@@ -1178,9 +1175,9 @@ impl<E: Executor> Reactor<E> {
                             consensus_height = %decision.consensus_height,
                             "Draining deferred block decision"
                         );
-                        self.handle_block_with_decision(block, &decision)
+                        self.handle_block(block, &decision)
                             .await
-                            .context("handle_block_with_decision failed in deferred drain")?;
+                            .context("handle_block failed in deferred drain")?;
                         // The tip moved — anything held may now be ready.
                         restore_waiting(&mut self.consensus.deferred_decisions, &mut waiting);
                     } else {
@@ -1437,6 +1434,16 @@ impl<E: Executor> Reactor<E> {
                     // asks the DB whether an EXECUTED block differs, and at
                     // `last_height + 1` nothing is executed yet, so it would read
                     // "not stale" and defer a decision we just declined.
+                    // Built ONCE. Every arm below needs the same four fields, and
+                    // `certificate` is the full validator-set commit certificate —
+                    // cloning it per arm is pure waste.
+                    let decision = consensus_state::DeferredDecision {
+                        consensus_height: certificate.height,
+                        value: proposal.value.clone(),
+                        certificate: cert_bytes,
+                        certified_txids: None,
+                    };
+
                     let mut declined_stale = false;
                     let ready = match ready {
                         Some(block) if block.hash != *hash => {
@@ -1447,13 +1454,7 @@ impl<E: Executor> Reactor<E> {
                                 consensus_height = %certificate.height,
                                 "Dropping stale block decision — hash mismatch after rollback"
                             );
-                            let declined = consensus_state::DeferredDecision {
-                                consensus_height: certificate.height,
-                                value: proposal.value.clone(),
-                                certificate: cert_bytes.clone(),
-                                certified_txids: None,
-                            };
-                            self.record_declined_block(&declined, *height, *hash).await;
+                            self.record_declined_block(&decision).await;
                             // Back in the buffer: it is the canonical block for this
                             // height on the new chain and still needs a fresh decision.
                             self.consensus.pending_blocks.insert(*height, block);
@@ -1470,15 +1471,7 @@ impl<E: Executor> Reactor<E> {
                             consensus_height = %certificate.height,
                             "Block decided and ready to process"
                         );
-                        result = consensus_state::ConsensusResult::Block(
-                            block,
-                            consensus_state::DeferredDecision {
-                                consensus_height: certificate.height,
-                                value: proposal.value.clone(),
-                                certificate: cert_bytes.clone(),
-                                certified_txids: None,
-                            },
-                        );
+                        result = consensus_state::ConsensusResult::Block(block, decision);
                     } else if !declined_stale {
                         let is_stale = match select_block_at_height(&conn, *height).await {
                             Ok(Some(row)) => row.hash != *hash,
@@ -1492,14 +1485,7 @@ impl<E: Executor> Reactor<E> {
                                 consensus_height = %certificate.height,
                                 "Block decided but not ready to execute — deferring"
                             );
-                            self.consensus.deferred_decisions.push_back(
-                                consensus_state::DeferredDecision {
-                                    consensus_height: certificate.height,
-                                    value: proposal.value.clone(),
-                                    certificate: cert_bytes.clone(),
-                                    certified_txids: None,
-                                },
-                            );
+                            self.consensus.deferred_decisions.push_back(decision);
                         } else {
                             warn!(
                                 block_height = height,
@@ -1507,17 +1493,7 @@ impl<E: Executor> Reactor<E> {
                                 consensus_height = %certificate.height,
                                 "Ignoring stale block decision (post-rollback)"
                             );
-                            self.record_declined_block(
-                                &consensus_state::DeferredDecision {
-                                    consensus_height: certificate.height,
-                                    value: proposal.value.clone(),
-                                    certificate: cert_bytes.clone(),
-                                    certified_txids: None,
-                                },
-                                *height,
-                                *hash,
-                            )
-                            .await;
+                            self.record_declined_block(&decision).await;
                         }
                     }
                 }

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -11,7 +11,7 @@ use malachitebft_core_types::{Round, Validity};
 use malachitebft_engine::host::Next;
 use metrics::{counter, gauge};
 use prost::Message;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::consensus::codec::encode_commit_certificate;
 use crate::consensus::finality_types::{DecidedBatch, StateEvent, UnfinalizedBatch, deadline_for};
@@ -199,12 +199,11 @@ fn restore_waiting(
 /// is unrefillable locally or by sync.
 ///
 /// The replay set goes FIRST and survivors keep their relative order behind it —
-/// deliberately NOT sorted by consensus height. `drain_deferred_decisions` is
-/// strictly ordered and parks on the first entry whose anchor exceeds the tip, so
-/// anything unready at the front stalls everything behind it. The replay set is
-/// precisely what raises the tip back up after a rollback; putting a survivor ahead
-/// of it wedges the drain permanently, since the block decisions that would advance
-/// the tip are themselves queued behind the parked entry.
+/// deliberately NOT sorted by consensus height. A survivor BLOCK decision whose
+/// block has not arrived still parks the drain and stops it (batches merely step
+/// aside; blocks cannot, since they must apply in sequence). The replay set is
+/// precisely what raises the tip back up after a rollback, so a survivor ordered
+/// ahead of it can stall the decisions that would make that survivor ready.
 ///
 /// Anchor order makes this correct as well as safe: a survivor was deferred because
 /// its anchor was above the pre-rollback tip, while every replayed batch is at or
@@ -993,7 +992,10 @@ impl<E: Executor> Reactor<E> {
                     ..
                 } => {
                     if *anchor_height > self.last_height {
-                        info!(
+                        // debug!, not info!: every held batch is re-tested after every
+                        // block execution, so a lagging node catching up would emit
+                        // this once per (held batch x block) from inside the loop.
+                        debug!(
                             anchor_height = *anchor_height,
                             last_height = self.last_height,
                             consensus_height = %decision.consensus_height,

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -1,5 +1,5 @@
 use std::cmp::Reverse;
-use std::collections::{BinaryHeap, HashMap, HashSet};
+use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
 use std::time::Instant;
 
 use anyhow::{Context, Result};
@@ -175,6 +175,36 @@ pub(super) fn batch_is_ordered(txs: &[bitcoin::Transaction]) -> bool {
         }
     }
     true
+}
+
+/// Merge a rollback's replay set with the decisions already queued, ordered by
+/// consensus height.
+///
+/// MERGE, not overwrite: the replay set comes from `select_batches_from_anchor`,
+/// which returns only heights that already have a `batches` row, while a queued
+/// decision is queued precisely BECAUSE its anchor was unprocessed and so has no
+/// row. Overwriting drops it permanently — `current_height` has already advanced
+/// past it and `delete_unexecuted_batch_suffix` can only trim a SUFFIX, so the gap
+/// is unrefillable locally or by sync.
+///
+/// Ordered by height rather than appended, because a queued decision can sit BELOW
+/// a replayed one: anchors go non-monotone across a rollback, so height H can defer
+/// on a high anchor while H+1 executes on a lower one and gets recorded. Appending
+/// survivors after the replay set would drop H for the same unrefillable reason.
+///
+/// The two inputs should be disjoint by height; where they are not, the replayed
+/// copy wins because it has been resolved and exclusion-filtered.
+fn merge_replay_queue(
+    replayed: VecDeque<consensus_state::DeferredDecision>,
+    queued: VecDeque<consensus_state::DeferredDecision>,
+) -> VecDeque<consensus_state::DeferredDecision> {
+    let mut merged: Vec<consensus_state::DeferredDecision> = replayed.into();
+    merged.extend(queued);
+    // Stable sort + dedup keeps the replayed copy of any shared height, since it
+    // was pushed first.
+    merged.sort_by_key(|d| d.consensus_height);
+    merged.dedup_by_key(|d| d.consensus_height);
+    merged.into()
 }
 
 /// What `process_decided_batch` did with a decided batch. Callers must not
@@ -735,21 +765,10 @@ impl<E: Executor> Reactor<E> {
                 self.consensus.pending_transactions.remove(txid);
             }
         }
-        // SPLICE, don't assign. The replay set comes from `select_batches_from_anchor`,
-        // which only returns heights that already have a `batches` row — but a queued
-        // decision is queued precisely BECAUSE its anchor was unprocessed, so it has
-        // no row yet. Overwriting the queue drops it permanently: `current_height` has
-        // already advanced past it and `delete_unexecuted_batch_suffix` can only trim
-        // a suffix, so the gap is unrefillable locally or by sync. Survivors keep
-        // their order and follow the replayed set, which is strictly below them.
-        let last_replayed = deferred.back().map(|d| d.consensus_height);
-        let survivors: Vec<consensus_state::DeferredDecision> =
-            std::mem::take(&mut self.consensus.deferred_decisions)
-                .into_iter()
-                .filter(|d| last_replayed.is_none_or(|last| d.consensus_height > last))
-                .collect();
-        deferred.extend(survivors);
-        self.consensus.deferred_decisions = deferred;
+        self.consensus.deferred_decisions = merge_replay_queue(
+            deferred,
+            std::mem::take(&mut self.consensus.deferred_decisions),
+        );
         self.consensus
             .unfinalized_batches
             .retain(|b| b.anchor_height < from_anchor);
@@ -1191,11 +1210,15 @@ impl<E: Executor> Reactor<E> {
 
 #[cfg(test)]
 mod tests {
-    use super::{batch_is_ordered, dependency_sort, transitive_exclusion};
+    use super::{batch_is_ordered, dependency_sort, merge_replay_queue, transitive_exclusion};
+    use crate::consensus::{Height, Value};
+    use crate::reactor::consensus_state::DeferredDecision;
     use bitcoin::absolute::LockTime;
+    use bitcoin::hashes::Hash;
     use bitcoin::transaction::Version;
     use bitcoin::{Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness};
     use std::collections::HashSet;
+    use std::collections::VecDeque;
 
     /// A tx spending each outpoint in `parents`, with one output. `nonce`
     /// perturbs the output value so distinct txs get distinct txids.
@@ -1307,6 +1330,71 @@ mod tests {
         // dependency across the replay sequence.
         let result = transitive_exclusion(&[vec![parent.clone()], vec![child.clone()]], &excluded);
         assert!(result.contains(&child.compute_txid()));
+    }
+
+    /// Decisions are identified by consensus height, not by position.
+    fn decision(consensus_height: u64) -> DeferredDecision {
+        DeferredDecision {
+            consensus_height: Height::new(consensus_height),
+            value: Value::new_batch_raw(0, bitcoin::BlockHash::all_zeros(), vec![]),
+            certificate: Vec::new(),
+        }
+    }
+
+    fn heights(q: &VecDeque<DeferredDecision>) -> Vec<u64> {
+        q.iter().map(|d| d.consensus_height.as_u64()).collect()
+    }
+
+    /// A queued decision BELOW the replay set's max must survive. Anchors go
+    /// non-monotone across a rollback, so height H can defer on a high anchor while
+    /// H+1 executes on a lower one and gets a `batches` row — putting H below the
+    /// replay set. H has no row, so dropping it leaves a permanent, unrefillable
+    /// gap in the consensus-height sequence.
+    #[test]
+    fn merge_replay_queue_keeps_a_queued_decision_below_the_replay_set() {
+        let replayed: VecDeque<_> = [decision(11), decision(12)].into();
+        let queued: VecDeque<_> = [decision(10), decision(13)].into();
+        assert_eq!(
+            heights(&merge_replay_queue(replayed, queued)),
+            vec![10, 11, 12, 13]
+        );
+    }
+
+    #[test]
+    fn merge_replay_queue_orders_by_consensus_height() {
+        let replayed: VecDeque<_> = [decision(5), decision(9)].into();
+        let queued: VecDeque<_> = [decision(6), decision(7)].into();
+        assert_eq!(
+            heights(&merge_replay_queue(replayed, queued)),
+            vec![5, 6, 7, 9]
+        );
+    }
+
+    #[test]
+    fn merge_replay_queue_prefers_the_replayed_copy_of_a_shared_height() {
+        // Distinguishable by certificate: the replayed copy has been resolved and
+        // exclusion-filtered, so it must win.
+        let mut replayed_copy = decision(4);
+        replayed_copy.certificate = vec![0xAA];
+        let replayed: VecDeque<_> = [replayed_copy].into();
+        let queued: VecDeque<_> = [decision(4)].into();
+
+        let merged = merge_replay_queue(replayed, queued);
+        assert_eq!(heights(&merged), vec![4]);
+        assert_eq!(merged[0].certificate, vec![0xAA]);
+    }
+
+    #[test]
+    fn merge_replay_queue_handles_either_side_empty() {
+        assert_eq!(
+            heights(&merge_replay_queue(VecDeque::new(), [decision(3)].into())),
+            vec![3]
+        );
+        assert_eq!(
+            heights(&merge_replay_queue([decision(3)].into(), VecDeque::new())),
+            vec![3]
+        );
+        assert!(merge_replay_queue(VecDeque::new(), VecDeque::new()).is_empty());
     }
 
     #[test]

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -2,7 +2,7 @@ use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
 use std::time::Instant;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use bitcoin::hashes::Hash;
 use bitcoin::{BlockHash, Txid};
 use indexer_types::Event;
@@ -11,7 +11,7 @@ use malachitebft_core_types::{Round, Validity};
 use malachitebft_engine::host::Next;
 use metrics::{counter, gauge};
 use prost::Message;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::consensus::codec::encode_commit_certificate;
 use crate::consensus::finality_types::{DecidedBatch, StateEvent, UnfinalizedBatch, deadline_for};
@@ -22,10 +22,10 @@ use crate::database::queries::{
 };
 use crate::metrics::{CONSENSUS_HEIGHT, ITEMS_INDEXED};
 
-use super::Reactor;
 use super::consensus_state;
 use super::executor::Executor;
 use super::mempool_fee_index::MempoolFeeIndex;
+use super::{MAX_DEFERRED_DECISIONS, Reactor};
 
 /// Multiplier applied to `MempoolFeeIndex::fastest_fee()` to derive the
 /// per-batch acceptance threshold, as an integer ratio: 9/10 means we accept
@@ -644,6 +644,19 @@ impl<E: Executor> Reactor<E> {
         let value = match data {
             ProposalData::Block { height: bh, hash } => {
                 if let Some(block) = self.consensus.pending_blocks.get(bh) {
+                    // Deliberately NOT gated on `bh == last_height + 1`.
+                    //
+                    // Tempting, since a node behind on execution votes here for a
+                    // block it cannot yet apply. But a `Value::Block` asserts only
+                    // "this is the canonical Bitcoin block at this height", which
+                    // this node can confirm from its own buffer; when to run it is
+                    // a local ordering matter, settled by `handle_finalized` and
+                    // the deferred queue. Withholding the vote would trade a stuck
+                    // node for a stalled chain: at 3-of-4 quorum with one
+                    // validator already down, one nil vote is the difference
+                    // between the network advancing and halting — which is the
+                    // failure this whole change exists to prevent, reintroduced
+                    // from the other side.
                     if block.hash != *hash {
                         warn!(
                             block_height = bh,
@@ -654,10 +667,34 @@ impl<E: Executor> Reactor<E> {
                         return Ok(None);
                     }
                 } else {
-                    warn!(
-                        block_height = bh,
-                        "Rejecting block proposal: block not yet received"
-                    );
+                    // "Not yet received" and "already processed" are opposite
+                    // conditions with opposite remedies — one resolves itself
+                    // when the poller catches up, the other never does — and
+                    // they were indistinguishable in the logs. Naming them costs
+                    // one lookup on a path that is already rejecting.
+                    match select_block_at_height(&conn, *bh).await {
+                        Ok(Some(row)) if row.hash == *hash => warn!(
+                            block_height = bh,
+                            %hash,
+                            last_height,
+                            "Rejecting block proposal: height already processed"
+                        ),
+                        Ok(Some(row)) => warn!(
+                            block_height = bh,
+                            proposed = %hash,
+                            executed = %row.hash,
+                            "Rejecting block proposal: height processed with a different hash (reorg)"
+                        ),
+                        Ok(None) => warn!(
+                            block_height = bh,
+                            last_height, "Rejecting block proposal: block not yet received"
+                        ),
+                        Err(e) => warn!(
+                            error = %e,
+                            block_height = bh,
+                            "Rejecting block proposal: block lookup failed"
+                        ),
+                    }
                     return Ok(None);
                 }
                 Value::new_block(*bh, *hash)
@@ -1025,6 +1062,67 @@ impl<E: Executor> Reactor<E> {
                 } => {
                     let bh = *bh;
                     let decided_hash = *decided_hash;
+
+                    // Gate on the tip BEFORE touching `pending_blocks`. A block
+                    // can only execute at exactly `last_height + 1`; handing
+                    // `handle_block` anything else trips its height guard, which
+                    // is fatal to the reactor. Holding the block buffered is not
+                    // permission to run it — a node whose execution has fallen
+                    // behind caches the whole window from its tip to the
+                    // network's, so the buffer hit says nothing about ordering.
+                    if bh <= self.last_height {
+                        // Terminal, never parked: the height is already executed
+                        // (a re-decide after a rollback, or a sync replaying
+                        // both) or was reorged away. Parking a decision that
+                        // nothing can ever satisfy wedges the drain forever.
+                        // Reachable with the block still buffered, too — the
+                        // finality path deliberately keeps `pending_blocks`
+                        // across a rollback and re-execution.
+                        match select_block_at_height(&self.db_conn(), bh).await {
+                            Ok(row) => {
+                                warn!(
+                                    block_height = bh,
+                                    decided = %decided_hash,
+                                    executed = ?row.map(|r| r.hash),
+                                    last_height = self.last_height,
+                                    consensus_height = %decision.consensus_height,
+                                    "Dropping deferred block decision — at or below tip"
+                                );
+                                // Dropped is not unrecorded. `batches` is the only
+                                // copy of the decided sequence — Malachite asks us
+                                // for decided values rather than keeping them — and
+                                // the startup cleanup trims an unexecuted SUFFIX,
+                                // never a hole in the middle. A height that leaves
+                                // no row can never be served to a syncing peer.
+                                self.record_declined_block(&decision, bh, decided_hash)
+                                    .await;
+                                continue;
+                            }
+                            Err(e) => {
+                                warn!(error = %e, block_height = bh, "Block lookup failed during drain; parking decision");
+                                self.consensus.deferred_decisions.push_front(decision);
+                                break;
+                            }
+                        }
+                    }
+                    if bh > self.last_height + 1 {
+                        // The predecessors were decided by the network but never
+                        // reached this node's executor. Nothing here can close
+                        // that gap — the missed heights will not be re-decided —
+                        // so park and stay loud: this node needs a re-sync, and
+                        // the alternative (executing out of order) is fatal.
+                        error!(
+                            block_height = bh,
+                            last_height = self.last_height,
+                            gap = bh - self.last_height,
+                            consensus_height = %decision.consensus_height,
+                            "Deferred block decision is ahead of the tip — this node cannot \
+                             catch up on its own and needs a re-sync"
+                        );
+                        self.consensus.deferred_decisions.push_front(decision);
+                        break;
+                    }
+
                     let block = {
                         let cs = &mut self.consensus;
                         cs.pending_blocks.remove(&bh)
@@ -1060,33 +1158,11 @@ impl<E: Executor> Reactor<E> {
                         // The tip moved — anything held may now be ready.
                         restore_waiting(&mut self.consensus.deferred_decisions, &mut waiting);
                     } else {
-                        // No pending block at this height. Before parking the
-                        // queue on it, check whether the height was already
-                        // executed: a block row with the SAME hash means this
-                        // decision is a duplicate record (a re-decide after a
-                        // rollback, or a sync replaying both) — already
-                        // satisfied; a DIFFERENT hash means the decided block
-                        // was reorged away. Either way the decision is
-                        // terminal — parking it would wedge the drain forever
-                        // on a delivery that can never come.
-                        match select_block_at_height(&self.db_conn(), bh).await {
-                            Ok(Some(row)) => {
-                                warn!(
-                                    block_height = bh,
-                                    decided = %decided_hash,
-                                    executed = %row.hash,
-                                    consensus_height = %decision.consensus_height,
-                                    "Dropping deferred block decision — height already executed"
-                                );
-                                self.record_declined_block(&decision, bh, decided_hash)
-                                    .await;
-                                continue;
-                            }
-                            Ok(None) => {}
-                            Err(e) => {
-                                warn!(error = %e, block_height = bh, "Block lookup failed during drain; parking decision");
-                            }
-                        }
+                        // `bh == last_height + 1` and the poller has not
+                        // delivered it yet. The already-executed and reorged
+                        // cases were both settled by the tip gate above, so this
+                        // is the one genuinely transient case: park and wait for
+                        // `BlockInsert` to drive the drain again.
                         info!(
                             block_height = bh,
                             consensus_height = %decision.consensus_height,
@@ -1293,7 +1369,37 @@ impl<E: Executor> Reactor<E> {
                         .context("Failed to encode commit certificate")?
                         .encode_to_vec();
 
-                    if let Some(block) = self.consensus.pending_blocks.remove(height) {
+                    // Take the block only when it can execute immediately: the
+                    // exact next height, with no earlier block decision still
+                    // queued ahead of it. Everything else goes through the
+                    // deferred queue, the single ordered execution path.
+                    //
+                    // Without this, a buffered-but-not-next block was handed
+                    // straight to the executor, whose height guard is a `bail!`
+                    // — and the `batches` row had already been written. That is
+                    // how a signet validator spent 20 h restarting: each boot it
+                    // took one decision for a height 128 ahead of its tip, wrote
+                    // the record, died on the guard, and came back one consensus
+                    // height further from the state it actually held.
+                    //
+                    // The queue check is `is_block`, not `is_empty`: a deferred
+                    // BATCH must not hold a block back. Batches are only ever
+                    // gated on their own anchor (see `drain_deferred_decisions`),
+                    // and a batch waiting on this very block would deadlock
+                    // against it.
+                    let in_order = *height == self.last_height + 1
+                        && !self
+                            .consensus
+                            .deferred_decisions
+                            .iter()
+                            .any(|d| d.value.is_block());
+                    let ready = if in_order {
+                        self.consensus.pending_blocks.remove(height)
+                    } else {
+                        None
+                    };
+
+                    if let Some(block) = ready {
                         info!(
                             block_height = height,
                             block_hash = %hash,
@@ -1318,8 +1424,9 @@ impl<E: Executor> Reactor<E> {
                             info!(
                                 block_height = height,
                                 block_hash = %hash,
+                                last_height = self.last_height,
                                 consensus_height = %certificate.height,
-                                "Block decided but not yet received — deferring"
+                                "Block decided but not ready to execute — deferring"
                             );
                             self.consensus.deferred_decisions.push_back(
                                 consensus_state::DeferredDecision {
@@ -1361,6 +1468,23 @@ impl<E: Executor> Reactor<E> {
                 height = %certificate.height,
                 value = %certificate.value_id,
                 "Finalized a value not held among our undecided proposals for this height"
+            );
+        }
+
+        // An OOM backstop, not a policy knob. A node that genuinely cannot catch
+        // up accumulates one deferred decision per decided value, each carrying a
+        // certificate and possibly raw txs, forever. Failing here turns an
+        // eventual OOM-kill into an explicit, diagnosable exit that names the
+        // gap. Deliberately far above any real backlog: a tight bound would
+        // recreate the crash loop this whole change exists to remove, and on a
+        // bare-quorum network a crash loop takes the chain down with it.
+        if self.consensus.deferred_decisions.len() > MAX_DEFERRED_DECISIONS {
+            bail!(
+                "deferred decision queue exceeded {MAX_DEFERRED_DECISIONS} entries at block \
+                 height {} (consensus height {}) — this node is not executing what consensus \
+                 decides and cannot recover on its own; re-sync required",
+                self.last_height,
+                certificate.height
             );
         }
 

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -862,6 +862,28 @@ impl<E: Executor> Reactor<E> {
     /// startup cleanup forgets the unexecuted suffix and the node re-syncs).
     /// Before the truncation it would instead CANCEL a rollback that finality
     /// already demanded.
+    /// Pair each decision with the transactions it carries.
+    ///
+    /// Both sides of the replay merge must resolve the SAME way: the exclusion
+    /// closure needs tx INPUTS from the queued survivors too, and resolving only the
+    /// replay set let a descendant of an excluded tx through to execute against state
+    /// the rollback had wiped (#427 in a second form).
+    async fn resolve_decisions(
+        &mut self,
+        decisions: impl IntoIterator<Item = consensus_state::DeferredDecision>,
+    ) -> Result<Vec<(consensus_state::DeferredDecision, Vec<bitcoin::Transaction>)>> {
+        let decisions = decisions.into_iter();
+        let mut out = Vec::with_capacity(decisions.size_hint().0);
+        for decision in decisions {
+            let txs = match &decision.value {
+                Value::Batch { txs, .. } => self.resolve_batch_txs(txs).await?,
+                Value::Block { .. } => Vec::new(),
+            };
+            out.push((decision, txs));
+        }
+        Ok(out)
+    }
+
     pub(super) async fn prepare_replay(
         &mut self,
         from_anchor: u64,
@@ -883,23 +905,9 @@ impl<E: Executor> Reactor<E> {
         // set let such a child through to execute against state the rollback wiped
         // (#427 in a second form). Resolution pulls from the same sources the drain
         // would use later.
-        let mut replayed = Vec::with_capacity(replay_batches.len());
-        for decision in replay_batches {
-            let txs = match &decision.value {
-                Value::Batch { txs, .. } => self.resolve_batch_txs(txs).await?,
-                Value::Block { .. } => Vec::new(),
-            };
-            replayed.push((decision, txs));
-        }
+        let replayed = self.resolve_decisions(replay_batches).await?;
         let queued = std::mem::take(&mut self.consensus.deferred_decisions);
-        let mut survivors = Vec::with_capacity(queued.len());
-        for decision in queued {
-            let txs = match &decision.value {
-                Value::Batch { txs, .. } => self.resolve_batch_txs(txs).await?,
-                Value::Block { .. } => Vec::new(),
-            };
-            survivors.push((decision, txs));
-        }
+        let survivors = self.resolve_decisions(queued).await?;
 
         let (queue, excluded) = build_replay_queue(replayed, survivors, &excluded_txids);
         self.consensus.deferred_decisions = queue;
@@ -1457,19 +1465,7 @@ impl<E: Executor> Reactor<E> {
                         None
                     };
 
-                    // Being buffered at the right height is not the same as being the
-                    // DECIDED block. A rollback can leave a decision whose block was
-                    // reorged away, and the block now pending at that height belongs
-                    // to the new chain — executing it under the old decision binds the
-                    // wrong block to that consensus record. The deferred drain has
-                    // always checked this; this path did not, so the guard held only
-                    // when the decision happened to arrive late.
-                    // Set when the mismatch branch below has already settled this
-                    // decision. The `else` arm cannot detect this case on its own — it
-                    // asks the DB whether an EXECUTED block differs, and at
-                    // `last_height + 1` nothing is executed yet, so it would read
-                    // "not stale" and defer a decision we just declined.
-                    // Built ONCE. Every arm below needs the same four fields, and
+                    // Built ONCE. Every arm needs the same four fields, and
                     // `certificate` is the full validator-set commit certificate —
                     // cloning it per arm is pure waste.
                     let decision = consensus_state::DeferredDecision {
@@ -1479,9 +1475,30 @@ impl<E: Executor> Reactor<E> {
                         certified_txs: None,
                     };
 
-                    let mut declined_stale = false;
-                    let ready = match ready {
-                        Some(block) if block.hash != *hash => {
+                    // Being buffered at the right height is not the same as being the
+                    // DECIDED block. A rollback can leave a decision whose block was
+                    // reorged away, and the block now pending at that height belongs
+                    // to the new chain — executing it under the old decision binds the
+                    // wrong block to that consensus record. The deferred drain has
+                    // always checked this; this path did not, so the guard held only
+                    // when the decision happened to arrive late.
+                    match ready {
+                        // Buffered, and it IS the decided block.
+                        Some(block) if block.hash == *hash => {
+                            info!(
+                                block_height = height,
+                                block_hash = %hash,
+                                consensus_height = %certificate.height,
+                                "Block decided and ready to process"
+                            );
+                            result = consensus_state::ConsensusResult::Block(block, decision);
+                        }
+                        // Buffered, but a DIFFERENT block — the decision is stale.
+                        // Settled here rather than falling through: the arm below asks
+                        // the DB whether an EXECUTED block differs, and at
+                        // `last_height + 1` nothing is executed yet, so it would read
+                        // "not stale" and defer a decision we just declined.
+                        Some(block) => {
                             warn!(
                                 block_height = height,
                                 decided = %hash,
@@ -1493,42 +1510,32 @@ impl<E: Executor> Reactor<E> {
                             // Back in the buffer: it is the canonical block for this
                             // height on the new chain and still needs a fresh decision.
                             self.consensus.pending_blocks.insert(*height, block);
-                            declined_stale = true;
-                            None
                         }
-                        other => other,
-                    };
-
-                    if let Some(block) = ready {
-                        info!(
-                            block_height = height,
-                            block_hash = %hash,
-                            consensus_height = %certificate.height,
-                            "Block decided and ready to process"
-                        );
-                        result = consensus_state::ConsensusResult::Block(block, decision);
-                    } else if !declined_stale {
-                        let is_stale = match select_block_at_height(&conn, *height).await {
-                            Ok(Some(row)) => row.hash != *hash,
-                            _ => false,
-                        };
-                        if !is_stale {
-                            info!(
-                                block_height = height,
-                                block_hash = %hash,
-                                last_height = self.last_height,
-                                consensus_height = %certificate.height,
-                                "Block decided but not ready to execute — deferring"
+                        // Not buffered: either the poller has not delivered it yet, or
+                        // the height was executed with a different block (reorged).
+                        None => {
+                            let is_stale = matches!(
+                                select_block_at_height(&conn, *height).await,
+                                Ok(Some(row)) if row.hash != *hash
                             );
-                            self.consensus.deferred_decisions.push_back(decision);
-                        } else {
-                            warn!(
-                                block_height = height,
-                                block_hash = %hash,
-                                consensus_height = %certificate.height,
-                                "Ignoring stale block decision (post-rollback)"
-                            );
-                            self.record_declined_block(&decision).await;
+                            if is_stale {
+                                warn!(
+                                    block_height = height,
+                                    block_hash = %hash,
+                                    consensus_height = %certificate.height,
+                                    "Ignoring stale block decision (post-rollback)"
+                                );
+                                self.record_declined_block(&decision).await;
+                            } else {
+                                info!(
+                                    block_height = height,
+                                    block_hash = %hash,
+                                    last_height = self.last_height,
+                                    consensus_height = %certificate.height,
+                                    "Block decided but not ready to execute — deferring"
+                                );
+                                self.consensus.deferred_decisions.push_back(decision);
+                            }
                         }
                     }
                 }

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -1592,9 +1592,9 @@ impl<E: Executor> Reactor<E> {
                                 // range receives no further block events to trigger
                                 // the drain: without this it parks forever with the
                                 // re-decided chain queued behind it.
-                                self.advance().await.context(
-                                    "advance failed after deferring a block decision",
-                                )?;
+                                self.advance()
+                                    .await
+                                    .context("advance failed after deferring a block decision")?;
                             }
                         }
                     }
@@ -2266,5 +2266,4 @@ mod tests {
         restore_waiting(&mut queue, &mut waiting);
         assert_eq!(heights(&queue), vec![7]);
     }
-
 }

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -1190,11 +1190,37 @@ impl<E: Executor> Reactor<E> {
                         }
                     }
                     if bh > self.last_height + 1 {
-                        // The predecessors were decided by the network but never
-                        // reached this node's executor. Nothing here can close
-                        // that gap — the missed heights will not be re-decided —
-                        // so park and stay loud: this node needs a re-sync, and
-                        // the alternative (executing out of order) is fatal.
+                        // A decision ahead of the tip is one of two things, told
+                        // apart by the buffered block at its height. After a
+                        // reorg DEEPER than one block, the stale decisions for
+                        // the orphaned heights land here (only `tip + 1` can be
+                        // declined by the hash check below), while the re-decided
+                        // chain-B blocks queue up BEHIND them — parking would
+                        // wedge the drain forever, on every node that ever syncs
+                        // across the reorg. The poller's canonical block at this
+                        // height carrying a different hash is exactly the
+                        // evidence the `tip + 1` decline acts on: decline and
+                        // record, and let the re-decisions behind it through.
+                        if let Some(block) = self.consensus.pending_blocks.get(&bh)
+                            && block.hash != decided_hash
+                        {
+                            warn!(
+                                block_height = bh,
+                                decided = %decided_hash,
+                                local = %block.hash,
+                                consensus_height = %decision.consensus_height,
+                                "Dropping stale deferred block decision ahead of the tip — \
+                                 the canonical chain has replaced it"
+                            );
+                            self.record_declined_block(&decision).await;
+                            continue;
+                        }
+                        // No buffered block, or the hashes match: the
+                        // predecessors were decided by the network but never
+                        // reached this node's executor, and nothing here can
+                        // close that gap — the missed heights will not be
+                        // re-decided — so park and stay loud: this node needs a
+                        // re-sync, and executing out of order is fatal.
                         error!(
                             block_height = bh,
                             last_height = self.last_height,
@@ -1552,6 +1578,17 @@ impl<E: Executor> Reactor<E> {
                                     "Block decided but not ready to execute — deferring"
                                 );
                                 self.consensus.deferred_decisions.push_back(decision);
+                                // Run the drain NOW rather than waiting for the next
+                                // block event. The decision just queued may already be
+                                // settleable — after a ≥2-deep reorg, the stale
+                                // pre-reorg decision lands here with its replacement
+                                // block already buffered, and a node syncing that
+                                // range receives no further block events to trigger
+                                // the drain: without this it parks forever with the
+                                // re-decided chain queued behind it.
+                                self.advance().await.context(
+                                    "advance failed after deferring a block decision",
+                                )?;
                             }
                         }
                     }

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -244,13 +244,16 @@ fn build_replay_queue(
             } = &decision.value
             {
                 let (anchor_height, anchor_hash) = (*anchor_height, *anchor_hash);
-                let decided: Vec<Txid> = txs.iter().map(|tx| tx.compute_txid()).collect();
                 let kept: Vec<bitcoin::Transaction> = txs
-                    .into_iter()
+                    .iter()
                     .filter(|tx| !excluded.contains(&tx.compute_txid()))
+                    .cloned()
                     .collect();
+                let decided = txs;
                 // Narrowing what we execute must not narrow what we record as
-                // decided — see `DeferredDecision::certified_txids`.
+                // decided — see `DeferredDecision::certified_txs`. The BODIES are
+                // retained, not just the txids: an excluded tx never confirmed, so
+                // this is the only copy left and a peer can get it nowhere else.
                 //
                 // `get_or_insert`, not assignment: a batch can be narrowed by more
                 // than one rollback, and on the second pass `txs` is already the
@@ -258,7 +261,7 @@ fn build_replay_queue(
                 // whatever the first pass excluded. The earliest list is the decided
                 // one; later passes only ever remove more.
                 if kept.len() != decided.len() {
-                    decision.certified_txids.get_or_insert(decided);
+                    decision.certified_txs.get_or_insert(decided);
                 }
                 decision.value = Value::new_batch_raw(anchor_height, anchor_hash, kept);
             }
@@ -328,19 +331,22 @@ impl<E: Executor> Reactor<E> {
         conn: &libsql::Connection,
         consensus_height: Height,
         batch_txs: &[bitcoin::Transaction],
-        certified: Option<&[Txid]>,
+        certified: Option<&[bitcoin::Transaction]>,
     ) -> Result<()> {
-        let txids: Vec<String> = match certified {
-            Some(decided) => decided.iter().map(|t| t.to_string()).collect(),
-            None => batch_txs
-                .iter()
-                .map(|tx| tx.compute_txid().to_string())
-                .collect(),
-        };
+        // Both lists come from the DECIDED set when a replay has narrowed this batch:
+        // `batch_txids` because that is what consensus agreed (I4), and the raw
+        // bodies because an EXCLUDED transaction never confirmed, so this node's copy
+        // is the only one a syncing peer can ever obtain. Recording only what we
+        // executed leaves that height permanently unresolvable.
+        let decided: &[bitcoin::Transaction] = certified.unwrap_or(batch_txs);
+        let txids: Vec<String> = decided
+            .iter()
+            .map(|tx| tx.compute_txid().to_string())
+            .collect();
         insert_batch_txids(conn, consensus_height.as_u64(), &txids)
             .await
             .context("Failed to insert batch txids")?;
-        for raw_tx in batch_txs {
+        for raw_tx in decided {
             let txid = raw_tx.compute_txid();
             let serialized = bitcoin::consensus::serialize(raw_tx);
             insert_unconfirmed_batch_tx(
@@ -362,9 +368,9 @@ impl<E: Executor> Reactor<E> {
         consensus_height: Height,
         certificate: &[u8],
         batch_txs: &[bitcoin::Transaction],
-        // The DECIDED txid list, when a rollback exclusion has narrowed
+        // The DECIDED transactions, when a rollback exclusion has narrowed
         // `batch_txs`. Recorded instead of the executed set — see `record_batch_txs`.
-        certified: Option<&[Txid]>,
+        certified: Option<&[bitcoin::Transaction]>,
     ) -> Result<BatchOutcome> {
         let started_at = Instant::now();
         let conn = self.db_conn();
@@ -1231,7 +1237,7 @@ impl<E: Executor> Reactor<E> {
                             decision.consensus_height,
                             &decision.certificate,
                             &resolved_txs,
-                            decision.certified_txids.as_deref(),
+                            decision.certified_txs.as_deref(),
                         )
                         .await
                         .context("process_decided_batch failed in deferred drain")?;
@@ -1362,7 +1368,7 @@ impl<E: Executor> Reactor<E> {
                                 consensus_height: certificate.height,
                                 value: proposal.value.clone(),
                                 certificate: cert_bytes,
-                                certified_txids: None,
+                                certified_txs: None,
                             },
                         );
                     } else {
@@ -1441,7 +1447,7 @@ impl<E: Executor> Reactor<E> {
                         consensus_height: certificate.height,
                         value: proposal.value.clone(),
                         certificate: cert_bytes,
-                        certified_txids: None,
+                        certified_txs: None,
                     };
 
                     let mut declined_stale = false;
@@ -1678,7 +1684,7 @@ mod tests {
             consensus_height: Height::new(consensus_height),
             value: Value::new_batch_raw(0, bitcoin::BlockHash::all_zeros(), vec![]),
             certificate: Vec::new(),
-            certified_txids: None,
+            certified_txs: None,
         }
     }
 
@@ -1768,8 +1774,8 @@ mod tests {
             "the descendant must not execute"
         );
         assert_eq!(
-            survivor.certified_txids.as_deref(),
-            Some(&[child.compute_txid(), kept.compute_txid()][..]),
+            survivor.decided_txids(),
+            vec![child.compute_txid(), kept.compute_txid()],
             "the DECIDED list must be preserved in full for the record"
         );
     }
@@ -1800,9 +1806,51 @@ mod tests {
             "every tx descends from the excluded parent, so nothing may execute"
         );
         assert_eq!(
-            survivor.certified_txids.as_deref(),
-            Some(&[child_a.compute_txid(), child_b.compute_txid()][..]),
+            survivor.decided_txids(),
+            vec![child_a.compute_txid(), child_b.compute_txid()],
             "an emptied batch still has a decided list, and it must survive"
+        );
+    }
+
+    /// Narrowing must not destroy the EXCLUDED transactions' bodies.
+    ///
+    /// A batch in the replay set already persisted its bodies when it first
+    /// executed. A SURVIVOR — queued, never executed, so with no rows at all — has
+    /// persisted nothing, and `build_replay_queue` is holding the fully-resolved
+    /// bodies at the exact moment it drops them. Recording the excluded txids in
+    /// `batch_txids` while discarding their bodies leaves that consensus height
+    /// unresolvable: a syncing peer gets `BatchTx::Id`, cannot resolve it from pool,
+    /// DB or bitcoind (it never confirmed), and `resolve_batch_txs` bails — killing
+    /// the peer's reactor.
+    #[test]
+    fn build_replay_queue_keeps_the_excluded_transactions_bodies() {
+        let parent = tx(&[OutPoint::null()], 1);
+        let child = tx(&[spend(&parent)], 2);
+        let kept = tx(&[OutPoint::null()], 3);
+
+        let excluded: HashSet<Txid> = [parent.compute_txid()].into();
+        let (queue, _) = build_replay_queue(
+            vec![carrying(10, vec![parent.clone()])],
+            vec![carrying(14, vec![child.clone(), kept.clone()])],
+            &excluded,
+        );
+
+        let survivor = &queue[1];
+        assert_eq!(
+            survivor.value.batch_raw_txs().len(),
+            1,
+            "only the kept tx may EXECUTE"
+        );
+        let servable: HashSet<Txid> = survivor
+            .decided_txs()
+            .iter()
+            .map(|t| t.compute_txid())
+            .collect();
+        assert_eq!(
+            servable,
+            [child.compute_txid(), kept.compute_txid()].into(),
+            "but the body of the EXCLUDED tx must still be servable — it is the one \
+             a peer can obtain from nowhere else"
         );
     }
 
@@ -1816,16 +1864,13 @@ mod tests {
         let first = tx(&[OutPoint::null()], 1);
         let second = tx(&[OutPoint::null()], 2);
         let survivor_tx = tx(&[OutPoint::null()], 3);
-        let decided_all = vec![
-            first.compute_txid(),
-            second.compute_txid(),
-            survivor_tx.compute_txid(),
-        ];
+        let decided_all = vec![first.clone(), second.clone(), survivor_tx.clone()];
+        let decided_ids: Vec<Txid> = decided_all.iter().map(|t| t.compute_txid()).collect();
 
         // Pass one already ran: `first` was excluded, and the decision carries the
         // full decided list alongside the narrowed transactions.
         let (mut decision, _) = carrying(14, vec![second.clone(), survivor_tx.clone()]);
-        decision.certified_txids = Some(decided_all.clone());
+        decision.certified_txs = Some(decided_all.clone());
 
         // Pass two excludes `second`.
         let excluded: HashSet<Txid> = [second.compute_txid()].into();
@@ -1841,8 +1886,8 @@ mod tests {
             "only the untouched tx should remain executable"
         );
         assert_eq!(
-            queue[0].certified_txids.as_deref(),
-            Some(&decided_all[..]),
+            queue[0].decided_txids(),
+            decided_ids,
             "the ORIGINAL decided list must survive a second narrowing"
         );
     }
@@ -1850,14 +1895,14 @@ mod tests {
     /// Nothing excluded means nothing to preserve — the value is already the
     /// decided content and a redundant copy would just be a second answer.
     #[test]
-    fn build_replay_queue_leaves_certified_txids_unset_when_nothing_is_filtered() {
+    fn build_replay_queue_leaves_certified_txs_unset_when_nothing_is_filtered() {
         let a = tx(&[OutPoint::null()], 1);
         let (queue, _) = build_replay_queue(
             vec![carrying(10, vec![a.clone()])],
             Vec::new(),
             &HashSet::new(),
         );
-        assert!(queue[0].certified_txids.is_none());
+        assert!(queue[0].certified_txs.is_none());
     }
 
     /// A queued decision BELOW the replay set's max must SURVIVE. Anchors go

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -17,8 +17,9 @@ use crate::consensus::codec::encode_commit_certificate;
 use crate::consensus::finality_types::{DecidedBatch, StateEvent, UnfinalizedBatch, deadline_for};
 use crate::consensus::{CommitCertificate, Ctx, Height, ProposalData, Value};
 use crate::database::queries::{
-    insert_batch, insert_batch_txids, insert_transaction, insert_unconfirmed_batch_tx,
-    select_block_at_height, select_existing_txids, select_previously_excluded_txids,
+    insert_batch, insert_batch_txids, insert_excluded_batch_txids, insert_transaction,
+    insert_unconfirmed_batch_tx, select_block_at_height, select_excluded_batch_txids,
+    select_existing_txids,
 };
 use crate::metrics::{CONSENSUS_HEIGHT, ITEMS_INDEXED};
 
@@ -912,6 +913,17 @@ impl<E: Executor> Reactor<E> {
         let (queue, excluded) = build_replay_queue(replayed, survivors, &excluded_txids);
         self.consensus.deferred_decisions = queue;
 
+        // Record what this pass dropped, so a later pass cannot reload it from the
+        // append-only certified list and execute it again.
+        let dropped: Vec<String> = excluded.iter().map(|t| t.to_string()).collect();
+        if let Err(e) = insert_excluded_batch_txids(&self.db_conn(), &dropped).await {
+            warn!(
+                error = %e,
+                count = dropped.len(),
+                "Failed to record this pass's exclusions; a later replay may re-include them"
+            );
+        }
+
         // The excluded txids must also leave the proposal pool, or the next
         // make_value re-proposes the very txs whose missing confirmations caused
         // this rollback — repeating the same finality failure with no progress.
@@ -1002,17 +1014,20 @@ impl<E: Executor> Reactor<E> {
             .await
             .context("load_replay_decisions failed")?;
 
-        // Carry forward what earlier passes already excluded, for the same reason and
-        // from the same rows (also pre-truncation). The replay reloads each batch from
-        // the append-only `batch_txids`, so without this the exclusion set is rebuilt
-        // from scratch every pass: pass one drops Y and keeps X, a later reorg
-        // un-confirms X, pass two drops X and puts Y BACK — the transaction pass one
-        // already proved never confirms. The two passes then alternate forever and the
-        // tip oscillates with no progress, deterministically on every node, which is a
-        // network-wide liveness halt rather than a divergence. Unioning makes the set
-        // monotone, so a batch can only ever shrink and the replay terminates.
+        // Carry forward what earlier passes already excluded (pre-truncation, like the
+        // load above). The replay reloads each batch from the append-only
+        // `batch_txids`, so without this the exclusion set is rebuilt from scratch
+        // every pass: pass one drops Y and keeps X, a later reorg un-confirms X, pass
+        // two drops X and puts Y BACK — the transaction pass one already proved never
+        // confirms. The two alternate forever and the tip oscillates with no progress,
+        // deterministically on every node. Unioning makes the set monotone.
+        //
+        // Read from the RECORD of what we excluded, never re-derived as "certified but
+        // not executed": that predicate is also true of a record-only batch, whose txs
+        // its peers DID run, and excluding those would diverge this node's state from
+        // the network — a worse failure than the one being fixed.
         let mut excluded = excluded;
-        match select_previously_excluded_txids(&conn, rollback_anchor).await {
+        match select_excluded_batch_txids(&conn).await {
             Ok(previous) => {
                 for txid in previous {
                     if let Ok(parsed) = txid.parse::<Txid>() {
@@ -1024,7 +1039,6 @@ impl<E: Executor> Reactor<E> {
                 // Not fatal, but it removes the termination guarantee — say so.
                 warn!(
                     error = %e,
-                    from_anchor = rollback_anchor,
                     "Could not load previously excluded txids; replay may re-include a \
                      transaction an earlier pass dropped"
                 );

--- a/core/indexer/src/reactor/blocks.rs
+++ b/core/indexer/src/reactor/blocks.rs
@@ -174,19 +174,38 @@ impl<E: Executor> Reactor<E> {
     /// then rollback. Unlike `/inspect`, this carries live error strings —
     /// they're not persisted to chain state, only available here while the
     /// virtual block is still in scope.
+    /// Runs the simulation with its out-of-transaction state restored on EVERY
+    /// exit, not just the successful one.
+    ///
+    /// The savepoint covers the database; these two are outside it. The inner
+    /// function is full of `?`, so restoring at the end of it would silently skip
+    /// on error — which is how the height restore was written, and it survives only
+    /// because the caller kills the node on a simulate error. That makes a `bail!`
+    /// load-bearing for correctness, which it should not be.
     pub(super) async fn simulate(
+        &mut self,
+        tx: indexer_types::Transaction,
+    ) -> Result<Vec<OpWithResult>> {
+        let restore_height = self.runtime.storage.height;
+        self.runtime.simulating = true;
+        let result = self.simulate_inner(tx).await;
+        self.runtime.simulating = false;
+        self.runtime.storage.height = restore_height;
+        result
+    }
+
+    async fn simulate_inner(
         &mut self,
         tx: indexer_types::Transaction,
     ) -> Result<Vec<OpWithResult>> {
         // Simulation runs against a FABRICATED block one past the tip and then
         // rolls it away. `execute_block` sets `storage.height` to that block as it
-        // goes, so without restoring it here the runtime is left pointing at a
-        // height whose `blocks` row no longer exists. The next identity created
+        // goes, so without the restore in `simulate` the runtime is left pointing at
+        // a height whose `blocks` row no longer exists. The next identity created
         // outside a `set_context` — a decided batch executing at the real tip, say —
         // then inserts `signers(height = <discarded height>)` and trips the
         // `signers.height -> blocks.height` foreign key, which is classified
         // non-deterministic and kills the reactor.
-        let restore_height = self.runtime.storage.height;
         self.runtime
             .storage
             .savepoint()
@@ -236,7 +255,6 @@ impl<E: Executor> Reactor<E> {
             .rollback()
             .await
             .context("Failed to rollback simulation")?;
-        self.runtime.storage.height = restore_height;
         Ok(results)
     }
 

--- a/core/indexer/src/reactor/blocks.rs
+++ b/core/indexer/src/reactor/blocks.rs
@@ -94,6 +94,35 @@ impl<E: Executor> Reactor<E> {
         Ok(())
     }
 
+    /// The fallible body of `handle_block`'s transaction: the decision record
+    /// (when the block arrives decided) plus the block's own writes. Split out
+    /// so `handle_block` has a single place to roll back from.
+    async fn block_txn(
+        &mut self,
+        block: &Block,
+        decision: &consensus_state::DeferredDecision,
+    ) -> Result<(usize, u64)> {
+        insert_batch(
+            &self.db_conn(),
+            decision.consensus_height.as_u64(),
+            block.height,
+            &block.hash.to_string(),
+            &decision.certificate,
+            true,
+        )
+        .await
+        .context("Failed to insert block batch decision")?;
+
+        let (unbatched_count, executed_ops, _failures) = self
+            .execute_block(block)
+            .await
+            .context("execute_block failed")?;
+        self.run_block_lifecycle(block)
+            .await
+            .context("run_block_lifecycle failed")?;
+        Ok((unbatched_count, executed_ops))
+    }
+
     /// Execute a block: insert block row, process transactions.
     /// Returns the number of unbatched (non-deduped) transactions, the count
     /// of ops actually executed (only ops in non-deduped txs — deduped txs
@@ -108,37 +137,6 @@ impl<E: Executor> Reactor<E> {
     ///
     /// The reactor's canonical block-processing path discards this; the
     /// simulate handler consumes it.
-    /// The fallible body of `handle_block`'s transaction: the decision record
-    /// (when the block arrives decided) plus the block's own writes. Split out
-    /// so `handle_block` has a single place to roll back from.
-    async fn block_txn(
-        &mut self,
-        block: &Block,
-        decision: Option<&consensus_state::DeferredDecision>,
-    ) -> Result<(usize, u64)> {
-        if let Some(decision) = decision {
-            insert_batch(
-                &self.db_conn(),
-                decision.consensus_height.as_u64(),
-                block.height,
-                &block.hash.to_string(),
-                &decision.certificate,
-                true,
-            )
-            .await
-            .context("Failed to insert block batch decision")?;
-        }
-
-        let (unbatched_count, executed_ops, _failures) = self
-            .execute_block(block)
-            .await
-            .context("execute_block failed")?;
-        self.run_block_lifecycle(block)
-            .await
-            .context("run_block_lifecycle failed")?;
-        Ok((unbatched_count, executed_ops))
-    }
-
     pub(super) async fn execute_block(
         &mut self,
         block: &Block,
@@ -337,18 +335,13 @@ impl<E: Executor> Reactor<E> {
         Ok(())
     }
 
-    pub(super) async fn handle_block_with_decision(
-        &mut self,
-        block: Block,
-        decision: &consensus_state::DeferredDecision,
-    ) -> Result<()> {
-        self.handle_block(block, Some(decision))
-            .await
-            .context("handle_block failed after block batch decision")
-    }
-
-    /// Execute `block` and, when it arrives decided, record that decision in the
-    /// SAME transaction as the block's own writes.
+    /// Execute `block` and record the decision that certifies it in the SAME
+    /// transaction as the block's own writes.
+    ///
+    /// The decision is NOT optional: a block is only ever executed because
+    /// consensus decided it, and taking it by value rather than `Option` makes
+    /// "no block executes without a consensus record" a type-level fact instead
+    /// of a convention a future caller could opt out of.
     ///
     /// A consensus record and the execution it certifies must commit or fail
     /// together. Writing the `batches` row first — as this did — let a node keep
@@ -360,7 +353,7 @@ impl<E: Executor> Reactor<E> {
     pub(super) async fn handle_block(
         &mut self,
         block: Block,
-        decision: Option<&consensus_state::DeferredDecision>,
+        decision: &consensus_state::DeferredDecision,
     ) -> Result<()> {
         let started_at = Instant::now();
         let height = block.height;

--- a/core/indexer/src/reactor/blocks.rs
+++ b/core/indexer/src/reactor/blocks.rs
@@ -108,6 +108,37 @@ impl<E: Executor> Reactor<E> {
     ///
     /// The reactor's canonical block-processing path discards this; the
     /// simulate handler consumes it.
+    /// The fallible body of `handle_block`'s transaction: the decision record
+    /// (when the block arrives decided) plus the block's own writes. Split out
+    /// so `handle_block` has a single place to roll back from.
+    async fn block_txn(
+        &mut self,
+        block: &Block,
+        decision: Option<&consensus_state::DeferredDecision>,
+    ) -> Result<(usize, u64)> {
+        if let Some(decision) = decision {
+            insert_batch(
+                &self.db_conn(),
+                decision.consensus_height.as_u64(),
+                block.height,
+                &block.hash.to_string(),
+                &decision.certificate,
+                true,
+            )
+            .await
+            .context("Failed to insert block batch decision")?;
+        }
+
+        let (unbatched_count, executed_ops, _failures) = self
+            .execute_block(block)
+            .await
+            .context("execute_block failed")?;
+        self.run_block_lifecycle(block)
+            .await
+            .context("run_block_lifecycle failed")?;
+        Ok((unbatched_count, executed_ops))
+    }
+
     pub(super) async fn execute_block(
         &mut self,
         block: &Block,
@@ -311,23 +342,26 @@ impl<E: Executor> Reactor<E> {
         block: Block,
         decision: &consensus_state::DeferredDecision,
     ) -> Result<()> {
-        insert_batch(
-            &self.db_conn(),
-            decision.consensus_height.as_u64(),
-            block.height,
-            &block.hash.to_string(),
-            &decision.certificate,
-            true,
-        )
-        .await
-        .context("Failed to insert block batch decision")?;
-        self.handle_block(block)
+        self.handle_block(block, Some(decision))
             .await
-            .context("handle_block failed after block batch decision")?;
-        Ok(())
+            .context("handle_block failed after block batch decision")
     }
 
-    pub(super) async fn handle_block(&mut self, block: Block) -> Result<()> {
+    /// Execute `block` and, when it arrives decided, record that decision in the
+    /// SAME transaction as the block's own writes.
+    ///
+    /// A consensus record and the execution it certifies must commit or fail
+    /// together. Writing the `batches` row first — as this did — let a node keep
+    /// a row claiming a height it never executed: the row survived, the
+    /// execution did not, and every restart then resumed consensus above state
+    /// the node did not hold. `delete_unexecuted_batch_suffix` cleans that up at
+    /// startup, but the window should not exist at all; `process_decided_batch`
+    /// has always taken the savepoint first, and the block path was the outlier.
+    pub(super) async fn handle_block(
+        &mut self,
+        block: Block,
+        decision: Option<&consensus_state::DeferredDecision>,
+    ) -> Result<()> {
         let started_at = Instant::now();
         let height = block.height;
         let hash = block.hash;
@@ -356,28 +390,40 @@ impl<E: Executor> Reactor<E> {
             );
         }
 
-        self.last_height = height;
-        self.last_hash = Some(hash);
-
         self.runtime
             .storage
             .savepoint()
             .await
             .context("Failed to begin block transaction")?;
 
-        let (unbatched_count, executed_ops, _failures) = self
-            .execute_block(&block)
-            .await
-            .context("execute_block failed")?;
-        self.run_block_lifecycle(&block)
-            .await
-            .context("run_block_lifecycle failed")?;
+        // Everything up to the commit is one transaction, rolled back explicitly
+        // on any error rather than left open for process teardown to discard.
+        // `last_height`/`last_hash` advance only after the commit, so a failed
+        // block leaves no trace in memory either.
+        let txn = self.block_txn(&block, decision).await;
+        let (unbatched_count, executed_ops) = match txn {
+            Ok(counts) => counts,
+            Err(e) => {
+                if let Err(rollback_err) = self.runtime.storage.rollback().await {
+                    warn!(error = %rollback_err, height, "Failed to roll back block transaction");
+                }
+                return Err(e);
+            }
+        };
 
         self.runtime
             .storage
             .commit()
             .await
             .context("Failed to commit block transaction")?;
+
+        self.last_height = height;
+        self.last_hash = Some(hash);
+        // Blocks at or below the tip can no longer be proposed or decided.
+        // Dropping them keeps `make_value` proposing only heights still ahead,
+        // and keeps `validate_batch`'s "a block is pending" gate honest.
+        self.consensus.pending_blocks.retain(|&h, _| h > height);
+
         // Reflect what's actually persisted, not what we're mid-processing.
         // Op counter increments only after commit so the simulation path
         // (rolls back instead of committing) doesn't inflate it.

--- a/core/indexer/src/reactor/blocks.rs
+++ b/core/indexer/src/reactor/blocks.rs
@@ -154,6 +154,15 @@ impl<E: Executor> Reactor<E> {
         &mut self,
         tx: indexer_types::Transaction,
     ) -> Result<Vec<OpWithResult>> {
+        // Simulation runs against a FABRICATED block one past the tip and then
+        // rolls it away. `execute_block` sets `storage.height` to that block as it
+        // goes, so without restoring it here the runtime is left pointing at a
+        // height whose `blocks` row no longer exists. The next identity created
+        // outside a `set_context` — a decided batch executing at the real tip, say —
+        // then inserts `signers(height = <discarded height>)` and trips the
+        // `signers.height -> blocks.height` foreign key, which is classified
+        // non-deterministic and kills the reactor.
+        let restore_height = self.runtime.storage.height;
         self.runtime
             .storage
             .savepoint()
@@ -203,6 +212,7 @@ impl<E: Executor> Reactor<E> {
             .rollback()
             .await
             .context("Failed to rollback simulation")?;
+        self.runtime.storage.height = restore_height;
         Ok(results)
     }
 

--- a/core/indexer/src/reactor/blocks.rs
+++ b/core/indexer/src/reactor/blocks.rs
@@ -36,6 +36,30 @@ const PRUNE_VACUUM_HIGH_PAGES: i64 = 512; // ~2 MiB slack before we bother recla
 const PRUNE_VACUUM_MAX_PAGES: i64 = 512; // ~2 MiB returned per call (bounds lock hold)
 
 impl<E: Executor> Reactor<E> {
+    /// Refuse a rollback that reaches below what pruning retains.
+    ///
+    /// Reconstructing state as of `to_height` needs the superseded `contract_state`
+    /// versions, and the GC removes those below the retain window — so truncating
+    /// past it does not roll state back, it corrupts it silently. Both rollback
+    /// paths must check: the Bitcoin-reorg path has always been able to go deep, and
+    /// the finality path can now too, because tracking is rehydrated from disk and a
+    /// node that missed a verdict may carry a batch anchored far below its tip.
+    pub(super) fn check_rollback_depth(&self, to_height: u64) -> Result<()> {
+        if !self.prune.enabled {
+            return Ok(());
+        }
+        let retain = self.prune.retain_blocks.max(FINALITY_WINDOW);
+        if self.last_height.saturating_sub(to_height) > retain {
+            bail!(
+                "rollback to height {to_height} is deeper than the prune retain window \
+                 ({retain}) below tip {}; pruned state cannot be rolled back locally — \
+                 re-sync required",
+                self.last_height
+            );
+        }
+        Ok(())
+    }
+
     pub(super) async fn rollback(&mut self, height: u64) -> Result<()> {
         // The `blocks` cascade + the off-checkpoint footprint-cache reversal run
         // together in one savepoint (capture-before, recompute-after enforced inside),

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -30,9 +30,9 @@ use crate::consensus::{
 };
 use crate::database::queries::{
     delete_unexecuted_batch_suffix, get_checkpoint_latest, get_transaction_by_txid,
-    select_batches_from_anchor, select_batches_in_range, select_block_at_height,
-    select_block_latest, select_existing_txids, select_latest_consensus_height,
-    select_min_batch_height, select_unconfirmed_batch_txs,
+    min_unconfirmed_batch_tx_height, select_batches_from_anchor, select_batches_in_range,
+    select_block_at_height, select_existing_txids, select_latest_consensus_height,
+    select_min_batch_height, select_unconfirmed_batch_txs, select_unfinalized_batches,
 };
 
 /// Result from processing a consensus message.
@@ -145,6 +145,40 @@ async fn missing_txids(conn: &libsql::Connection, batch: &UnfinalizedBatch) -> V
         }
     }
     missing
+}
+
+/// Rebuild the in-memory finality-tracking set from disk at startup.
+///
+/// A batch is still tracked iff its anchor sits in the window ending at `tip`, so
+/// this reconstructs exactly what a node that never restarted would be holding.
+async fn load_unfinalized_batches(
+    conn: &libsql::Connection,
+    tip: u64,
+) -> Result<Vec<UnfinalizedBatch>> {
+    let rows = select_unfinalized_batches(conn, tracking_floor(tip))
+        .await
+        .context("Failed to query unfinalized batches")?;
+    let mut batches = Vec::with_capacity(rows.len());
+    for row in rows {
+        let anchor_hash = row
+            .anchor_hash
+            .parse::<bitcoin::BlockHash>()
+            .with_context(|| format!("Bad anchor hash for batch {}", row.consensus_height))?;
+        let txids = row
+            .txids
+            .iter()
+            .map(|t| t.parse::<Txid>())
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .with_context(|| format!("Bad txid for batch {}", row.consensus_height))?;
+        batches.push(UnfinalizedBatch {
+            consensus_height: Height::new(row.consensus_height),
+            anchor_height: row.anchor_height,
+            anchor_hash,
+            txids,
+            deadline: deadline_for(row.anchor_height),
+        });
+    }
+    Ok(batches)
 }
 
 /// Decide what an at-deadline set means, given each batch's unconfirmed txids.
@@ -276,6 +310,43 @@ impl ConsensusState {
             }
             _ => Height::new(1),
         };
+
+        // Rebuild finality tracking. Without this a restart inside the window drops
+        // every pending deadline, so the node never performs a rollback its peers do
+        // and its `transactions` table keeps rows theirs no longer have — the
+        // divergence behind #515. Runs AFTER the suffix cleanup above, both so we
+        // never re-track a batch it just deleted and because that cleanup is what
+        // bounds the band on a lagging node (the anchor-mismatch record-only branch
+        // writes rows at the PROPOSED higher anchor).
+        let unfinalized_batches = load_unfinalized_batches(&conn, last_block_height)
+            .await
+            .context("Failed to rehydrate finality tracking")?;
+        if !unfinalized_batches.is_empty() {
+            info!(
+                count = unfinalized_batches.len(),
+                tip = last_block_height,
+                "Rehydrated finality tracking"
+            );
+        }
+
+        // Divergence probe, diagnostic only. A batch-executed transaction still
+        // unconfirmed below the finality window is past the point where a rollback
+        // can act on it, and if it later confirms this node dedups where a peer
+        // executes — same ops, different heights, forked checkpoints. Deliberately a
+        // WARNING rather than a startup refusal: the predicate has legitimate
+        // transient hits (a node stopped between a deadline passing and its check),
+        // and bricking a healthy validator is worse than the fork it screens for.
+        match min_unconfirmed_batch_tx_height(&conn).await {
+            Ok(Some(height)) if height < tracking_floor(last_block_height) => warn!(
+                height,
+                floor = tracking_floor(last_block_height),
+                "Unconfirmed batch transaction below the finality window — this node may have \
+                 diverged from its peers; compare checkpoints and re-sync if they differ"
+            ),
+            Ok(_) => {}
+            Err(e) => warn!(error = %e, "Divergence probe failed"),
+        }
+
         Ok(Self {
             signing_provider,
             address,
@@ -284,7 +355,7 @@ impl ConsensusState {
             current_height,
             current_round: Round::new(0),
             undecided: BTreeMap::new(),
-            unfinalized_batches: Vec::new(),
+            unfinalized_batches,
             deferred_decisions: VecDeque::new(),
             pending_blocks: BTreeMap::new(),
             current_validator_set,
@@ -299,11 +370,25 @@ impl ConsensusState {
 
     /// Clear consensus state that is invalidated by a reorg rollback.
     /// Pending blocks, cached blocks, and in-flight batch data are all stale.
-    pub fn clear_on_rollback(&mut self) {
+    pub async fn clear_on_rollback(&mut self, conn: &libsql::Connection, to_height: u64) {
         self.pending_blocks.clear();
         self.deferred_decisions.clear();
-        self.unfinalized_batches.clear();
         self.pending_proposal = None;
+        // Finality tracking is RE-DERIVED, not cleared. Batches anchored at or below
+        // the fork are untouched by the rollback — their `transactions` rows carry
+        // `height = anchor_height` and survive the cascade — so discarding their
+        // deadlines reopens exactly the #515 hole on the reorg path. Re-deriving
+        // rather than filtering in memory also drops the batches whose anchor block
+        // was replaced: the query joins the block CURRENTLY at that height by hash.
+        match load_unfinalized_batches(conn, to_height).await {
+            Ok(batches) => self.unfinalized_batches = batches,
+            Err(e) => {
+                // Losing tracking here is the #515 divergence, so make it loud
+                // rather than silently continuing with a stale set.
+                warn!(error = %e, to_height, "Failed to re-derive finality tracking after rollback");
+                self.unfinalized_batches.clear();
+            }
+        }
     }
 
     fn validator_set(&self) -> ValidatorSet {
@@ -505,22 +590,24 @@ impl ConsensusState {
         }
     }
 
+    /// Raw transactions we still hold for a decided batch, for sync to attach.
+    ///
+    /// Deliberately unbounded by the finality window. Gating on it made every
+    /// historical batch sync as txids only, and a peer that has to resolve a txid
+    /// tries its mempool, then its DB, then bitcoind — none of which can produce a
+    /// transaction that never confirmed and was excluded by a finality rollback.
+    /// `resolve_batch_txs` then bails and the reactor exits, so a chain that had
+    /// ever performed an exclusion was not reliably re-syncable from genesis.
+    ///
+    /// Serving whatever remains is self-limiting: `unconfirmed_batch_txs` rows are
+    /// deleted on confirmation and by the startup suffix cleanup, so a batch whose
+    /// transactions all confirmed has none and the only rows ever served are the
+    /// otherwise-unresolvable ones.
     async fn load_raw_txs_if_unfinalized(
         &self,
         conn: &libsql::Connection,
-        anchor_height: u64,
         consensus_height: u64,
     ) -> Result<Option<Vec<bitcoin::Transaction>>> {
-        let tip = match select_block_latest(conn)
-            .await
-            .context("Failed to query latest block for finality check")?
-        {
-            Some(tip) => tip,
-            None => return Ok(None),
-        };
-        if anchor_height + FINALITY_WINDOW <= tip.height {
-            return Ok(None);
-        }
         let raw_bytes = select_unconfirmed_batch_txs(conn, consensus_height)
             .await
             .context("Failed to query unconfirmed batch txs")?;
@@ -582,7 +669,7 @@ impl ConsensusState {
 
             if !b.is_block
                 && let Some(raw_txs) = self
-                    .load_raw_txs_if_unfinalized(conn, b.anchor_height, b.consensus_height)
+                    .load_raw_txs_if_unfinalized(conn, b.consensus_height)
                     .await?
             {
                 value.set_raw_txs(raw_txs);

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -29,10 +29,11 @@ use crate::consensus::{
     ValidatorSet, Value,
 };
 use crate::database::queries::{
-    delete_unexecuted_batch_suffix, get_checkpoint_latest, get_transaction_by_txid,
-    min_unsettled_batch_tx_height, select_batches_from_anchor, select_batches_in_range,
-    select_block_at_height, select_existing_txids, select_latest_consensus_height,
-    select_min_batch_height, select_unconfirmed_batch_txs, select_unfinalized_batches,
+    delete_unexecuted_batch_suffix, get_checkpoint_latest, get_transaction_by_txid, insert_batch,
+    insert_batch_txids, min_unsettled_batch_tx_height, select_batches_from_anchor,
+    select_batches_in_range, select_block_at_height, select_existing_txids,
+    select_latest_consensus_height, select_min_batch_height, select_unconfirmed_batch_txs,
+    select_unfinalized_batches,
 };
 
 /// Result from processing a consensus message.
@@ -170,6 +171,64 @@ async fn missing_txids(conn: &libsql::Connection, batch: &UnfinalizedBatch) -> R
         }
     }
     Ok(missing)
+}
+
+/// Write the decided record for every decision still sitting in the queue, so
+/// discarding the queue does not discard consensus history.
+///
+/// Best-effort, matching `record_declined_block`. Propagating would take the node
+/// down on a reorg for a transient DB error, and since the queue lives only in memory
+/// the decisions would be lost on restart anyway — strictly worse than a loud warning.
+/// The `batches` row is what a syncing peer needs; the batch's decided txid list goes
+/// with it (I4), but no `unconfirmed_batch_txs` rows, because this node held nothing.
+async fn record_undrained_decisions(
+    conn: &libsql::Connection,
+    decisions: &VecDeque<DeferredDecision>,
+) {
+    for decision in decisions {
+        let consensus_height = decision.consensus_height.as_u64();
+        if let Err(e) = insert_batch(
+            conn,
+            consensus_height,
+            decision.value.block_height(),
+            &decision.value.block_hash().to_string(),
+            &decision.certificate,
+            decision.value.is_block(),
+        )
+        .await
+        {
+            warn!(
+                error = %e,
+                consensus_height,
+                "Failed to record an undrained decision — consensus history now has a gap"
+            );
+            continue;
+        }
+
+        if decision.value.is_block() {
+            continue;
+        }
+        // The DECIDED list, which is the full one even if a replay had narrowed what
+        // this node would have executed.
+        let txids: Vec<String> = match &decision.certified_txids {
+            Some(decided) => decided.iter().map(|t| t.to_string()).collect(),
+            None => decision
+                .value
+                .batch_txids()
+                .iter()
+                .map(|t| t.to_string())
+                .collect(),
+        };
+        if !txids.is_empty()
+            && let Err(e) = insert_batch_txids(conn, consensus_height, &txids).await
+        {
+            warn!(
+                error = %e,
+                consensus_height,
+                "Failed to record an undrained batch's decided txids"
+            );
+        }
+    }
 }
 
 /// Probe every batch whose deadline has passed, in the order `check_finality` will
@@ -439,6 +498,15 @@ impl ConsensusState {
         to_height: u64,
     ) -> Result<()> {
         self.pending_blocks.clear();
+        // Record before discarding. A queued decision is queued precisely BECAUSE it
+        // could not be applied, so unlike the executed and record-only ones it has
+        // written NO `batches` row — clearing it erases the only copy of that
+        // consensus height (I3). `current_height` is already past it so it is never
+        // re-decided, and `delete_unexecuted_batch_suffix` trims a SUFFIX, so the hole
+        // is permanent and this node becomes a defective sync source for any range
+        // covering it. The drain's two discard paths already record; this was the
+        // third and only unrecorded one.
+        record_undrained_decisions(conn, &self.deferred_decisions).await;
         self.deferred_decisions.clear();
         self.pending_proposal = None;
         // Finality tracking is RE-DERIVED, not cleared. Batches anchored at or below
@@ -863,8 +931,12 @@ impl ConsensusState {
 
 #[cfg(test)]
 mod tests {
-    use super::{UnfinalizedBatch, build_finality_events, missing_txids, probe_at_deadline};
+    use super::{
+        DeferredDecision, UnfinalizedBatch, VecDeque, build_finality_events, missing_txids,
+        probe_at_deadline, record_undrained_decisions,
+    };
     use crate::consensus::Height;
+    use crate::consensus::Value;
     use crate::consensus::finality_types::FinalityEvent;
     use crate::database::queries::{confirm_transaction, insert_block, insert_transaction};
     use crate::test_utils::{new_mock_block_hash, new_test_db};
@@ -1110,6 +1182,62 @@ mod tests {
             missing_txids(&conn, &b).await.is_err(),
             "a failed read must propagate — reporting the txid as missing would \
              render a consensus verdict on a table this node could not read"
+        );
+    }
+
+    /// A reorg discards the deferred queue, and every entry in it is there precisely
+    /// BECAUSE it could not be applied — so none of them has a `batches` row yet.
+    /// Dropping them silently erases those consensus heights: nothing re-decides them
+    /// (`current_height` is already past), and the startup cleanup only trims a
+    /// SUFFIX, so a middle hole is permanent and this node can never serve those
+    /// heights to a syncing peer. That is I3, violated on the one discard path the
+    /// rest of this PR did not cover.
+    #[tokio::test]
+    async fn undrained_decisions_are_recorded_before_the_queue_is_discarded() {
+        let (_reader, writer, _dir) = new_test_db().await.unwrap();
+        let conn = writer.connection();
+
+        let mut queued: VecDeque<DeferredDecision> = VecDeque::new();
+        queued.push_back(DeferredDecision {
+            consensus_height: Height::new(41),
+            value: Value::new_block(300, BlockHash::all_zeros()),
+            certificate: vec![1, 2, 3],
+            certified_txids: None,
+        });
+        queued.push_back(DeferredDecision {
+            consensus_height: Height::new(42),
+            value: Value::new_batch_raw(301, BlockHash::all_zeros(), vec![]),
+            certificate: vec![4, 5, 6],
+            // A replay had already narrowed this one — the DECIDED list is what a
+            // syncing peer needs, not the empty set we would have executed.
+            certified_txids: Some(vec![txid(7), txid(8)]),
+        });
+
+        record_undrained_decisions(&conn, &queued).await;
+
+        for h in [41u64, 42] {
+            let mut rows = conn
+                .query(
+                    "SELECT COUNT(*) FROM batches WHERE consensus_height = ?",
+                    [h],
+                )
+                .await
+                .unwrap();
+            let n: u64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+            assert_eq!(n, 1, "consensus height {h} must leave a row in `batches`");
+        }
+
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM batch_txids WHERE batch_height = ?",
+                [42u64],
+            )
+            .await
+            .unwrap();
+        let n: u64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert_eq!(
+            n, 2,
+            "the batch's DECIDED txid list must be recorded, not the narrowed one"
         );
     }
 

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -143,18 +143,32 @@ pub struct ObservationChannels {
 /// a tx confirmed one block past the deadline reads missing to a node evaluating at
 /// the deadline and confirmed to one evaluating later. Two honest nodes then
 /// disagree about the same batch and one rolls back while the other finalizes it.
-async fn missing_txids(conn: &libsql::Connection, batch: &UnfinalizedBatch) -> Vec<Txid> {
+///
+/// Fallible on purpose. "No row" and "could not read the table" are different
+/// facts: the first is a verdict, the second is this node's own I/O failing, and
+/// folding them together turns a transient SQLITE_BUSY or WAL hiccup into a
+/// consensus decision. The damage is not transient — the resulting rollback
+/// deletes the transaction's row and the replay drops it from the batch, so it is
+/// later re-executed as an unbatched block transaction at a different height than
+/// every peer used, and nothing detects the divergence because the decided value
+/// carries no state root. Propagating instead costs a retry on the next tip move:
+/// `unfinalized_batches` is left untouched, and a fault that does not clear
+/// exits the node, which is recoverable since tracking is rehydrated from disk.
+/// This matches `execute_block`'s handling of the same query and the reasoning
+/// already written down in `clear_on_rollback`.
+async fn missing_txids(conn: &libsql::Connection, batch: &UnfinalizedBatch) -> Result<Vec<Txid>> {
     let mut missing = Vec::new();
     for txid in &batch.txids {
-        let confirmed = match get_transaction_by_txid(conn, &txid.to_string()).await {
-            Ok(Some(row)) => row.confirmed_height.is_some_and(|h| h <= batch.deadline),
-            _ => false,
-        };
+        let row = get_transaction_by_txid(conn, &txid.to_string())
+            .await
+            .with_context(|| format!("Failed to read transaction {txid} for a finality verdict"))?;
+        let confirmed =
+            row.is_some_and(|r| r.confirmed_height.is_some_and(|h| h <= batch.deadline));
         if !confirmed {
             missing.push(*txid);
         }
     }
-    missing
+    Ok(missing)
 }
 
 /// Rebuild the in-memory finality-tracking set from disk at startup.
@@ -509,7 +523,7 @@ impl ConsensusState {
         &mut self,
         conn: &libsql::Connection,
         last_height: u64,
-    ) -> Vec<FinalityEvent> {
+    ) -> Result<Vec<FinalityEvent>> {
         let mut events = Vec::new();
         let tip = last_height;
 
@@ -531,7 +545,7 @@ impl ConsensusState {
 
         let mut missing_per_batch = Vec::with_capacity(at_deadline.len());
         for batch in &at_deadline {
-            missing_per_batch.push(missing_txids(conn, batch).await);
+            missing_per_batch.push(missing_txids(conn, batch).await?);
         }
 
         let (built, surviving) = build_finality_events(
@@ -541,7 +555,7 @@ impl ConsensusState {
         );
         events.extend(built);
         self.unfinalized_batches = surviving;
-        events
+        Ok(events)
     }
 
     pub(super) fn emit_finality_events(&self, events: &[FinalityEvent]) {
@@ -733,8 +747,8 @@ impl ConsensusState {
         &mut self,
         conn: &libsql::Connection,
         last_height: u64,
-    ) -> (Vec<FinalityEvent>, Option<(u64, HashSet<Txid>)>) {
-        let finality_events = self.check_finality(conn, last_height).await;
+    ) -> Result<(Vec<FinalityEvent>, Option<(u64, HashSet<Txid>)>)> {
+        let finality_events = self.check_finality(conn, last_height).await?;
         // At most one Rollback per pass — `check_finality` folds every failing
         // at-deadline batch into a single event. Taking the FIRST rather than the
         // last matters if that ever regresses: last-wins would keep the highest
@@ -761,7 +775,7 @@ impl ConsensusState {
         // Deliberately NOT emitted here. A rollback the caller then refuses — because
         // it would reach below the prune watermark — must not be announced as though
         // it happened. The caller emits once it has committed to acting.
-        (finality_events, result)
+        Ok((finality_events, result))
     }
 
     /// Validate batch-level rules. Returns a rejection reason if any rule
@@ -1014,14 +1028,17 @@ mod tests {
         let b = batch(500, 10, &[1, 2]);
         assert_eq!(b.deadline, 16);
         assert_eq!(
-            missing_txids(&conn, &b).await,
+            missing_txids(&conn, &b).await.expect("probe must read"),
             vec![txid(2)],
             "the tx confirmed at deadline+1 must count as missing"
         );
 
         // The same batch against the same tables gives the same answer regardless
         // of how far the chain has moved on — there is no tip input at all.
-        assert_eq!(missing_txids(&conn, &b).await, vec![txid(2)]);
+        assert_eq!(
+            missing_txids(&conn, &b).await.expect("probe must read"),
+            vec![txid(2)]
+        );
     }
 
     #[tokio::test]
@@ -1029,6 +1046,34 @@ mod tests {
         let (_reader, writer, _dir) = new_test_db().await.unwrap();
         let conn = writer.connection();
         let b = batch(500, 10, &[9]);
-        assert_eq!(missing_txids(&conn, &b).await, vec![txid(9)]);
+        assert_eq!(
+            missing_txids(&conn, &b).await.expect("probe must read"),
+            vec![txid(9)]
+        );
+    }
+
+    /// "No row" is a verdict; "could not read the table" is this node's own I/O
+    /// failing. Folding the second into the first turns a transient DB fault into a
+    /// consensus rollback that excludes a transaction which DID confirm — and the
+    /// damage outlives the fault, because the replay drops that tx and it is later
+    /// re-executed as an unbatched block transaction at a height no peer used.
+    /// Nothing detects the divergence: the decided value carries no state root.
+    #[tokio::test]
+    async fn an_unreadable_table_yields_an_error_not_a_verdict() {
+        let (_reader, writer, _dir) = new_test_db().await.unwrap();
+        let conn = writer.connection();
+
+        // Stand-in for any read failure: with the table gone, the query errors
+        // rather than returning "no such transaction".
+        conn.execute("DROP TABLE transactions", ())
+            .await
+            .expect("drop transactions");
+
+        let b = batch(500, 10, &[1]);
+        assert!(
+            missing_txids(&conn, &b).await.is_err(),
+            "a failed read must propagate — reporting the txid as missing would \
+             render a consensus verdict on a table this node could not read"
+        );
     }
 }

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -315,14 +315,17 @@ async fn load_unfinalized_batches(
     // floor down to the oldest batch transaction still unconfirmed — the exact set
     // that can still be owed a verdict — so the range stays indexed rather than
     // becoming a full scan of `batches`.
-    let floor = match min_unsettled_batch_tx_height(conn, FINALITY_WINDOW).await {
-        Ok(Some(oldest)) => oldest.min(tracking_floor(tip)),
-        Ok(None) => tracking_floor(tip),
-        Err(e) => {
-            warn!(error = %e, "Unconfirmed-height probe failed; using the window floor");
-            tracking_floor(tip)
-        }
-    };
+    // A failed probe PROPAGATES rather than falling back to the window floor:
+    // the fallback silently narrows the band, dropping exactly the crash-window
+    // batches the extension exists to re-arm — permanently, since every later
+    // reload repeats the same fold. Failing here is recoverable (restart,
+    // re-probe); a batch dropped from tracking is not.
+    let floor = min_unsettled_batch_tx_height(conn, FINALITY_WINDOW)
+        .await
+        .context("Failed to probe the unsettled-batch floor")?
+        .map_or(tracking_floor(tip), |oldest| {
+            oldest.min(tracking_floor(tip))
+        });
     let rows = select_unfinalized_batches(conn, floor)
         .await
         .context("Failed to query unfinalized batches")?;
@@ -992,8 +995,8 @@ impl ConsensusState {
 #[cfg(test)]
 mod tests {
     use super::{
-        DeferredDecision, UnfinalizedBatch, VecDeque, build_finality_events, missing_txids,
-        probe_at_deadline, record_undrained_decisions,
+        DeferredDecision, UnfinalizedBatch, VecDeque, build_finality_events,
+        load_unfinalized_batches, missing_txids, probe_at_deadline, record_undrained_decisions,
     };
     use crate::consensus::Height;
     use crate::consensus::Value;
@@ -1277,6 +1280,34 @@ mod tests {
             missing_txids(&conn, &b).await.is_err(),
             "a failed read must propagate — reporting the txid as missing would \
              render a consensus verdict on a table this node could not read"
+        );
+    }
+
+    /// The rehydration floor extension exists to re-arm batches whose deadline
+    /// passed with no verdict rendered (a crash inside one drain). Folding a
+    /// failed probe into "use the plain window floor" silently narrows the
+    /// tracking band — dropping exactly those crash-window batches from tracking,
+    /// permanently, since every later reload repeats the same fold. A failed read
+    /// is recoverable by restart; a silently narrowed band is not.
+    #[tokio::test]
+    async fn a_failed_floor_probe_is_an_error_not_a_narrower_band() {
+        let (_reader, writer, _dir) = new_test_db().await.unwrap();
+        let conn = writer.connection();
+
+        // Break ONLY the probe's query: it reads `height`, which nothing else on
+        // the rehydration path touches (the `executed_batch_txids` view carries
+        // batch_height/txid/id).
+        conn.execute(
+            "ALTER TABLE transactions RENAME COLUMN height TO height_hidden",
+            (),
+        )
+        .await
+        .expect("rename column");
+
+        assert!(
+            load_unfinalized_batches(&conn, 100).await.is_err(),
+            "a failed floor probe must propagate — rehydrating from a silently \
+             narrowed band drops crash-window batches from tracking permanently"
         );
     }
 

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -908,7 +908,9 @@ impl ConsensusState {
     }
 
     /// Run finality checks. Returns the events produced and, if a rollback is needed,
-    /// `(rollback_anchor, excluded_txids)`.
+    /// `(rollback_anchor, missing)` — the missing txids attributed to the decided
+    /// batch each failed in (`Vec<BatchExclusion>`), deliberately never flattened:
+    /// a flat set is how a global txid ban gets built by accident.
     ///
     /// Does NOT emit the events — the caller does, after deciding it can actually
     /// perform the rollback. The tracking set IS drained here either way; a caller

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -279,9 +279,7 @@ async fn record_undrained_decisions(
     }
 }
 
-/// Probe every batch whose deadline has passed, in the order `check_finality` will
-/// evaluate them: `anchor_height` primary, so the first failure is the minimal
-/// failing anchor.
+/// Probe every batch whose deadline has passed, in the caller's evaluation order.
 ///
 /// Borrows rather than consuming ON PURPOSE. This is the only fallible step in the
 /// verdict, and doing it against a borrow is what lets `check_finality` fail without
@@ -291,11 +289,11 @@ async fn probe_at_deadline(
     batches: &[UnfinalizedBatch],
     tip: u64,
 ) -> Result<Vec<Vec<Txid>>> {
-    let mut order: Vec<&UnfinalizedBatch> = batches.iter().filter(|b| b.deadline <= tip).collect();
-    order.sort_by_key(|b| (b.anchor_height, b.consensus_height));
-
-    let mut missing_per_batch = Vec::with_capacity(order.len());
-    for batch in order {
+    // Takes `batches` ALREADY in evaluation order (`check_finality` sorts in place
+    // before calling) and filters stably, so the results line up with the caller's
+    // partition by construction rather than by a second sort that has to agree.
+    let mut missing_per_batch = Vec::new();
+    for batch in batches.iter().filter(|b| b.deadline <= tip) {
         missing_per_batch.push(missing_txids(conn, batch).await?);
     }
     Ok(missing_per_batch)
@@ -666,6 +664,15 @@ impl ConsensusState {
         let mut events = Vec::new();
         let tip = last_height;
 
+        // ONE definition of the evaluation order, established before anything reads
+        // the set. `from_anchor` is taken from the FIRST failing batch, which is the
+        // minimal failing anchor only because `anchor_height` is the PRIMARY key
+        // here; sorting by `consensus_height` alone would silently break it. Sorting
+        // in place means the probe and the partition below cannot disagree, rather
+        // than sorting twice and asserting afterwards that they matched.
+        self.unfinalized_batches
+            .sort_by_key(|b| (b.anchor_height, b.consensus_height));
+
         // PROBE BEFORE TAKING THE SET APART. `missing_txids` is fallible, and
         // draining first would mean an unreadable table costs us the whole tracking
         // set — every pending deadline gone from memory, which is the #515 hole
@@ -674,7 +681,8 @@ impl ConsensusState {
         // tip move simply retries.
         let missing_per_batch = probe_at_deadline(conn, &self.unfinalized_batches, tip).await?;
 
-        // Every probe succeeded, so it is now safe to consume the set.
+        // Every probe succeeded, so it is now safe to consume the set. The partition
+        // is stable, so `at_deadline` inherits the sort above.
         let mut still_pending = Vec::new();
         let mut at_deadline = Vec::new();
         for batch in self.unfinalized_batches.drain(..) {
@@ -684,21 +692,6 @@ impl ConsensusState {
                 still_pending.push(batch);
             }
         }
-
-        // `from_anchor` below is taken from the FIRST failing batch, which is the
-        // minimal failing anchor only because `anchor_height` is the PRIMARY sort
-        // key here. Re-sorting by `consensus_height` alone would silently break it.
-        //
-        // This must reproduce `probe_at_deadline`'s order exactly, or the verdicts
-        // line up against the wrong batches. It does: both collect the at-deadline
-        // batches in ascending original-index order and then stable-sort on the same
-        // key, so ties resolve identically.
-        at_deadline.sort_by_key(|b| (b.anchor_height, b.consensus_height));
-        debug_assert_eq!(
-            at_deadline.len(),
-            missing_per_batch.len(),
-            "probe and partition disagree about which batches are at deadline"
-        );
 
         let (built, surviving) = build_finality_events(
             &at_deadline,
@@ -1310,33 +1303,46 @@ mod tests {
         );
     }
 
-    /// The probe and the partition must agree on ORDER, or verdicts land against the
-    /// wrong batches — and `from_anchor` is taken from the first failure, so a
-    /// mismatch silently rolls back to the wrong anchor. They are two separate sorts
-    /// over two separate collections; this pins that they agree, including on ties.
+    /// `check_finality` sorts the tracking set IN PLACE once and both the probe and
+    /// the partition then walk that same order — so they agree by construction rather
+    /// than by a second sort that has to match. This pins the two properties that
+    /// makes rest on: the probe filters by deadline, and it preserves input order.
+    ///
+    /// It matters because `from_anchor` is taken from the first failure. If the probe
+    /// reordered relative to the partition, verdicts would land against the wrong
+    /// batches and the rollback would target the wrong anchor.
     #[tokio::test]
-    async fn probe_order_matches_the_partition_order() {
+    async fn the_probe_filters_by_deadline_and_preserves_input_order() {
         let (_reader, writer, _dir) = new_test_db().await.unwrap();
         let conn = writer.connection();
 
-        // Deliberately out of order, with an anchor tie broken by consensus height.
-        let tracked = vec![
+        // As `check_finality` hands it over: already in evaluation order.
+        let mut tracked = vec![
             batch(502, 30, &[3]),
             batch(500, 20, &[1]),
             batch(500, 10, &[2]),
         ];
+        tracked.sort_by_key(|b| (b.anchor_height, b.consensus_height));
+
         let probed = probe_at_deadline(&conn, &tracked, 999)
             .await
             .expect("probe must read");
-
-        let mut partitioned: Vec<_> = tracked.iter().filter(|b| b.deadline <= 999).collect();
-        partitioned.sort_by_key(|b| (b.anchor_height, b.consensus_height));
-
         let probed_txids: Vec<_> = probed.into_iter().map(|m| m[0]).collect();
-        let expected: Vec<_> = partitioned.iter().map(|b| b.txids[0]).collect();
+        let expected: Vec<_> = tracked.iter().map(|b| b.txids[0]).collect();
         assert_eq!(
             probed_txids, expected,
-            "probe results must line up with the partition, ties included"
+            "the probe must return results in the caller's order, ties included"
+        );
+
+        // Only the batches whose deadline has passed. `batch(_, anchor, _)` sets
+        // deadline = anchor + 6, so a tip of 26 covers anchor 20 but not 30.
+        let due = probe_at_deadline(&conn, &tracked, 26)
+            .await
+            .expect("probe must read");
+        assert_eq!(
+            due.len(),
+            2,
+            "only the two at-deadline batches may be probed"
         );
     }
 }

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::time::Instant;
 
 use std::time::Duration;
@@ -408,10 +408,18 @@ fn build_finality_events(
     // (`batch_txids` is append-only and the exclusion filter is in-memory), so a
     // batch left out re-executes, re-arms the identical deadline, and rolls back
     // again with the complementary set — a cycle that never converges.
-    let missing: Vec<Txid> = missing_per_batch[first_fail..]
+    // Per DECISION, not flattened. Flattening loses which batch each txid failed in,
+    // and that attribution is exactly what keeps the recorded exclusion scoped to the
+    // height it belongs to instead of becoming a global ban on the txid.
+    let missing: Vec<BatchExclusion> = at_deadline[first_fail..]
         .iter()
-        .flatten()
-        .copied()
+        .zip(&missing_per_batch[first_fail..])
+        .filter(|(_, txids)| !txids.is_empty())
+        .map(|(batch, txids)| BatchExclusion {
+            consensus_height: batch.consensus_height,
+            anchor_height: batch.anchor_height,
+            txids: txids.clone(),
+        })
         .collect();
 
     let mut surviving = Vec::new();
@@ -426,14 +434,14 @@ fn build_finality_events(
     warn!(
         from_anchor,
         invalidated = ?invalidated,
-        missing = missing.len(),
+        missing = missing.iter().map(|m| m.txids.len()).sum::<usize>(),
         "Cascade invalidation triggered"
     );
 
     events.push(FinalityEvent::Rollback {
         from_anchor,
         invalidated_batches: invalidated,
-        missing_txids: missing,
+        missing,
     });
 
     (events, surviving)
@@ -900,7 +908,7 @@ impl ConsensusState {
         &mut self,
         conn: &libsql::Connection,
         last_height: u64,
-    ) -> Result<(Vec<FinalityEvent>, Option<(u64, HashSet<Txid>)>)> {
+    ) -> Result<(Vec<FinalityEvent>, Option<(u64, Vec<BatchExclusion>)>)> {
         let finality_events = self.check_finality(conn, last_height).await?;
         // At most one Rollback per pass — `check_finality` folds every failing
         // at-deadline batch into a single event. Taking the FIRST rather than the
@@ -917,12 +925,9 @@ impl ConsensusState {
         let result = finality_events.iter().find_map(|event| match event {
             FinalityEvent::Rollback {
                 from_anchor,
-                missing_txids,
+                missing,
                 ..
-            } => {
-                let excluded: HashSet<Txid> = missing_txids.iter().copied().collect();
-                Some((*from_anchor, excluded))
-            }
+            } => Some((*from_anchor, missing.clone())),
             _ => None,
         });
         // Deliberately NOT emitted here. A rollback the caller then refuses — because
@@ -1009,16 +1014,19 @@ mod tests {
         }
     }
 
+    /// Flattens `missing` for the assertions that only care about the union. The
+    /// per-batch attribution itself is asserted by
+    /// `every_missing_txid_is_attributed_to_its_own_batch`.
     fn rollback_of(events: &[FinalityEvent]) -> (u64, Vec<Height>, Vec<Txid>) {
         let mut found = events.iter().filter_map(|e| match e {
             FinalityEvent::Rollback {
                 from_anchor,
                 invalidated_batches,
-                missing_txids,
+                missing,
             } => Some((
                 *from_anchor,
                 invalidated_batches.clone(),
-                missing_txids.clone(),
+                missing.iter().flat_map(|m| m.txids.clone()).collect(),
             )),
             _ => None,
         });

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -393,8 +393,7 @@ fn build_finality_events(
     // at a lower consensus height, sorting ahead of it while being torn out all
     // the same. It replays in full — no missing txids, so no exclusion rows.
     let from_anchor = at_deadline[first_fail].anchor_height;
-    let finalize_end =
-        at_deadline[..first_fail].partition_point(|b| b.anchor_height < from_anchor);
+    let finalize_end = at_deadline[..first_fail].partition_point(|b| b.anchor_height < from_anchor);
     for batch in &at_deadline[..finalize_end] {
         info!(
             consensus_height = %batch.consensus_height,

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -155,7 +155,23 @@ async fn load_unfinalized_batches(
     conn: &libsql::Connection,
     tip: u64,
 ) -> Result<Vec<UnfinalizedBatch>> {
-    let rows = select_unfinalized_batches(conn, tracking_floor(tip))
+    // The window floor assumes every deadline below it was already settled. A crash
+    // between a tip advance and the settle that should have followed breaks that:
+    // `advance` can execute several blocks inside one drain before `settle_finality`
+    // runs, so the tip can pass a deadline that no verdict was ever rendered on, and
+    // a fixed floor would then drop that batch from tracking permanently. Extend the
+    // floor down to the oldest batch transaction still unconfirmed — the exact set
+    // that can still be owed a verdict — so the range stays indexed rather than
+    // becoming a full scan of `batches`.
+    let floor = match min_unconfirmed_batch_tx_height(conn).await {
+        Ok(Some(oldest)) => oldest.min(tracking_floor(tip)),
+        Ok(None) => tracking_floor(tip),
+        Err(e) => {
+            warn!(error = %e, "Unconfirmed-height probe failed; using the window floor");
+            tracking_floor(tip)
+        }
+    };
+    let rows = select_unfinalized_batches(conn, floor)
         .await
         .context("Failed to query unfinalized batches")?;
     let mut batches = Vec::with_capacity(rows.len());

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -379,13 +379,20 @@ fn build_finality_events(
         return (events, still_pending);
     };
 
-    // Only batches strictly ahead of the first failure finalize. Everything from it
-    // onward is replayed by this same rollback — the sort guarantees they all have
-    // anchor_height >= from_anchor — so they are invalidated whether or not their
-    // own txids confirmed. Finalizing one of them would announce a batch that is
-    // about to be torn out, and dropping it from tracking silently left convergence
-    // to an implicit replay invariant (#426).
-    for batch in &at_deadline[..first_fail] {
+    // Only batches anchored strictly BELOW the first failure's anchor finalize.
+    // Everything anchored at or above it is replayed by this same rollback — the
+    // truncation goes to `from_anchor - 1` and the replay reloads every batch
+    // anchored at or above `from_anchor` — so they are invalidated whether or not
+    // their own txids confirmed. Finalizing one would announce a batch that is
+    // about to be torn out, and dropping it from tracking silently left
+    // convergence to an implicit replay invariant (#426). The boundary is the
+    // ANCHOR, not the index: a passing batch can share the failing batch's anchor
+    // at a lower consensus height, sorting ahead of it while being torn out all
+    // the same. It replays in full — no missing txids, so no exclusion rows.
+    let from_anchor = at_deadline[first_fail].anchor_height;
+    let finalize_end =
+        at_deadline[..first_fail].partition_point(|b| b.anchor_height < from_anchor);
+    for batch in &at_deadline[..finalize_end] {
         info!(
             consensus_height = %batch.consensus_height,
             anchor = batch.anchor_height,
@@ -397,8 +404,7 @@ fn build_finality_events(
         });
     }
 
-    let from_anchor = at_deadline[first_fail].anchor_height;
-    let mut invalidated: Vec<Height> = at_deadline[first_fail..]
+    let mut invalidated: Vec<Height> = at_deadline[finalize_end..]
         .iter()
         .map(|b| b.consensus_height)
         .collect();
@@ -1112,6 +1118,36 @@ mod tests {
                 "{h} was both finalized and invalidated"
             );
         }
+    }
+
+    /// A PASSING batch that shares the failing batch's ANCHOR is torn out by the
+    /// same rollback: the truncation goes to `from_anchor - 1`, deleting its
+    /// anchor block, and the replay reloads everything anchored at or above
+    /// `from_anchor`. Sorting puts it before the failure (lower consensus
+    /// height), but index order is not the finalize boundary — anchor order is.
+    /// Finalizing it would announce permanence for state the same pass deletes.
+    #[test]
+    fn passing_batch_sharing_the_failing_anchor_is_invalidated_not_finalized() {
+        let at_deadline = vec![
+            batch(10, 100, &[1]), // passes, same anchor as the failure
+            batch(11, 100, &[2]), // fails
+        ];
+        let missing = vec![vec![], vec![txid(2)]];
+
+        let (events, _) = build_finality_events(&at_deadline, &missing, Vec::new());
+        let (from_anchor, invalidated, excluded) = rollback_of(&events);
+
+        assert_eq!(from_anchor, 100);
+        assert!(
+            finalized_heights(&events).is_empty(),
+            "a batch the rollback is about to tear out must not be finalized"
+        );
+        assert_eq!(invalidated, vec![Height::new(10), Height::new(11)]);
+        assert_eq!(
+            excluded,
+            vec![txid(2)],
+            "the passing batch replays in full — no exclusions for it"
+        );
     }
 
     /// `from_anchor` comes from the first FAILING batch, which is minimal among

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -30,7 +30,7 @@ use crate::consensus::{
 };
 use crate::database::queries::{
     delete_unexecuted_batch_suffix, get_checkpoint_latest, get_transaction_by_txid,
-    min_unconfirmed_batch_tx_height, select_batches_from_anchor, select_batches_in_range,
+    min_unsettled_batch_tx_height, select_batches_from_anchor, select_batches_in_range,
     select_block_at_height, select_existing_txids, select_latest_consensus_height,
     select_min_batch_height, select_unconfirmed_batch_txs, select_unfinalized_batches,
 };
@@ -163,7 +163,7 @@ async fn load_unfinalized_batches(
     // floor down to the oldest batch transaction still unconfirmed — the exact set
     // that can still be owed a verdict — so the range stays indexed rather than
     // becoming a full scan of `batches`.
-    let floor = match min_unconfirmed_batch_tx_height(conn).await {
+    let floor = match min_unsettled_batch_tx_height(conn, FINALITY_WINDOW).await {
         Ok(Some(oldest)) => oldest.min(tracking_floor(tip)),
         Ok(None) => tracking_floor(tip),
         Err(e) => {
@@ -352,7 +352,7 @@ impl ConsensusState {
         // WARNING rather than a startup refusal: the predicate has legitimate
         // transient hits (a node stopped between a deadline passing and its check),
         // and bricking a healthy validator is worse than the fork it screens for.
-        match min_unconfirmed_batch_tx_height(&conn).await {
+        match min_unsettled_batch_tx_height(&conn, FINALITY_WINDOW).await {
             Ok(Some(height)) if height < tracking_floor(last_block_height) => warn!(
                 height,
                 floor = tracking_floor(last_block_height),

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -59,7 +59,34 @@ pub struct DeferredDecision {
     /// list would serve a value that no longer matches its own certificate.
     ///
     /// `None` when nothing was excluded, i.e. the two are the same list.
-    pub certified_txids: Option<Vec<Txid>>,
+    ///
+    /// Holds the BODIES, not just the txids. An excluded transaction never
+    /// confirmed, so it exists in no mempool and no block — this decision is the
+    /// only place its body still exists, and dropping it makes the height
+    /// unresolvable for every syncing peer.
+    pub certified_txs: Option<Vec<bitcoin::Transaction>>,
+}
+
+impl DeferredDecision {
+    /// The bodies this decision can still serve to a syncing peer.
+    ///
+    /// An EXCLUDED transaction is the one a peer cannot obtain any other way — it
+    /// never confirmed, so it is in nobody's mempool and bitcoind has never heard of
+    /// it — which makes this the set that has to be persisted, not the executed one.
+    pub fn decided_txs(&self) -> Vec<bitcoin::Transaction> {
+        match &self.certified_txs {
+            Some(decided) => decided.clone(),
+            None => self.value.batch_raw_txs(),
+        }
+    }
+
+    /// The txid list as DECIDED — what `batch_txids` must record (I4).
+    pub fn decided_txids(&self) -> Vec<Txid> {
+        match &self.certified_txs {
+            Some(decided) => decided.iter().map(|t| t.compute_txid()).collect(),
+            None => self.value.batch_txids(),
+        }
+    }
 }
 
 /// A GetValue reply that we're holding until transactions arrive.
@@ -216,15 +243,11 @@ async fn record_undrained_decisions(
         }
         // The DECIDED list, which is the full one even if a replay had narrowed what
         // this node would have executed.
-        let txids: Vec<String> = match &decision.certified_txids {
-            Some(decided) => decided.iter().map(|t| t.to_string()).collect(),
-            None => decision
-                .value
-                .batch_txids()
-                .iter()
-                .map(|t| t.to_string())
-                .collect(),
-        };
+        let txids: Vec<String> = decision
+            .decided_txids()
+            .iter()
+            .map(|t| t.to_string())
+            .collect();
         if !txids.is_empty()
             && let Err(e) = insert_batch_txids(conn, consensus_height, &txids).await
         {
@@ -235,7 +258,7 @@ async fn record_undrained_decisions(
             );
         }
 
-        for raw in decision.value.batch_raw_txs() {
+        for raw in decision.decided_txs() {
             let serialized = bitcoin::consensus::serialize(&raw);
             if let Err(e) = insert_unconfirmed_batch_tx(
                 conn,
@@ -749,7 +772,7 @@ impl ConsensusState {
                     certificate: b.certificate,
                     // Loaded straight from the decided record, so `value` already
                     // holds the certified content — nothing to preserve separately.
-                    certified_txids: None,
+                    certified_txs: None,
                 })
             })
             .collect()
@@ -1237,7 +1260,7 @@ mod tests {
             consensus_height: Height::new(41),
             value: Value::new_block(300, BlockHash::all_zeros()),
             certificate: vec![1, 2, 3],
-            certified_txids: None,
+            certified_txs: None,
         });
         queued.push_back(DeferredDecision {
             consensus_height: Height::new(42),
@@ -1245,7 +1268,7 @@ mod tests {
             certificate: vec![4, 5, 6],
             // A replay had already narrowed this one — the DECIDED list is what a
             // syncing peer needs, not the empty set we would have executed.
-            certified_txids: Some(vec![make_tx(1).compute_txid(), make_tx(2).compute_txid()]),
+            certified_txs: Some(vec![make_tx(1), make_tx(2)]),
         });
 
         record_undrained_decisions(&conn, &queued).await;

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -534,7 +534,7 @@ impl ConsensusState {
         events
     }
 
-    fn emit_finality_events(&self, events: &[FinalityEvent]) {
+    pub(super) fn emit_finality_events(&self, events: &[FinalityEvent]) {
         if let Some(obs) = &self.observation {
             for event in events {
                 let _ = obs.finality_tx.try_send(event.clone());
@@ -710,13 +710,17 @@ impl ConsensusState {
             .map(Height::new))
     }
 
-    /// Run finality checks. Returns (rollback_anchor, excluded_txids) if a rollback is needed.
-    /// The reactor is responsible for DB truncation and calling `initiate_rollback`.
+    /// Run finality checks. Returns the events produced and, if a rollback is needed,
+    /// `(rollback_anchor, excluded_txids)`.
+    ///
+    /// Does NOT emit the events — the caller does, after deciding it can actually
+    /// perform the rollback. The tracking set IS drained here either way; a caller
+    /// that declines the rollback is expected to halt, which this node does.
     pub async fn run_finality_checks(
         &mut self,
         conn: &libsql::Connection,
         last_height: u64,
-    ) -> Option<(u64, HashSet<Txid>)> {
+    ) -> (Vec<FinalityEvent>, Option<(u64, HashSet<Txid>)>) {
         let finality_events = self.check_finality(conn, last_height).await;
         // At most one Rollback per pass — `check_finality` folds every failing
         // at-deadline batch into a single event. Taking the FIRST rather than the
@@ -741,8 +745,10 @@ impl ConsensusState {
             }
             _ => None,
         });
-        self.emit_finality_events(&finality_events);
-        result
+        // Deliberately NOT emitted here. A rollback the caller then refuses — because
+        // it would reach below the prune watermark — must not be announced as though
+        // it happened. The caller emits once it has committed to acting.
+        (finality_events, result)
     }
 
     /// Validate batch-level rules. Returns a rejection reason if any rule

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -30,10 +30,10 @@ use crate::consensus::{
 };
 use crate::database::queries::{
     delete_unexecuted_batch_suffix, get_checkpoint_latest, get_transaction_by_txid, insert_batch,
-    insert_batch_txids, min_unsettled_batch_tx_height, select_batches_from_anchor,
-    select_batches_in_range, select_block_at_height, select_existing_txids,
-    select_latest_consensus_height, select_min_batch_height, select_unconfirmed_batch_txs,
-    select_unfinalized_batches,
+    insert_batch_txids, insert_unconfirmed_batch_tx, min_unsettled_batch_tx_height,
+    select_batches_from_anchor, select_batches_in_range, select_block_at_height,
+    select_existing_txids, select_latest_consensus_height, select_min_batch_height,
+    select_unconfirmed_batch_txs, select_unfinalized_batches,
 };
 
 /// Result from processing a consensus message.
@@ -179,8 +179,14 @@ async fn missing_txids(conn: &libsql::Connection, batch: &UnfinalizedBatch) -> R
 /// Best-effort, matching `record_declined_block`. Propagating would take the node
 /// down on a reorg for a transient DB error, and since the queue lives only in memory
 /// the decisions would be lost on restart anyway — strictly worse than a loud warning.
-/// The `batches` row is what a syncing peer needs; the batch's decided txid list goes
-/// with it (I4), but no `unconfirmed_batch_txs` rows, because this node held nothing.
+///
+/// Writes all three: the `batches` row, the DECIDED txid list (I4), and the raw
+/// bodies the value was carrying. That last one is easy to talk yourself out of —
+/// the batch was never executed, so it is tempting to say this node "held nothing" —
+/// but a queued batch is normally `BatchTx::Raw`, and for a transaction that never
+/// confirms this node's copy is the only one a syncing peer can obtain: not its
+/// mempool, not bitcoind. Dropping them reopens the sync hole this change closes
+/// elsewhere by removing the finality-window gate on serving raw txs.
 async fn record_undrained_decisions(
     conn: &libsql::Connection,
     decisions: &VecDeque<DeferredDecision>,
@@ -227,6 +233,25 @@ async fn record_undrained_decisions(
                 consensus_height,
                 "Failed to record an undrained batch's decided txids"
             );
+        }
+
+        for raw in decision.value.batch_raw_txs() {
+            let serialized = bitcoin::consensus::serialize(&raw);
+            if let Err(e) = insert_unconfirmed_batch_tx(
+                conn,
+                &raw.compute_txid().to_string(),
+                consensus_height,
+                &serialized,
+            )
+            .await
+            {
+                warn!(
+                    error = %e,
+                    consensus_height,
+                    "Failed to record an undrained batch's raw transaction — a peer may \
+                     be unable to resolve it"
+                );
+            }
         }
     }
 }
@@ -946,7 +971,9 @@ mod tests {
     use crate::consensus::Height;
     use crate::consensus::Value;
     use crate::consensus::finality_types::FinalityEvent;
+    use crate::database::queries::select_unconfirmed_batch_txs;
     use crate::database::queries::{confirm_transaction, insert_block, insert_transaction};
+    use crate::reactor::mock_bitcoin::make_tx;
     use crate::test_utils::{new_mock_block_hash, new_test_db};
     use bitcoin::hashes::Hash;
     use bitcoin::{BlockHash, Txid};
@@ -1214,14 +1241,25 @@ mod tests {
         });
         queued.push_back(DeferredDecision {
             consensus_height: Height::new(42),
-            value: Value::new_batch_raw(301, BlockHash::all_zeros(), vec![]),
+            value: Value::new_batch_raw(301, BlockHash::all_zeros(), vec![make_tx(1), make_tx(2)]),
             certificate: vec![4, 5, 6],
             // A replay had already narrowed this one — the DECIDED list is what a
             // syncing peer needs, not the empty set we would have executed.
-            certified_txids: Some(vec![txid(7), txid(8)]),
+            certified_txids: Some(vec![make_tx(1).compute_txid(), make_tx(2).compute_txid()]),
         });
 
         record_undrained_decisions(&conn, &queued).await;
+
+        // The raw bodies the value was carrying must survive too. A queued batch is
+        // usually `BatchTx::Raw` (the proposer builds it that way, and `upgrade`
+        // promotes what it can), and for a tx that never confirms this node's copy is
+        // the ONLY one a syncing peer can get — not its mempool, not bitcoind.
+        // Recording txids alone reopens the sync hole this PR closes elsewhere.
+        assert_eq!(
+            select_unconfirmed_batch_txs(&conn, 42).await.unwrap().len(),
+            2,
+            "the raw transactions the decision carried must be recorded, not dropped"
+        );
 
         for h in [41u64, 42] {
             let mut rows = conn

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -370,7 +370,11 @@ impl ConsensusState {
 
     /// Clear consensus state that is invalidated by a reorg rollback.
     /// Pending blocks, cached blocks, and in-flight batch data are all stale.
-    pub async fn clear_on_rollback(&mut self, conn: &libsql::Connection, to_height: u64) {
+    pub async fn clear_on_rollback(
+        &mut self,
+        conn: &libsql::Connection,
+        to_height: u64,
+    ) -> Result<()> {
         self.pending_blocks.clear();
         self.deferred_decisions.clear();
         self.pending_proposal = None;
@@ -380,15 +384,15 @@ impl ConsensusState {
         // deadlines reopens exactly the #515 hole on the reorg path. Re-deriving
         // rather than filtering in memory also drops the batches whose anchor block
         // was replaced: the query joins the block CURRENTLY at that height by hash.
-        match load_unfinalized_batches(conn, to_height).await {
-            Ok(batches) => self.unfinalized_batches = batches,
-            Err(e) => {
-                // Losing tracking here is the #515 divergence, so make it loud
-                // rather than silently continuing with a stale set.
-                warn!(error = %e, to_height, "Failed to re-derive finality tracking after rollback");
-                self.unfinalized_batches.clear();
-            }
-        }
+        // Propagate rather than clear on failure: an empty tracking set is exactly
+        // the #515 divergence condition, and reaching it from a transient error
+        // (SQLITE_BUSY, a WAL hiccup) would be silent. The sole caller sits in
+        // `process_block_event`, which already returns `Result`, and the startup
+        // path treats the same failure as fatal.
+        self.unfinalized_batches = load_unfinalized_batches(conn, to_height)
+            .await
+            .context("Failed to re-derive finality tracking after rollback")?;
+        Ok(())
     }
 
     fn validator_set(&self) -> ValidatorSet {

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -750,10 +750,18 @@ impl ConsensusState {
     /// `resolve_batch_txs` then bails and the reactor exits, so a chain that had
     /// ever performed an exclusion was not reliably re-syncable from genesis.
     ///
-    /// Serving whatever remains is self-limiting: `unconfirmed_batch_txs` rows are
-    /// deleted on confirmation and by the startup suffix cleanup, so a batch whose
-    /// transactions all confirmed has none and the only rows ever served are the
-    /// otherwise-unresolvable ones.
+    /// Serving whatever remains is self-limiting: a row goes away as soon as its
+    /// transaction is indexed on chain — `confirm_transaction` when a row already
+    /// existed, `insert_transaction` when it did not — plus the startup suffix
+    /// cleanup. So a batch whose transactions all confirmed has none, and the only
+    /// rows ever served are the otherwise-unresolvable ones.
+    ///
+    /// That second deletion site is load-bearing and was missing: a RECORD-ONLY batch
+    /// stores raw txs but writes no `transactions` row, so the confirming block takes
+    /// the insert path, never `confirm_transaction`. Without it every record-only
+    /// batch — i.e. every batch decided while this node lags, the case this whole
+    /// change exists for — kept a full transaction body forever AND attached it to
+    /// that consensus height on every sync.
     async fn load_raw_txs_if_unfinalized(
         &self,
         conn: &libsql::Connection,

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -151,9 +151,10 @@ pub struct ObservationChannels {
 /// deletes the transaction's row and the replay drops it from the batch, so it is
 /// later re-executed as an unbatched block transaction at a different height than
 /// every peer used, and nothing detects the divergence because the decided value
-/// carries no state root. Propagating instead costs a retry on the next tip move:
-/// `unfinalized_batches` is left untouched, and a fault that does not clear
-/// exits the node, which is recoverable since tracking is rehydrated from disk.
+/// carries no state root. Propagating instead costs a retry on the next tip move —
+/// but ONLY because `probe_at_deadline` runs this against a borrow before
+/// `check_finality` drains anything. Probing mid-drain would lose the whole tracking
+/// set to a transient read error, which is #515 again from a new direction.
 /// This matches `execute_block`'s handling of the same query and the reasoning
 /// already written down in `clear_on_rollback`.
 async fn missing_txids(conn: &libsql::Connection, batch: &UnfinalizedBatch) -> Result<Vec<Txid>> {
@@ -169,6 +170,28 @@ async fn missing_txids(conn: &libsql::Connection, batch: &UnfinalizedBatch) -> R
         }
     }
     Ok(missing)
+}
+
+/// Probe every batch whose deadline has passed, in the order `check_finality` will
+/// evaluate them: `anchor_height` primary, so the first failure is the minimal
+/// failing anchor.
+///
+/// Borrows rather than consuming ON PURPOSE. This is the only fallible step in the
+/// verdict, and doing it against a borrow is what lets `check_finality` fail without
+/// having already dismantled its own tracking set.
+async fn probe_at_deadline(
+    conn: &libsql::Connection,
+    batches: &[UnfinalizedBatch],
+    tip: u64,
+) -> Result<Vec<Vec<Txid>>> {
+    let mut order: Vec<&UnfinalizedBatch> = batches.iter().filter(|b| b.deadline <= tip).collect();
+    order.sort_by_key(|b| (b.anchor_height, b.consensus_height));
+
+    let mut missing_per_batch = Vec::with_capacity(order.len());
+    for batch in order {
+        missing_per_batch.push(missing_txids(conn, batch).await?);
+    }
+    Ok(missing_per_batch)
 }
 
 /// Rebuild the in-memory finality-tracking set from disk at startup.
@@ -527,9 +550,17 @@ impl ConsensusState {
         let mut events = Vec::new();
         let tip = last_height;
 
+        // PROBE BEFORE TAKING THE SET APART. `missing_txids` is fallible, and
+        // draining first would mean an unreadable table costs us the whole tracking
+        // set — every pending deadline gone from memory, which is the #515 hole
+        // reopened by the very code meant to close it. Borrowing for the probe makes
+        // the early return leave `unfinalized_batches` exactly as it was, so the next
+        // tip move simply retries.
+        let missing_per_batch = probe_at_deadline(conn, &self.unfinalized_batches, tip).await?;
+
+        // Every probe succeeded, so it is now safe to consume the set.
         let mut still_pending = Vec::new();
         let mut at_deadline = Vec::new();
-
         for batch in self.unfinalized_batches.drain(..) {
             if batch.deadline <= tip {
                 at_deadline.push(batch);
@@ -541,12 +572,17 @@ impl ConsensusState {
         // `from_anchor` below is taken from the FIRST failing batch, which is the
         // minimal failing anchor only because `anchor_height` is the PRIMARY sort
         // key here. Re-sorting by `consensus_height` alone would silently break it.
+        //
+        // This must reproduce `probe_at_deadline`'s order exactly, or the verdicts
+        // line up against the wrong batches. It does: both collect the at-deadline
+        // batches in ascending original-index order and then stable-sort on the same
+        // key, so ties resolve identically.
         at_deadline.sort_by_key(|b| (b.anchor_height, b.consensus_height));
-
-        let mut missing_per_batch = Vec::with_capacity(at_deadline.len());
-        for batch in &at_deadline {
-            missing_per_batch.push(missing_txids(conn, batch).await?);
-        }
+        debug_assert_eq!(
+            at_deadline.len(),
+            missing_per_batch.len(),
+            "probe and partition disagree about which batches are at deadline"
+        );
 
         let (built, surviving) = build_finality_events(
             &at_deadline,
@@ -827,7 +863,7 @@ impl ConsensusState {
 
 #[cfg(test)]
 mod tests {
-    use super::{UnfinalizedBatch, build_finality_events, missing_txids};
+    use super::{UnfinalizedBatch, build_finality_events, missing_txids, probe_at_deadline};
     use crate::consensus::Height;
     use crate::consensus::finality_types::FinalityEvent;
     use crate::database::queries::{confirm_transaction, insert_block, insert_transaction};
@@ -1074,6 +1110,36 @@ mod tests {
             missing_txids(&conn, &b).await.is_err(),
             "a failed read must propagate — reporting the txid as missing would \
              render a consensus verdict on a table this node could not read"
+        );
+    }
+
+    /// The probe and the partition must agree on ORDER, or verdicts land against the
+    /// wrong batches — and `from_anchor` is taken from the first failure, so a
+    /// mismatch silently rolls back to the wrong anchor. They are two separate sorts
+    /// over two separate collections; this pins that they agree, including on ties.
+    #[tokio::test]
+    async fn probe_order_matches_the_partition_order() {
+        let (_reader, writer, _dir) = new_test_db().await.unwrap();
+        let conn = writer.connection();
+
+        // Deliberately out of order, with an anchor tie broken by consensus height.
+        let tracked = vec![
+            batch(502, 30, &[3]),
+            batch(500, 20, &[1]),
+            batch(500, 10, &[2]),
+        ];
+        let probed = probe_at_deadline(&conn, &tracked, 999)
+            .await
+            .expect("probe must read");
+
+        let mut partitioned: Vec<_> = tracked.iter().filter(|b| b.deadline <= 999).collect();
+        partitioned.sort_by_key(|b| (b.anchor_height, b.consensus_height));
+
+        let probed_txids: Vec<_> = probed.into_iter().map(|m| m[0]).collect();
+        let expected: Vec<_> = partitioned.iter().map(|b| b.txids[0]).collect();
+        assert_eq!(
+            probed_txids, expected,
+            "probe results must line up with the partition, ties included"
         );
     }
 }

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -49,6 +49,16 @@ pub struct DeferredDecision {
     pub consensus_height: Height,
     pub value: Value,
     pub certificate: Vec<u8>,
+    /// The txid list as DECIDED, retained when a rollback exclusion has narrowed
+    /// `value` to the subset this node will actually execute.
+    ///
+    /// `batch_txids` must record what CONSENSUS decided, not what we ran: a peer
+    /// syncing this height re-derives the exclusions itself by applying the same
+    /// deadline rules, so it needs the full decided content. Recording the narrowed
+    /// list would serve a value that no longer matches its own certificate.
+    ///
+    /// `None` when nothing was excluded, i.e. the two are the same list.
+    pub certified_txids: Option<Vec<Txid>>,
 }
 
 /// A GetValue reply that we're holding until transactions arrive.
@@ -594,6 +604,9 @@ impl ConsensusState {
                     consensus_height: Height::new(b.consensus_height),
                     value,
                     certificate: b.certificate,
+                    // Loaded straight from the decided record, so `value` already
+                    // holds the certified content — nothing to preserve separately.
+                    certified_txids: None,
                 })
             })
             .collect()

--- a/core/indexer/src/reactor/executor.rs
+++ b/core/indexer/src/reactor/executor.rs
@@ -313,6 +313,15 @@ pub async fn process_input(
     txid: bitcoin::Txid,
     op_return_data: Option<&[u8]>,
 ) -> Result<Vec<Option<anyhow::Error>>> {
+    // Pin the execution height BEFORE anything resolves a signer — both branches do,
+    // ahead of the first `set_context`. `get_or_create_identity` inserts
+    // `signers(height = storage.height)`, and that column has a foreign key to
+    // `blocks`; reading it ambiently lands the row at whatever height the previous
+    // caller left behind. After a rollback (or a rolled-back simulation block) that
+    // height has no `blocks` row, so the insert trips the FK, which is classified
+    // non-deterministic and kills the reactor.
+    runtime.storage.height = height;
+
     let errors = if input.insts.is_aggregate() {
         process_aggregate_input(
             runtime,
@@ -352,12 +361,6 @@ async fn process_direct_input(
     txid: bitcoin::Txid,
     op_return_data: Option<&[u8]>,
 ) -> Result<Vec<Option<anyhow::Error>>> {
-    // Pin the execution height BEFORE resolving the signer. `get_or_create_identity`
-    // inserts `signers(height = storage.height)`, which has a foreign key to
-    // `blocks` — reading that ambiently means the row lands at whatever height the
-    // previous caller happened to leave behind (a rolled-back simulation block, for
-    // instance) rather than the one we are executing at.
-    runtime.storage.height = height;
     let identity = runtime
         .get_or_create_identity(&input.x_only_pubkey.to_string())
         .await?;

--- a/core/indexer/src/reactor/executor.rs
+++ b/core/indexer/src/reactor/executor.rs
@@ -352,6 +352,12 @@ async fn process_direct_input(
     txid: bitcoin::Txid,
     op_return_data: Option<&[u8]>,
 ) -> Result<Vec<Option<anyhow::Error>>> {
+    // Pin the execution height BEFORE resolving the signer. `get_or_create_identity`
+    // inserts `signers(height = storage.height)`, which has a foreign key to
+    // `blocks` — reading that ambiently means the row lands at whatever height the
+    // previous caller happened to leave behind (a rolled-back simulation block, for
+    // instance) rather than the one we are executing at.
+    runtime.storage.height = height;
     let identity = runtime
         .get_or_create_identity(&input.x_only_pubkey.to_string())
         .await?;

--- a/core/indexer/src/reactor/lite_executor.rs
+++ b/core/indexer/src/reactor/lite_executor.rs
@@ -1,3 +1,4 @@
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
@@ -11,7 +12,7 @@ use crate::reactor::executor::Executor;
 use crate::reactor::mock_bitcoin::MockBitcoin;
 use crate::runtime::wit::Signer;
 use crate::runtime::{ComponentCache, ContractAddress, Runtime, Storage, TransactionContext};
-use crate::test_utils::{new_mock_block_hash, new_mock_transaction, new_test_db};
+use crate::test_utils::{new_mock_block_hash, new_mock_transaction, new_test_db_dir, open_test_db};
 use indexer_types::{BlockRow, TransactionRow};
 use testlib::ContractReader;
 
@@ -23,7 +24,10 @@ pub async fn shared_engine_and_cache() -> (wasmtime::Engine, ComponentCache) {
         let cache = ComponentCache::new();
         let mock_btc = Arc::new(Mutex::new(MockBitcoin::new(0)));
         let (dummy_tx, _dummy_rx) = tokio::sync::mpsc::channel(1);
+        let (dir, db_name) = new_test_db_dir().expect("prewarm dir");
         let (_executor, runtime) = LiteExecutor::new(
+            dir.path(),
+            &db_name,
             mock_btc,
             "prewarm".to_string(),
             &[],
@@ -41,7 +45,9 @@ pub async fn shared_engine_and_cache() -> (wasmtime::Engine, ComponentCache) {
 }
 
 pub struct LiteExecutor {
-    _db_dir: tempfile::TempDir,
+    /// The directory is owned by the CLUSTER, not by us: a node that stops must
+    /// leave its database behind so it can be restarted onto it.
+    data_dir: PathBuf,
     counter_address: ContractAddress,
     signer: Signer,
     mock_bitcoin: Arc<Mutex<MockBitcoin>>,
@@ -49,11 +55,52 @@ pub struct LiteExecutor {
 }
 
 impl LiteExecutor {
-    pub fn data_dir(&self) -> std::path::PathBuf {
-        self._db_dir.path().to_path_buf()
+    pub fn data_dir(&self) -> PathBuf {
+        self.data_dir.clone()
+    }
+
+    /// Bring a node back up on a database it already has — no genesis seeding.
+    /// The counterpart to `new`, and what makes a restart mean anything: the node
+    /// must recover from durable state rather than starting fresh.
+    pub async fn reopen(
+        data_dir: &Path,
+        db_name: &str,
+        mock_bitcoin: Arc<Mutex<MockBitcoin>>,
+        shared_pubkey: String,
+        engine: wasmtime::Engine,
+        component_cache: ComponentCache,
+        block_tx: tokio::sync::mpsc::Sender<crate::bitcoin_follower::event::BlockEvent>,
+    ) -> Result<(Self, Runtime)> {
+        let (_reader, writer) = open_test_db(data_dir, db_name).await?;
+        let storage = Storage::builder()
+            .height(0)
+            .conn(writer.connection())
+            .build();
+        let linkers = Runtime::new_linkers(&engine)?;
+        let runtime = Runtime::new_with(engine, linkers, component_cache, storage).await?;
+
+        // Already persisted by the first boot — this resolves the existing row.
+        let identity = runtime.get_or_create_identity(&shared_pubkey).await?;
+
+        Ok((
+            Self {
+                data_dir: data_dir.to_path_buf(),
+                counter_address: ContractAddress {
+                    name: "counter".to_string(),
+                    height: 0,
+                    tx_index: 0,
+                },
+                signer: Signer::Id(identity),
+                mock_bitcoin,
+                block_tx,
+            },
+            runtime,
+        ))
     }
 
     pub async fn new(
+        data_dir: &Path,
+        db_name: &str,
         mock_bitcoin: Arc<Mutex<MockBitcoin>>,
         shared_pubkey: String,
         genesis_validators: &[crate::runtime::GenesisValidator],
@@ -61,7 +108,7 @@ impl LiteExecutor {
         component_cache: ComponentCache,
         block_tx: tokio::sync::mpsc::Sender<crate::bitcoin_follower::event::BlockEvent>,
     ) -> Result<(Self, Runtime)> {
-        let (_reader, writer, (db_dir, _db_name)) = new_test_db().await?;
+        let (_reader, writer) = open_test_db(data_dir, db_name).await?;
         let conn = writer.connection();
 
         insert_block(
@@ -148,7 +195,7 @@ impl LiteExecutor {
 
         Ok((
             Self {
-                _db_dir: db_dir,
+                data_dir: data_dir.to_path_buf(),
                 counter_address,
                 signer,
                 mock_bitcoin,

--- a/core/indexer/src/reactor/mock_bitcoin.rs
+++ b/core/indexer/src/reactor/mock_bitcoin.rs
@@ -201,9 +201,7 @@ impl MockBitcoin {
             .mined_blocks
             .iter()
             .find_map(|e| match e {
-                BlockEvent::BlockInsert { block, .. } if block.height == height => {
-                    Some(block.hash)
-                }
+                BlockEvent::BlockInsert { block, .. } if block.height == height => Some(block.hash),
                 _ => None,
             })
             .unwrap_or_else(|| new_mock_block_hash(height as u32));

--- a/core/indexer/src/reactor/mock_bitcoin.rs
+++ b/core/indexer/src/reactor/mock_bitcoin.rs
@@ -38,6 +38,17 @@ pub struct MockBitcoin {
     block_txids: HashMap<u64, Vec<Txid>>,
     /// History of mined blocks for late joiners.
     mined_blocks: Vec<BlockEvent>,
+    /// Bumped by every `reset_to`, and mixed into new block hashes, so a block
+    /// mined after a reorg differs from the one it replaces — as on the real
+    /// chain. Without this, a re-mined block at the same height is bit-identical
+    /// and no test can produce the stale-decision paths a real reorg produces.
+    fork: u32,
+}
+
+/// Distinct hashes per (height, fork). The stride keeps the two inputs from
+/// colliding for any test-sized height.
+fn fork_block_hash(height: u64, fork: u32) -> BlockHash {
+    new_mock_block_hash(fork * 1_000_000 + height as u32)
 }
 
 impl MockBitcoin {
@@ -50,6 +61,7 @@ impl MockBitcoin {
             mined_txs: HashMap::new(),
             block_txids: HashMap::new(),
             mined_blocks: Vec::new(),
+            fork: 0,
         }
     }
 
@@ -105,7 +117,7 @@ impl MockBitcoin {
         self.tip_height += 1;
         let height = self.tip_height;
 
-        let hash = new_mock_block_hash(height as u32);
+        let hash = fork_block_hash(height, self.fork);
         let prev_hash = self.prev_hash;
         self.prev_hash = hash;
 
@@ -178,11 +190,24 @@ impl MockBitcoin {
             }
         }
         self.tip_height = height;
-        self.prev_hash = new_mock_block_hash(height as u32);
         self.mined_blocks.retain(|e| match e {
             BlockEvent::BlockInsert { target_height, .. } => *target_height <= height,
             _ => true,
         });
+        // The next block builds on the SURVIVING block at the fork height, which
+        // may itself have been mined under an earlier fork value — take its real
+        // hash rather than recomputing one.
+        self.prev_hash = self
+            .mined_blocks
+            .iter()
+            .find_map(|e| match e {
+                BlockEvent::BlockInsert { block, .. } if block.height == height => {
+                    Some(block.hash)
+                }
+                _ => None,
+            })
+            .unwrap_or_else(|| new_mock_block_hash(height as u32));
+        self.fork += 1;
     }
 
     /// Get all block events for late joiners that missed earlier blocks.

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -75,6 +75,18 @@ use executor::Executor;
 /// Keep this constant and that config default in lockstep.
 const MAX_PENDING_BLOCKS: usize = 128;
 
+/// Ceiling on `consensus_state::deferred_decisions` — decided values parked
+/// because their data has not arrived or their turn has not come.
+///
+/// Unlike [`MAX_PENDING_BLOCKS`] this is not backpressure: there is nothing to
+/// slow down, since the queue is fed by consensus itself. It is an OOM backstop
+/// for the one state that cannot resolve itself — a node whose execution has
+/// fallen behind heights the network already decided, which parks one entry per
+/// decided value from then on. Set far above any legitimate backlog: a healthy
+/// node idles near zero and drains within a block, and a tight bound would turn
+/// a transient stall into the crash loop this bound exists to avoid.
+const MAX_DEFERRED_DECISIONS: usize = 4096;
+
 pub type Simulation = (
     indexer_types::Transaction,
     oneshot::Sender<Result<Vec<OpWithResult>>>,

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -492,6 +492,18 @@ impl<E: Executor> Reactor<E> {
         // reorgs both maintain the cache atomically, so a clean restart needs no rebuild.
         self.runtime.storage.footprint().reconstruct().await?;
 
+        // Settle any deadline that was ALREADY due when we started. Rehydration
+        // restores the tracking set, but nothing evaluates it until a tip advance —
+        // and a node that restarted at or past a deadline resumes consensus
+        // immediately, so without this it keeps executing batches on state its peers
+        // have already rolled back until the next Bitcoin block arrives (up to an
+        // hour on mainnet, indefinitely on a stalled chain). That is #515 again by a
+        // third route. The queues are empty here, so the drain inside is a no-op and
+        // only the finality check does work.
+        self.advance()
+            .await
+            .context("advance failed during startup finality settle")?;
+
         let result = self.run_event_loop().await;
 
         // Gracefully stop the Malachite consensus engine and wait for cleanup

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -34,7 +34,7 @@ use malachitebft_app_channel::app::types::core::VotingPower;
 use malachitebft_core_types::{LinearTimeouts, Round};
 use tracing::{debug, error, info, warn};
 
-use crate::consensus::finality_types::{FINALITY_WINDOW, StateEvent};
+use crate::consensus::finality_types::StateEvent;
 use crate::consensus::{BatchTx, Ctx};
 use crate::{
     bitcoin_follower::event::{BlockEvent, MempoolEvent},
@@ -270,17 +270,8 @@ impl<E: Executor> Reactor<E> {
                 // Hence the guard keys off `retain` (the assumption) — not the actual
                 // prune watermark — because what it really detects is "Bitcoin broke
                 // finality", which is catastrophic independent of pruning.
-                if self.prune.enabled {
-                    let retain = self.prune.retain_blocks.max(FINALITY_WINDOW);
-                    if self.last_height.saturating_sub(to_height) > retain {
-                        bail!(
-                            "Bitcoin reorg to height {to_height} is deeper than the prune \
-                             retain window ({retain}) below tip {}; pruned state cannot be \
-                             rolled back locally — re-sync required",
-                            self.last_height
-                        );
-                    }
-                }
+                self.check_rollback_depth(to_height)
+                    .context("Bitcoin reorg too deep")?;
                 self.rollback(to_height)
                     .await
                     .context("rollback failed during Bitcoin reorg")?;

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -294,7 +294,8 @@ impl<E: Executor> Reactor<E> {
                 // whose only block decision is queued behind it).
                 self.consensus
                     .clear_on_rollback(&self.db_conn(), to_height)
-                    .await;
+                    .await
+                    .context("clear_on_rollback failed during Bitcoin reorg")?;
                 let checkpoint = self.consensus.get_checkpoint(&self.db_conn()).await;
                 self.consensus
                     .emit_state_event(StateEvent::RollbackExecuted {

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -246,9 +246,9 @@ impl<E: Executor> Reactor<E> {
                 self.consensus
                     .pending_blocks
                     .insert(block.height, block.clone());
-                self.drain_deferred_decisions()
+                self.advance()
                     .await
-                    .context("drain_deferred_decisions failed after block insert")?;
+                    .context("advance failed after block insert")?;
                 // A pending block may be what we're waiting to propose
                 if self.consensus.pending_proposal.is_some() {
                     self.try_fulfill_pending_proposal()
@@ -292,7 +292,9 @@ impl<E: Executor> Reactor<E> {
                 // old-chain entries would order ahead of new-chain decisions in
                 // the drain queue and wedge it (a batch waiting on an anchor
                 // whose only block decision is queued behind it).
-                self.consensus.clear_on_rollback();
+                self.consensus
+                    .clear_on_rollback(&self.db_conn(), to_height)
+                    .await;
                 let checkpoint = self.consensus.get_checkpoint(&self.db_conn()).await;
                 self.consensus
                     .emit_state_event(StateEvent::RollbackExecuted {
@@ -453,57 +455,9 @@ impl<E: Executor> Reactor<E> {
                         self.handle_block_with_decision(block, &decision)
                             .await
                             .context("handle_block_with_decision failed after consensus block")?;
-                        self.drain_deferred_decisions()
+                        self.advance()
                             .await
-                            .context("drain_deferred_decisions failed after consensus block")?;
-                        // Check finality after block execution — batch txids may now be confirmed
-                        let conn = self.db_conn();
-                        if self.consensus
-                            .unfinalized_batches
-                            .iter()
-                            .any(|b| b.deadline <= self.last_height)
-                            && let Some((rollback_anchor, excluded)) = self.consensus.run_finality_checks(&conn, self.last_height).await {
-                                // Read replay decisions from DB before deleting state
-                                // (the txid join is cascade-deleted with the blocks).
-                                let replay = self
-                                    .load_replay_decisions(rollback_anchor)
-                                    .await
-                                    .context("load_replay_decisions failed")?;
-
-                                // Rollback to before the invalid anchor so all state at the
-                                // anchor height (including invalid tx effects) is wiped cleanly.
-                                self.rollback(rollback_anchor.saturating_sub(1))
-                                    .await
-                                    .context("rollback failed during finality rollback")?;
-
-                                // Fallible raw-tx resolution/filtering only after the
-                                // truncation is durable — a failure here must not
-                                // cancel the rollback finality demanded.
-                                self.prepare_replay(rollback_anchor, replay, excluded)
-                                    .await
-                                    .context("prepare_replay failed")?;
-
-                                // Emit rollback event
-                                let checkpoint = self.consensus.get_checkpoint(&conn).await;
-                                self.consensus.emit_state_event(StateEvent::RollbackExecuted {
-                                    to_anchor: rollback_anchor,
-                                    entries_removed: 0,
-                                    checkpoint,
-                                });
-
-                                // Process deferred decisions using already-cached blocks.
-                                // `pending_blocks` is deliberately NOT cleared here (#430):
-                                // a finality rollback re-executes against the SAME Bitcoin
-                                // chain, so cached blocks are still the right data and make
-                                // this drain immediate — `replay_blocks_after` re-delivery is
-                                // only the fallback. The Bitcoin-reorg path (`BlockEvent::
-                                // Rollback`) clears them instead because there the blocks
-                                // themselves changed; the drain's block-hash check guards
-                                // any stale remainder in both paths.
-                                self.drain_deferred_decisions()
-                                    .await
-                                    .context("drain_deferred_decisions failed after finality rollback")?;
-                            }
+                            .context("advance failed after consensus block")?;
                     }
                     // Yield to allow other channels (block_rx, mempool_rx) to be polled
                     tokio::task::yield_now().await;

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -249,6 +249,30 @@ impl<E: Executor> Reactor<E> {
                 }
                 info!("Block {}/{} {}", block.height, target_height, block.hash);
 
+                // A block at or below the tip is already applied and can never be
+                // proposed or executed again — buffering it is not merely useless,
+                // it HALTS THE CHAIN. `make_value` proposes the minimum pending
+                // height, peers still hold the block so they vote it valid, and it
+                // is decided; the finalize gate then refuses it as out of order and
+                // nothing removes it from the buffer. It stays the minimum forever,
+                // newer blocks are never proposed, and the only thing that would
+                // clear it — a successful block execution — is exactly what the loop
+                // prevents.
+                //
+                // Reachable from the poller: `replay_blocks_after` re-sends stored
+                // block events, and the finality path deliberately keeps
+                // `pending_blocks` across a rollback, so a replayed block can land
+                // after the deferred drain has already carried the tip past it.
+                if block.height <= self.last_height {
+                    debug!(
+                        block_height = block.height,
+                        %block.hash,
+                        last_height = self.last_height,
+                        "Ignoring block at or below the tip — already applied"
+                    );
+                    return Ok(());
+                }
+
                 info!(
                     block_height = block.height,
                     %block.hash,

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -480,9 +480,9 @@ impl<E: Executor> Reactor<E> {
                         warn!("Event receiver dropped, cannot send BatchProcessed event");
                     }
                     if let consensus_state::ConsensusResult::Block(block, decision) = consensus_result {
-                        self.handle_block_with_decision(block, &decision)
+                        self.handle_block(block, &decision)
                             .await
-                            .context("handle_block_with_decision failed after consensus block")?;
+                            .context("handle_block failed after consensus block")?;
                         self.advance()
                             .await
                             .context("advance failed after consensus block")?;

--- a/core/indexer/src/reactor/reactor_cluster_tests.rs
+++ b/core/indexer/src/reactor/reactor_cluster_tests.rs
@@ -1914,3 +1914,54 @@ async fn prod_reactor_out_of_order_block_decision_parks_instead_of_dying() -> Re
     cluster.shutdown().await;
     Ok(())
 }
+
+/// A block re-delivered AFTER the node already executed it must not stop the
+/// chain.
+///
+/// This is not a synthetic poke: `replay_blocks_after` re-sends every stored
+/// block event above a height, and the finality path deliberately keeps
+/// `pending_blocks` across a rollback. A replayed `BlockInsert` can therefore
+/// land after the deferred decisions have already drained and carried the tip
+/// past that height — the poller redelivering a block the node has since
+/// applied.
+///
+/// `process_block_event` buffers it with no tip check, and `make_value`
+/// proposes `pending_blocks.first_key_value()` with no tip check either, so the
+/// proposer offers an already-applied height. Nothing consumes it: the finalize
+/// gate only removes from `pending_blocks` when the decision is in order, and
+/// the drain's tip gate drops the decision without touching the buffer. If that
+/// is a closed loop, the stale entry stays the minimum forever, newer blocks
+/// are never proposed, and the chain stops.
+#[tokio::test]
+async fn prod_reactor_replayed_block_below_tip_does_not_stall_the_chain() -> Result<()> {
+    crate::logging::setup();
+
+    let mut cluster = ReactorCluster::start(3).await?;
+    cluster.wait_for_ready().await;
+
+    for height in 1..=3u64 {
+        cluster.mine_empty_and_send();
+        cluster
+            .wait_for_block(height, Duration::from_secs(60))
+            .await;
+    }
+
+    // Re-deliver block 2, now two heights below the tip — exactly what a late
+    // replay looks like.
+    let replayed = cluster
+        .mock_bitcoin()
+        .get_all_block_events()
+        .into_iter()
+        .find(|e| matches!(e, BlockEvent::BlockInsert { block, .. } if block.height == 2))
+        .expect("block 2 must have been mined");
+    cluster.send_block_event(replayed);
+
+    // The chain must still make progress. If the stale entry pins `make_value`,
+    // height 4 is never proposed and this times out.
+    cluster.mine_empty_and_send();
+    cluster.wait_for_block(4, Duration::from_secs(60)).await;
+
+    cluster.assert_no_reactor_errors();
+    cluster.shutdown().await;
+    Ok(())
+}

--- a/core/indexer/src/reactor/reactor_cluster_tests.rs
+++ b/core/indexer/src/reactor/reactor_cluster_tests.rs
@@ -1693,6 +1693,67 @@ async fn prod_reactor_reorg_at_batch_anchor_keeps_batch_tracked() -> Result<()> 
     Ok(())
 }
 
+/// A late joiner syncing across a ≥2-deep reorg episode. The decided sequence
+/// legitimately contains the stale chain-A block decisions followed by the
+/// chain-B re-decisions — every live node serves that history forever. The
+/// joiner declines the first stale decision at `tip + 1` by the buffered-hash
+/// check, but the DEEPER stale decisions sit ahead of its tip, where the drain
+/// used to park unconditionally — wedging on chain-A decisions with the
+/// chain-B re-decisions queued right behind them, permanently. This times out
+/// without the ahead-of-tip decline.
+#[tokio::test]
+async fn prod_reactor_late_joiner_syncs_across_a_deep_reorg() -> Result<()> {
+    crate::logging::setup();
+
+    let mut cluster = ReactorCluster::start_with(4, 3).await?;
+    cluster.wait_for_ready().await;
+
+    for h in 1..=3 {
+        cluster.mine_empty_and_send();
+        cluster.wait_for_block(h, Duration::from_secs(60)).await;
+    }
+
+    // Reorg the top two blocks away and decide a longer replacement chain. The
+    // decided sequence now reads ... 2A, 3A, 2B, 3B, 4B ... — with fork-salted
+    // mock hashes, 2A/3A name blocks that no longer exist anywhere.
+    cluster.mock_bitcoin().reset_to(1);
+    cluster.send_block_event(BlockEvent::Rollback { to_height: 1 });
+    cluster.wait_for_rollback(1, Duration::from_secs(60)).await;
+    for h in 2..=4 {
+        cluster.mine_empty_and_send();
+        cluster.wait_for_block(h, Duration::from_secs(60)).await;
+    }
+
+    // The joiner's poller serves only the surviving chain.
+    let node_idx = cluster.add_node().await?;
+    for event in cluster.mock_bitcoin().get_all_block_events() {
+        let _ = cluster.block_txs[node_idx].try_send(event);
+    }
+
+    // Poll the joiner's OWN database: it must execute the post-reorg chain to
+    // height 4. The shared event channel would be satisfied by the live nodes.
+    let conn = cluster.node_conn(node_idx).await.clone();
+    let mut tip = 0u64;
+    for _ in 0..240 {
+        let mut rows = conn
+            .query("SELECT COALESCE(MAX(height), 0) FROM blocks", ())
+            .await?;
+        tip = rows.next().await?.expect("row").get(0)?;
+        if tip >= 4 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    assert!(
+        tip >= 4,
+        "late joiner stuck at tip {tip} — the drain wedged on a stale pre-reorg \
+         block decision instead of declining it"
+    );
+
+    cluster.shutdown().await;
+    Ok(())
+}
+
 #[tokio::test]
 async fn prod_reactor_late_joiner_syncs_to_same_checkpoint() -> Result<()> {
     crate::logging::setup();

--- a/core/indexer/src/reactor/reactor_cluster_tests.rs
+++ b/core/indexer/src/reactor/reactor_cluster_tests.rs
@@ -63,6 +63,13 @@ struct ReactorCluster {
     /// while a single node can also be stopped on its own.
     node_cancels: Vec<CancellationToken>,
     block_txs: Vec<mpsc::Sender<BlockEvent>>,
+    /// Fatal errors that killed a node's reactor task.
+    ///
+    /// `spawn_node` used to log these and move on, which made "the reactor
+    /// died" unassertable: a test whose node crashed showed up as a timeout on
+    /// whatever it was waiting for, indistinguishable from consensus simply
+    /// being slow. Tests that expect every node to survive assert this is empty.
+    reactor_errors: Arc<Mutex<Vec<(usize, String)>>>,
     mempool_tx: broadcast::Sender<MempoolEvent>,
     decided_rx: mpsc::Receiver<DecidedBatch>,
     finality_rx: mpsc::Receiver<FinalityEvent>,
@@ -165,6 +172,7 @@ impl ReactorCluster {
         let (event_tx, event_rx) = mpsc::channel(1024);
 
         let mut join_set = JoinSet::new();
+        let reactor_errors: Arc<Mutex<Vec<(usize, String)>>> = Arc::new(Mutex::new(Vec::new()));
         let mut started_nodes = vec![false; total];
         let mut simulate_txs = Vec::new();
 
@@ -218,6 +226,7 @@ impl ReactorCluster {
                 node_dirs[i].0.path().to_path_buf(),
                 node_dirs[i].1.clone(),
                 true,
+                reactor_errors.clone(),
                 &mut join_set,
             );
             started_nodes[i] = true;
@@ -233,6 +242,7 @@ impl ReactorCluster {
             node_dirs,
             node_cancels,
             block_txs,
+            reactor_errors,
             mempool_tx,
             decided_rx,
             finality_rx,
@@ -330,6 +340,7 @@ impl ReactorCluster {
             self.node_dirs[i].0.path().to_path_buf(),
             self.node_dirs[i].1.clone(),
             false,
+            self.reactor_errors.clone(),
             &mut self.join_set,
         );
 
@@ -409,6 +420,7 @@ impl ReactorCluster {
         // seeding runs only on the first boot. That distinction is the whole point
         // of the restart path — a node that re-seeds has not really restarted.
         first_boot: bool,
+        reactor_errors: Arc<Mutex<Vec<(usize, String)>>>,
         join_set: &mut JoinSet<()>,
     ) {
         let genesis = genesis.clone();
@@ -530,7 +542,9 @@ impl ReactorCluster {
             let _ = rtx.send(i).await;
 
             if let Err(e) = reactor.run().await {
-                tracing::error!(node = i, e = format!("{e:#}"), "Reactor error");
+                let msg = format!("{e:#}");
+                tracing::error!(node = i, e = %msg, "Reactor error");
+                reactor_errors.lock().unwrap().push((i, msg));
             }
         });
     }
@@ -579,6 +593,7 @@ impl ReactorCluster {
             self.node_dirs[i].0.path().to_path_buf(),
             self.node_dirs[i].1.clone(),
             true,
+            self.reactor_errors.clone(),
             &mut self.join_set,
         );
 
@@ -724,6 +739,40 @@ impl ReactorCluster {
             txids,
             state_events,
             events,
+        }
+    }
+
+    /// Assert no node's reactor died during the test.
+    ///
+    /// Worth calling explicitly wherever survival is the property under test: a
+    /// dead reactor otherwise surfaces only as a timeout somewhere downstream,
+    /// which reads as "consensus was slow" and hides the actual failure.
+    fn assert_no_reactor_errors(&self) {
+        let errors = self.reactor_errors.lock().unwrap();
+        assert!(errors.is_empty(), "reactor(s) died: {errors:?}");
+    }
+
+    /// Wait until `height` is DECIDED by consensus, without requiring every node
+    /// to have executed it.
+    ///
+    /// `wait_for_block` demands `BlockProcessed` from all `node_count` nodes,
+    /// which is the right check when everyone is healthy but cannot express
+    /// "the chain advanced even though one node could not follow" — the exact
+    /// property at stake when a node is deliberately left behind.
+    async fn wait_for_block_decided(&mut self, height: u64, timeout: Duration) {
+        let deadline = tokio::time::sleep(timeout);
+        tokio::pin!(deadline);
+        loop {
+            tokio::select! {
+                _ = &mut deadline => {
+                    panic!("wait_for_block_decided(height={height}) timed out");
+                }
+                Some(d) = self.decided_rx.recv() => {
+                    if d.value.is_block() && d.value.block_height() == height {
+                        return;
+                    }
+                }
+            }
         }
     }
 
@@ -1788,6 +1837,80 @@ async fn prod_reactor_pending_blocks_bounded_under_stalled_consensus() -> Result
         "pending_blocks is unbounded: accepted {accepted}/{flood} exceeds {ceiling} — high-water gate not applied"
     );
 
+    cluster.shutdown().await;
+    Ok(())
+}
+
+/// A node whose execution has fallen behind heights the network already decided
+/// must PARK the out-of-order decision, not die on it.
+///
+/// This is the signet halt of 2026-08. One validator's executor was 128 blocks
+/// behind while its buffer held the whole window, so a decision for the network's
+/// tip found that block cached and went straight to the executor — whose height
+/// guard is a `bail!`, taken *after* the `batches` row was already committed.
+/// The reactor exited, the pod restarted, and because that validator held the
+/// third of three usable votes in a 3/4 quorum, each restart bought exactly one
+/// decided height before dying again: 121 restarts, 20 h, chain stopped.
+///
+/// The property is asymmetric on purpose. The lagging node stays stuck — the
+/// heights it missed will not be re-decided, and value-sync will not backfill a
+/// node whose *consensus* height is current — but it stays UP, keeps voting, and
+/// the chain keeps moving. A stuck node is an operator problem; a crash-looping
+/// one takes the network down with it.
+#[tokio::test]
+async fn prod_reactor_out_of_order_block_decision_parks_instead_of_dying() -> Result<()> {
+    crate::logging::setup();
+
+    let mut cluster = ReactorCluster::start(4).await?;
+    cluster.wait_for_ready().await;
+
+    // Blocks 1 and 2 reach only nodes 0-2. Node 3 has no block at all, so it
+    // rejects both proposals and votes nil; 3 of 4 still clears the 2/3
+    // threshold, so consensus decides and executes them without it. Node 3's
+    // consensus height advances with every decision — which is precisely why it
+    // will never be re-sent these heights.
+    let lagging = 3;
+    for height in 1..=2u64 {
+        let (blk_events, _) = cluster.mock_bitcoin().mine_empty_block();
+        for event in blk_events {
+            for (i, tx) in cluster.block_txs.iter().enumerate() {
+                if i != lagging {
+                    let _ = tx.try_send(event.clone());
+                }
+            }
+        }
+        cluster
+            .wait_for_block_decided(height, Duration::from_secs(60))
+            .await;
+    }
+
+    // Block 3 goes to everyone. Node 3 now holds a block for height 3 with a tip
+    // of 0 — buffered, but 2 heights out of reach. It accepts the proposal (the
+    // block IS the canonical one at that height, which is all a `Value::Block`
+    // asserts) and votes for it, so the decision lands on a node that cannot
+    // execute it. Before the ordering gate, this is the line that killed the
+    // reactor: "Unexpected block height 3, expected 1".
+    let (blk_events, _) = cluster.mock_bitcoin().mine_empty_block();
+    for event in blk_events {
+        cluster.send_block_event(event);
+    }
+    cluster
+        .wait_for_block_decided(3, Duration::from_secs(60))
+        .await;
+
+    // The chain keeps advancing afterwards — the lagging node still votes, so
+    // quorum survives. Two more heights prove it is not a one-off.
+    for height in 4..=5u64 {
+        let (blk_events, _) = cluster.mock_bitcoin().mine_empty_block();
+        for event in blk_events {
+            cluster.send_block_event(event);
+        }
+        cluster
+            .wait_for_block_decided(height, Duration::from_secs(60))
+            .await;
+    }
+
+    cluster.assert_no_reactor_errors();
     cluster.shutdown().await;
     Ok(())
 }

--- a/core/indexer/src/reactor/reactor_cluster_tests.rs
+++ b/core/indexer/src/reactor/reactor_cluster_tests.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::Result;
-use tokio::sync::{broadcast, mpsc, watch};
+use tokio::sync::{broadcast, mpsc, oneshot, watch};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
@@ -52,6 +52,10 @@ async fn wait_matching<T>(
 
 #[allow(dead_code)]
 struct ReactorCluster {
+    /// Per-node storage connections, resolved lazily from `conn_rxs` on first use.
+    /// A node that has not been started yet has neither.
+    conns: Vec<Option<libsql::Connection>>,
+    conn_rxs: Vec<Option<oneshot::Receiver<libsql::Connection>>>,
     block_txs: Vec<mpsc::Sender<BlockEvent>>,
     mempool_tx: broadcast::Sender<MempoolEvent>,
     decided_rx: mpsc::Receiver<DecidedBatch>,
@@ -137,6 +141,8 @@ impl ReactorCluster {
         let (mempool_tx, _) = broadcast::channel::<MempoolEvent>(256);
         let cancel = CancellationToken::new();
         let mut block_txs = Vec::new();
+        let mut conn_rxs: Vec<Option<oneshot::Receiver<libsql::Connection>>> =
+            (0..total).map(|_| None).collect();
         let mock_bitcoin = Arc::new(Mutex::new(MockBitcoin::new(0)));
         let shared_pubkey = random_x_only_pubkey();
         let (engine, component_cache) = shared_engine_and_cache().await;
@@ -173,6 +179,8 @@ impl ReactorCluster {
             // here on bind. Only the seed's receiver is read back (to bootstrap
             // the followers); the rest are dropped after spawn.
             let (addr_tx, addr_rx) = watch::channel(None);
+            let (node_conn_tx, node_conn_rx) = oneshot::channel();
+            conn_rxs[i] = Some(node_conn_rx);
 
             Self::spawn_node(
                 i,
@@ -195,6 +203,7 @@ impl ReactorCluster {
                 shared_pubkey.clone(),
                 engine.clone(),
                 component_cache.clone(),
+                node_conn_tx,
                 &mut join_set,
             );
             started_nodes[i] = true;
@@ -205,6 +214,8 @@ impl ReactorCluster {
         }
 
         Ok(Self {
+            conns: (0..total).map(|_| None).collect(),
+            conn_rxs,
             block_txs,
             mempool_tx,
             decided_rx,
@@ -231,6 +242,25 @@ impl ReactorCluster {
             simulate_txs,
             started_nodes,
         })
+    }
+
+    /// This node's storage connection, so a test can assert on what it actually
+    /// wrote rather than only on the events it emitted.
+    ///
+    /// Resolved on first use — the connection only exists once the node's runtime
+    /// has been built inside its task, so call this after `wait_for_ready`.
+    async fn node_conn(&mut self, i: usize) -> &libsql::Connection {
+        if self.conns[i].is_none() {
+            let rx = self.conn_rxs[i]
+                .take()
+                .unwrap_or_else(|| panic!("node {i} was never started"));
+            let conn = tokio::time::timeout(Duration::from_secs(30), rx)
+                .await
+                .unwrap_or_else(|_| panic!("node {i} never reported its connection"))
+                .unwrap_or_else(|_| panic!("node {i} died before reporting its connection"));
+            self.conns[i] = Some(conn);
+        }
+        self.conns[i].as_ref().unwrap()
     }
 
     async fn start(n: usize) -> Result<Self> {
@@ -293,6 +323,11 @@ impl ReactorCluster {
         pubkey: String,
         engine: wasmtime::Engine,
         component_cache: crate::runtime::ComponentCache,
+        // Hands this node's storage connection back to the test. The runtime is
+        // built inside the spawned task, so without this a test has no way to look
+        // at what a particular node actually wrote — which is most of what there is
+        // to assert about a consensus bug.
+        conn_tx: oneshot::Sender<libsql::Connection>,
         join_set: &mut JoinSet<()>,
     ) {
         let genesis = genesis.clone();
@@ -322,6 +357,9 @@ impl ReactorCluster {
             };
 
             let conn = runtime.get_storage_conn();
+            // Ignore the error: a test that never asks for the connection drops the
+            // receiver, which is fine.
+            let _ = conn_tx.send(conn.clone());
 
             let engine_output = match engine::start(engine_config).await {
                 Ok(o) => o,
@@ -404,6 +442,8 @@ impl ReactorCluster {
 
         // Late joiner bootstraps from the seed; its own address isn't read back.
         let (addr_tx, _addr_rx) = watch::channel(None);
+        let (node_conn_tx, node_conn_rx) = oneshot::channel();
+        self.conn_rxs[i] = Some(node_conn_rx);
 
         Self::spawn_node(
             i,
@@ -426,6 +466,7 @@ impl ReactorCluster {
             self.shared_pubkey.clone(),
             self.engine.clone(),
             self.component_cache.clone(),
+            node_conn_tx,
             &mut self.join_set,
         );
 
@@ -1274,6 +1315,57 @@ async fn prod_reactor_bitcoin_rollback_across_decided_batch() -> Result<()> {
         replayed.txids.len(),
         2,
         "rolled-back batch txs must re-execute in a fresh batch"
+    );
+
+    cluster.shutdown().await;
+    Ok(())
+}
+
+/// Every consensus height must leave a row in `batches` — that table is the decided
+/// sequence and the ONLY copy of it, since Malachite asks us for decided values
+/// rather than keeping them. A height with no row is a hole that cannot be refilled:
+/// the startup cleanup trims an unexecuted SUFFIX, never a gap in the middle.
+///
+/// SCOPE, so this is not mistaken for more than it is: measured green both with and
+/// without `record_declined_block`, so it does NOT cover that fix. Every decision in
+/// this scenario is executed before the reorg lands, so nothing is ever declined —
+/// reaching those paths needs a reorg to arrive between decide and execute, which
+/// the harness cannot schedule. What this does cover is the invariant itself, on a
+/// real reorg: it would catch a future change that starts dropping decisions.
+#[tokio::test]
+async fn prod_reactor_reorg_leaves_no_gap_in_the_decided_sequence() -> Result<()> {
+    crate::logging::setup();
+
+    let mut cluster = ReactorCluster::start(3).await?;
+    cluster.wait_for_ready().await;
+
+    for h in 1..=3 {
+        cluster.mine_empty_and_send();
+        cluster.wait_for_block(h, Duration::from_secs(60)).await;
+    }
+
+    // Reorg away the top two blocks, then let the new chain be decided.
+    cluster.mock_bitcoin().reset_to(1);
+    cluster.send_block_event(BlockEvent::Rollback { to_height: 1 });
+    cluster.wait_for_rollback(1, Duration::from_secs(60)).await;
+    for h in 2..=4 {
+        cluster.mine_empty_and_send();
+        cluster.wait_for_block(h, Duration::from_secs(60)).await;
+    }
+
+    let conn = cluster.node_conn(0).await;
+    let mut rows = conn
+        .query(
+            "SELECT MIN(consensus_height), MAX(consensus_height), COUNT(*) FROM batches",
+            (),
+        )
+        .await?;
+    let row = rows.next().await?.expect("batches must not be empty");
+    let (min, max, count): (u64, u64, u64) = (row.get(0)?, row.get(1)?, row.get(2)?);
+    assert_eq!(
+        count,
+        max - min + 1,
+        "decided sequence has a gap: heights {min}..={max} but only {count} rows"
     );
 
     cluster.shutdown().await;

--- a/core/indexer/src/reactor/reactor_cluster_tests.rs
+++ b/core/indexer/src/reactor/reactor_cluster_tests.rs
@@ -1286,14 +1286,11 @@ async fn prod_reactor_bitcoin_rollback_across_decided_batch() -> Result<()> {
 /// constructs this shape — the two existing reorg tests either track nothing or
 /// reorg BELOW the anchor so the rows cascade away.
 ///
-/// LIMITATION, so nobody reads more into this than it gives: it does NOT
-/// discriminate `clear_on_rollback`'s re-derivation from a plain `clear()`. Both
-/// were measured green here — a rollback naming the original batch fires either
-/// way, by a route not yet identified. Treat this as coverage of the path (it
-/// would catch a wedge, a crash, or a lost decision), not as a guard on the
-/// re-derivation itself. That guard still needs writing.
+/// Asserts on WHICH batch was invalidated, not merely that some rollback happened:
+/// the excluded transactions return via the mempool, so a rollback naming a
+/// different consensus height fires even when tracking was wiped.
 #[tokio::test]
-async fn prod_reactor_reorg_at_batch_anchor_completes() -> Result<()> {
+async fn prod_reactor_reorg_at_batch_anchor_keeps_batch_tracked() -> Result<()> {
     crate::logging::setup();
 
     let mut cluster = ReactorCluster::start(3).await?;
@@ -1338,7 +1335,7 @@ async fn prod_reactor_reorg_at_batch_anchor_completes() -> Result<()> {
     // Assert on WHICH batch was invalidated, not merely that some rollback happened:
     // the excluded txs return via the mempool, so a rollback naming a DIFFERENT
     // consensus height fires even with tracking wiped.
-    cluster
+    let events = cluster
         .wait_for_finality_event_matching(
             move |e| {
                 matches!(e, FinalityEvent::Rollback { invalidated_batches, .. }
@@ -1347,6 +1344,14 @@ async fn prod_reactor_reorg_at_batch_anchor_completes() -> Result<()> {
             Duration::from_secs(60),
         )
         .await;
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            FinalityEvent::Rollback { invalidated_batches, .. }
+                if invalidated_batches.contains(&tracked_height)
+        )),
+        "expected a Rollback invalidating the tracked batch {tracked_height}, got: {events:?}"
+    );
 
     cluster.shutdown().await;
     Ok(())

--- a/core/indexer/src/reactor/reactor_cluster_tests.rs
+++ b/core/indexer/src/reactor/reactor_cluster_tests.rs
@@ -1280,6 +1280,78 @@ async fn prod_reactor_bitcoin_rollback_across_decided_batch() -> Result<()> {
     Ok(())
 }
 
+/// A Bitcoin reorg that stops AT a tracked batch's anchor. The rollback deletes
+/// blocks strictly above the target, so a batch anchored at or below it keeps its
+/// `transactions` rows and is still owed a finality verdict. No other test
+/// constructs this shape — the two existing reorg tests either track nothing or
+/// reorg BELOW the anchor so the rows cascade away.
+///
+/// LIMITATION, so nobody reads more into this than it gives: it does NOT
+/// discriminate `clear_on_rollback`'s re-derivation from a plain `clear()`. Both
+/// were measured green here — a rollback naming the original batch fires either
+/// way, by a route not yet identified. Treat this as coverage of the path (it
+/// would catch a wedge, a crash, or a lost decision), not as a guard on the
+/// re-derivation itself. That guard still needs writing.
+#[tokio::test]
+async fn prod_reactor_reorg_at_batch_anchor_completes() -> Result<()> {
+    crate::logging::setup();
+
+    let mut cluster = ReactorCluster::start(3).await?;
+    cluster.wait_for_ready().await;
+
+    cluster.mine_empty_and_send();
+    cluster.wait_for_block(1, Duration::from_secs(60)).await;
+    cluster.mine_empty_and_send();
+    cluster.wait_for_block(2, Duration::from_secs(60)).await;
+
+    // A batch anchored at 2, whose txs will never confirm — deadline 2 + 6 = 8.
+    for event in cluster.mock_bitcoin().generate_mempool_txs(2) {
+        cluster.send_mempool_event(event);
+    }
+    let batch = cluster.wait_for_batch(2, Duration::from_secs(60)).await;
+    assert_eq!(batch.txids.len(), 2, "setup batch must carry both txs");
+    let tracked_height = batch
+        .state_events
+        .iter()
+        .find_map(|e| match e {
+            StateEvent::BatchApplied {
+                consensus_height, ..
+            } => Some(*consensus_height),
+            _ => None,
+        })
+        .expect("setup batch must report a consensus height");
+
+    cluster.mine_empty_and_send();
+    cluster.wait_for_block(3, Duration::from_secs(60)).await;
+
+    // Reorg back to the batch's own anchor. Block 2 survives with the same hash, so
+    // the batch is untouched — only the blocks above it go.
+    cluster.mock_bitcoin().reset_to(2);
+    cluster.send_block_event(BlockEvent::Rollback { to_height: 2 });
+    cluster.wait_for_rollback(2, Duration::from_secs(60)).await;
+
+    // Climb past the deadline. The surviving batch's txs are still unconfirmed, so
+    // finality must still invalidate it.
+    for _ in 0..7 {
+        cluster.mine_empty_and_send();
+    }
+    // Assert on WHICH batch was invalidated, not merely that some rollback happened:
+    // the excluded txs return via the mempool, so a rollback naming a DIFFERENT
+    // consensus height fires even with tracking wiped.
+    cluster
+        .wait_for_finality_event_matching(
+            move |e| {
+                matches!(e, FinalityEvent::Rollback { invalidated_batches, .. }
+                    if invalidated_batches.contains(&tracked_height))
+            },
+            Duration::from_secs(60),
+        )
+        .await;
+
+    cluster.shutdown().await;
+    Ok(())
+}
+
 #[tokio::test]
 async fn prod_reactor_late_joiner_syncs_to_same_checkpoint() -> Result<()> {
     crate::logging::setup();

--- a/core/indexer/src/reactor/reactor_cluster_tests.rs
+++ b/core/indexer/src/reactor/reactor_cluster_tests.rs
@@ -56,6 +56,12 @@ struct ReactorCluster {
     /// A node that has not been started yet has neither.
     conns: Vec<Option<libsql::Connection>>,
     conn_rxs: Vec<Option<oneshot::Receiver<libsql::Connection>>>,
+    /// Each node's data directory, owned HERE so it survives the node's task and a
+    /// restart can reopen it.
+    node_dirs: Vec<(tempfile::TempDir, String)>,
+    /// Child of the cluster token, so cancelling the cluster still stops everyone
+    /// while a single node can also be stopped on its own.
+    node_cancels: Vec<CancellationToken>,
     block_txs: Vec<mpsc::Sender<BlockEvent>>,
     mempool_tx: broadcast::Sender<MempoolEvent>,
     decided_rx: mpsc::Receiver<DecidedBatch>,
@@ -143,6 +149,11 @@ impl ReactorCluster {
         let mut block_txs = Vec::new();
         let mut conn_rxs: Vec<Option<oneshot::Receiver<libsql::Connection>>> =
             (0..total).map(|_| None).collect();
+        let node_dirs: Vec<(tempfile::TempDir, String)> = (0..total)
+            .map(|_| crate::test_utils::new_test_db_dir().expect("node data dir"))
+            .collect();
+        let node_cancels: Vec<CancellationToken> =
+            (0..total).map(|_| cancel.child_token()).collect();
         let mock_bitcoin = Arc::new(Mutex::new(MockBitcoin::new(0)));
         let shared_pubkey = random_x_only_pubkey();
         let (engine, component_cache) = shared_engine_and_cache().await;
@@ -192,7 +203,7 @@ impl ReactorCluster {
                 node_block_tx,
                 node_block_rx,
                 node_mempool_rx,
-                cancel.clone(),
+                node_cancels[i].clone(),
                 decided_tx.clone(),
                 finality_tx.clone(),
                 state_tx.clone(),
@@ -204,6 +215,9 @@ impl ReactorCluster {
                 engine.clone(),
                 component_cache.clone(),
                 node_conn_tx,
+                node_dirs[i].0.path().to_path_buf(),
+                node_dirs[i].1.clone(),
+                true,
                 &mut join_set,
             );
             started_nodes[i] = true;
@@ -216,6 +230,8 @@ impl ReactorCluster {
         Ok(Self {
             conns: (0..total).map(|_| None).collect(),
             conn_rxs,
+            node_dirs,
+            node_cancels,
             block_txs,
             mempool_tx,
             decided_rx,
@@ -261,6 +277,65 @@ impl ReactorCluster {
             self.conns[i] = Some(conn);
         }
         self.conns[i].as_ref().unwrap()
+    }
+
+    /// Stop one node, leaving the rest of the cluster running. Its data directory
+    /// is owned by the cluster, so the database survives for a restart.
+    async fn stop_node(&mut self, i: usize) {
+        self.node_cancels[i].cancel();
+        // Its connection belongs to a runtime that is going away.
+        self.conns[i] = None;
+    }
+
+    /// Stop a node and bring it back up on the state it left behind — the shape of
+    /// issue #515, where a restart inside the finality window lost tracking that
+    /// lived only in memory.
+    async fn restart_node(&mut self, i: usize) {
+        self.stop_node(i).await;
+        // Give the task a moment to unwind and release the database.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        self.node_cancels[i] = self.cancel.child_token();
+        let (node_block_tx, node_block_rx) = mpsc::channel(256);
+        self.block_txs[i] = node_block_tx.clone();
+        let node_mempool_rx = Self::bridge_mempool(&self.mempool_tx, &self.cancel);
+        let (sim_tx, sim_rx) = mpsc::channel(1);
+        self.simulate_txs[i] = sim_tx;
+        let (addr_tx, _addr_rx) = watch::channel(None);
+        let (node_conn_tx, node_conn_rx) = oneshot::channel();
+        self.conn_rxs[i] = Some(node_conn_rx);
+
+        Self::spawn_node(
+            i,
+            self.private_keys[i].clone(),
+            &self.genesis,
+            &self.genesis_validators,
+            vec![self.seed_addr.clone()],
+            addr_tx,
+            node_block_tx,
+            node_block_rx,
+            node_mempool_rx,
+            self.node_cancels[i].clone(),
+            self.decided_tx.clone(),
+            self.finality_tx.clone(),
+            self.state_tx.clone(),
+            self.ready_tx.clone(),
+            self.event_tx.clone(),
+            Some(sim_rx),
+            self.mock_bitcoin.clone(),
+            self.shared_pubkey.clone(),
+            self.engine.clone(),
+            self.component_cache.clone(),
+            node_conn_tx,
+            self.node_dirs[i].0.path().to_path_buf(),
+            self.node_dirs[i].1.clone(),
+            false,
+            &mut self.join_set,
+        );
+
+        // Only this node reports ready — `wait_for_ready` would block forever
+        // waiting on the peers that never went down.
+        let _ = self.ready_rx.recv().await;
     }
 
     async fn start(n: usize) -> Result<Self> {
@@ -328,21 +403,43 @@ impl ReactorCluster {
         // at what a particular node actually wrote — which is most of what there is
         // to assert about a consensus bug.
         conn_tx: oneshot::Sender<libsql::Connection>,
+        data_dir: std::path::PathBuf,
+        db_name: String,
+        // A restart must come back up on the state it left behind, so genesis
+        // seeding runs only on the first boot. That distinction is the whole point
+        // of the restart path — a node that re-seeds has not really restarted.
+        first_boot: bool,
         join_set: &mut JoinSet<()>,
     ) {
         let genesis = genesis.clone();
         let genesis_vals = genesis_validators.to_vec();
         join_set.spawn(async move {
-            let (executor, runtime) = LiteExecutor::new(
-                mock_btc,
-                pubkey,
-                &genesis_vals,
-                engine,
-                component_cache,
-                node_block_tx,
-            )
-            .await
-            .expect("LiteExecutor setup failed");
+            let (executor, runtime) = if first_boot {
+                LiteExecutor::new(
+                    &data_dir,
+                    &db_name,
+                    mock_btc,
+                    pubkey,
+                    &genesis_vals,
+                    engine,
+                    component_cache,
+                    node_block_tx,
+                )
+                .await
+                .expect("LiteExecutor setup failed")
+            } else {
+                LiteExecutor::reopen(
+                    &data_dir,
+                    &db_name,
+                    mock_btc,
+                    pubkey,
+                    engine,
+                    component_cache,
+                    node_block_tx,
+                )
+                .await
+                .expect("LiteExecutor reopen failed")
+            };
 
             let engine_config = EngineConfig {
                 private_key,
@@ -377,12 +474,24 @@ impl ReactorCluster {
                 .iter()
                 .position(|v| v.address == engine_output.address);
 
+            // A restarted node must resume from what it persisted. Hard-coding 0
+            // would make it believe the chain is fresh, and the restart test would
+            // then pass for entirely the wrong reason.
+            let (resume_height, resume_hash) = if first_boot {
+                (0, None)
+            } else {
+                match crate::database::queries::select_block_latest(&conn).await {
+                    Ok(Some(row)) => (row.height, Some(row.hash)),
+                    _ => (0, None),
+                }
+            };
+
             let mut state = ConsensusState::new(
                 conn.clone(),
                 engine_output.signing_provider,
                 genesis,
                 engine_output.address,
-                0,
+                resume_height,
                 engine_output.channels,
                 engine_output._handle,
                 validator_index,
@@ -410,8 +519,8 @@ impl ReactorCluster {
                     enabled: false,
                     retain_blocks: 144,
                 },
-                0,
-                None,
+                resume_height,
+                resume_hash,
                 // Same path as production: the reactor's `ConsensusReady` handler
                 // reads the resolved address and publishes it here. `start_with`
                 // awaits the seed's receiver to bootstrap the followers.
@@ -455,7 +564,7 @@ impl ReactorCluster {
             node_block_tx,
             node_block_rx,
             node_mempool_rx,
-            self.cancel.clone(),
+            self.node_cancels[i].clone(),
             self.decided_tx.clone(),
             self.finality_tx.clone(),
             self.state_tx.clone(),
@@ -467,6 +576,9 @@ impl ReactorCluster {
             self.engine.clone(),
             self.component_cache.clone(),
             node_conn_tx,
+            self.node_dirs[i].0.path().to_path_buf(),
+            self.node_dirs[i].1.clone(),
+            true,
             &mut self.join_set,
         );
 
@@ -1315,6 +1427,89 @@ async fn prod_reactor_bitcoin_rollback_across_decided_batch() -> Result<()> {
         replayed.txids.len(),
         2,
         "rolled-back batch txs must re-execute in a fresh batch"
+    );
+
+    cluster.shutdown().await;
+    Ok(())
+}
+
+/// THE #515 REGRESSION.
+///
+/// A validator executes a batch, restarts while that batch is still inside its
+/// finality window, and its transactions never confirm. Finality tracking used to
+/// live only in memory, so the restarted node came back owing a verdict it no
+/// longer knew about: its peers rolled the batch back, it did not, and it kept
+/// transaction rows they had deleted. Days later the network re-batched those same
+/// transactions, the node hit `transactions.txid UNIQUE`, and crash-looped.
+///
+/// Four validators so the remaining three still hold a supermajority while one is
+/// down. The assertion is on the restarted node's own database: after the deadline
+/// passes, the batch's rows must be gone — meaning it rendered the verdict and
+/// performed the rollback, which is only possible if tracking survived the restart.
+#[tokio::test]
+async fn prod_reactor_restart_inside_finality_window_still_rolls_back() -> Result<()> {
+    crate::logging::setup();
+
+    let mut cluster = ReactorCluster::start(4).await?;
+    cluster.wait_for_ready().await;
+
+    cluster.mine_empty_and_send();
+    cluster.wait_for_block(1, Duration::from_secs(60)).await;
+
+    // A batch anchored at 1 whose transactions are never mined — deadline 1 + 6 = 7.
+    for event in cluster.mock_bitcoin().generate_mempool_txs(2) {
+        cluster.send_mempool_event(event);
+    }
+    let batch = cluster.wait_for_batch(1, Duration::from_secs(60)).await;
+    assert_eq!(batch.txids.len(), 2, "setup batch must carry both txs");
+
+    // The node under test executed it, so the rows are there before the restart.
+    {
+        let conn = cluster.node_conn(3).await;
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM transactions WHERE batch_height IS NOT NULL",
+                (),
+            )
+            .await?;
+        let before: u64 = rows.next().await?.expect("row").get(0)?;
+        assert!(
+            before > 0,
+            "node 3 must have executed the batch before restart"
+        );
+    }
+
+    // Restart INSIDE the finality window — the #515 trigger.
+    cluster.restart_node(3).await;
+
+    // Climb past the deadline. The transactions never confirmed, so every node owes
+    // a rollback — including the one that restarted.
+    for _ in 0..8 {
+        cluster.mine_empty_and_send();
+    }
+    // Poll the restarted node's OWN database. Waiting on the shared finality
+    // channel would prove nothing — any of the three peers that never went down
+    // satisfies it. The restarted node has to sync the decisions it missed before
+    // it can render the verdict, so the wait belongs here.
+    let conn = cluster.node_conn(3).await.clone();
+    let mut after = u64::MAX;
+    for _ in 0..240 {
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM transactions WHERE batch_height IS NOT NULL",
+                (),
+            )
+            .await?;
+        after = rows.next().await?.expect("row").get(0)?;
+        if after == 0 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    assert_eq!(
+        after, 0,
+        "restarted node still holds batch rows its peers rolled back — finality \
+         tracking did not survive the restart (#515)"
     );
 
     cluster.shutdown().await;

--- a/core/indexer/src/reactor/reactor_cluster_tests.rs
+++ b/core/indexer/src/reactor/reactor_cluster_tests.rs
@@ -1079,13 +1079,13 @@ async fn prod_reactor_missing_tx_invalidation() -> Result<()> {
 
     let finality_events = cluster
         .wait_for_finality_event_matching(
-            |e| matches!(e, FinalityEvent::Rollback { missing_txids, .. } if missing_txids.contains(&missing_txid)),
+            |e| matches!(e, FinalityEvent::Rollback { missing, .. } if missing.iter().any(|m| m.txids.contains(&missing_txid))),
             Duration::from_secs(60),
         )
         .await;
     assert!(
         finality_events.iter().any(
-            |e| matches!(e, FinalityEvent::Rollback { missing_txids, .. } if missing_txids.contains(&missing_txid))
+            |e| matches!(e, FinalityEvent::Rollback { missing, .. } if missing.iter().any(|m| m.txids.contains(&missing_txid)))
         ),
         "Expected Rollback with missing txid {missing_txid}, got: {finality_events:?}"
     );

--- a/core/indexer/src/runtime/mod.rs
+++ b/core/indexer/src/runtime/mod.rs
@@ -33,7 +33,7 @@ pub use stdlib::{
     wave_type,
 };
 use stdlib::{contract_address, holder_ref, impls};
-use storage::print_component_wit;
+use storage::{ComponentDecodeError, print_component_wit};
 pub use storage::{Storage, TransactionContext};
 use tokio::sync::Mutex;
 pub use types::default_val_for_type;
@@ -623,18 +623,34 @@ impl Runtime {
         // Compile + cache the component once here; `init` and every later call
         // reuse the cached artifact. We keep the encoded `bytes` so the WIT check
         // below decodes from them instead of recomputing them.
-        // DETERMINISTIC, not NonDeterministic: decoding is a pure function of the
+        // Content failures are DETERMINISTIC: decoding is a pure function of the
         // submitted bytes, so every node fails identically — and a NonDeterministic
         // error propagates out of `execute_block` rather than being recorded, which
         // means the whole network exits at the same height. `filter_map` does not
-        // inspect Publish bytes, so this is reachable from any Bitcoin transaction.
+        // inspect Publish bytes, so that is reachable from any Bitcoin transaction.
         // Same reasoning as the `instantiate_pre` check just below.
-        let (bytes, component) = self
-            .component_bytes_and_compiled(contract_id)
+        //
+        // But only the CONTENT half. The read and the task join are this node's own
+        // machinery; calling those deterministic would make one node reject a publish
+        // its peers accept — the same divergence, silently and in the other direction.
+        let bytes = self
+            .storage
+            .decode_component_bytes(contract_id)
             .await
-            .map_err(|e| {
-                ExecutionError::Deterministic(e.context("contract bytes are not a valid component"))
+            .map_err(|e| match e {
+                ComponentDecodeError::Content(e) => ExecutionError::Deterministic(
+                    e.context("contract bytes are not a valid component"),
+                ),
+                ComponentDecodeError::Infrastructure(e) => ExecutionError::NonDeterministic(e),
             })?;
+        let component = Component::from_binary(&self.engine, &bytes).map_err(|e| {
+            ExecutionError::Deterministic(
+                anyhow!(e).context("contract is not a valid wasm component"),
+            )
+        })?;
+        self.component_cache
+            .put(contract_id, component.clone(), bytes.len())
+            .await;
         let linker = if is_native_contract_id(contract_id) {
             &self.linkers.native
         } else {
@@ -648,7 +664,7 @@ impl Runtime {
 
         if !is_native_contract_id(contract_id) {
             // Deterministic for the same reason: a pure function of bytes that already
-            // decoded, so a failure here is a property of the contract, not of this node.
+            // decoded, so a failure here is a property of the contract, not this node.
             let wit = print_component_wit(&bytes).map_err(|e| {
                 ExecutionError::Deterministic(e.context("contract WIT could not be read"))
             })?;
@@ -1167,6 +1183,34 @@ mod tests {
             matches!(err, super::ExecutionError::Deterministic(_)),
             "rejection must be Deterministic (recorded op failure), not NonDeterministic \
              (every node exits at this height): {err}"
+        );
+    }
+
+    /// The other half of the same classification: this node failing to READ the bytes
+    /// is NOT the contract's fault, and must stay NonDeterministic. Recording it as a
+    /// rejection would make one node refuse a publish its peers accept — the same
+    /// divergence as the halt, silently and in the other direction.
+    #[tokio::test]
+    async fn publish_read_failure_stays_non_deterministic() {
+        let (mut runtime, _dir, _name) = test_runtime().await.expect("test runtime");
+        runtime
+            .set_context(
+                0,
+                Some(super::TransactionContext::builder().build()),
+                None,
+                None,
+            )
+            .await;
+
+        // No contract row at this id — stands in for any failure to obtain the bytes.
+        let err = runtime
+            .validate_publishable(9_999_999)
+            .await
+            .expect_err("a missing contract must not validate");
+        assert!(
+            matches!(err, super::ExecutionError::NonDeterministic(_)),
+            "failing to read the bytes is this node's problem, so it must propagate \
+             rather than be recorded as a deterministic rejection: {err}"
         );
     }
 

--- a/core/indexer/src/runtime/mod.rs
+++ b/core/indexer/src/runtime/mod.rs
@@ -623,10 +623,18 @@ impl Runtime {
         // Compile + cache the component once here; `init` and every later call
         // reuse the cached artifact. We keep the encoded `bytes` so the WIT check
         // below decodes from them instead of recomputing them.
+        // DETERMINISTIC, not NonDeterministic: decoding is a pure function of the
+        // submitted bytes, so every node fails identically — and a NonDeterministic
+        // error propagates out of `execute_block` rather than being recorded, which
+        // means the whole network exits at the same height. `filter_map` does not
+        // inspect Publish bytes, so this is reachable from any Bitcoin transaction.
+        // Same reasoning as the `instantiate_pre` check just below.
         let (bytes, component) = self
             .component_bytes_and_compiled(contract_id)
             .await
-            .map_err(ExecutionError::NonDeterministic)?;
+            .map_err(|e| {
+                ExecutionError::Deterministic(e.context("contract bytes are not a valid component"))
+            })?;
         let linker = if is_native_contract_id(contract_id) {
             &self.linkers.native
         } else {
@@ -639,7 +647,11 @@ impl Runtime {
         })?;
 
         if !is_native_contract_id(contract_id) {
-            let wit = print_component_wit(&bytes).map_err(ExecutionError::NonDeterministic)?;
+            // Deterministic for the same reason: a pure function of bytes that already
+            // decoded, so a failure here is a property of the contract, not of this node.
+            let wit = print_component_wit(&bytes).map_err(|e| {
+                ExecutionError::Deterministic(e.context("contract WIT could not be read"))
+            })?;
             Self::validate_user_wit(&wit)?;
         }
         Ok(())
@@ -1119,6 +1131,42 @@ mod tests {
         assert!(
             matches!(err, super::ExecutionError::Deterministic(_)),
             "rejection must be Deterministic (graceful reject), not NonDeterministic (shutdown): {err}"
+        );
+    }
+
+    /// Bytes that are not a decodable component must be rejected DETERMINISTICALLY.
+    ///
+    /// This one is a chain-halt guard, not a nicety. `filter_map` does not inspect
+    /// Publish bytes, so a malformed payload reaches execution from an ordinary
+    /// Bitcoin transaction — no API access needed. Classified NonDeterministic it
+    /// propagates out of `execute_block` instead of being recorded as an op failure,
+    /// and because the payload is deterministic content EVERY node reaches the same
+    /// conclusion at the same height and exits together.
+    #[tokio::test]
+    async fn publish_rejects_undecodable_bytes_deterministically() {
+        let (mut runtime, _dir, _name) = test_runtime().await.expect("test runtime");
+        runtime
+            .set_context(
+                0,
+                Some(super::TransactionContext::builder().build()),
+                None,
+                None,
+            )
+            .await;
+        let contract_id = runtime
+            .storage
+            .insert_contract("garbage", &[0xFFu8; 64])
+            .await
+            .expect("insert contract");
+
+        let err = runtime
+            .validate_publishable(contract_id)
+            .await
+            .expect_err("undecodable bytes must be rejected");
+        assert!(
+            matches!(err, super::ExecutionError::Deterministic(_)),
+            "rejection must be Deterministic (recorded op failure), not NonDeterministic \
+             (every node exits at this height): {err}"
         );
     }
 

--- a/core/indexer/src/runtime/mod.rs
+++ b/core/indexer/src/runtime/mod.rs
@@ -664,9 +664,14 @@ impl Runtime {
                 anyhow!(e).context("contract is not a valid wasm component"),
             )
         })?;
-        self.component_cache
-            .put(contract_id, component.clone(), bytes.len())
-            .await;
+        // Guarded for the same reason as the write in `component_bytes_and_compiled`,
+        // and this is the site that actually matters: a `Publish` inside a simulation
+        // reaches the cache HERE, under a `contracts.id` the rollback frees for reuse.
+        if !self.simulating {
+            self.component_cache
+                .put(contract_id, component.clone(), bytes.len())
+                .await;
+        }
         let linker = if is_native_contract_id(contract_id) {
             &self.linkers.native
         } else {
@@ -1348,11 +1353,13 @@ mod tests {
     /// would then be served to whatever contract is later assigned that id, on this
     /// node alone, which is a silent divergence from the rest of the network.
     ///
-    /// SCOPE: this pins the guard at the cache's single write site, which both
-    /// routes into it funnel through — `load_component` for calls, and
-    /// `validate_publishable` for publishes. It does not drive a publish through the
-    /// reactor's `simulate`: the lite executor's transactions carry no ops, so the
-    /// cluster harness cannot express one.
+    /// SCOPE: the cache has TWO write sites, and both are covered here —
+    /// `component_bytes_and_compiled` (reached by `load_component`, i.e. calls) and
+    /// `validate_publishable` (reached by `publish`). The publish one is the site the
+    /// hazard is actually about, so it is asserted directly rather than assumed to
+    /// share a path with the other. It does not drive a publish through the reactor's
+    /// `simulate`: the lite executor's transactions carry no ops, so the cluster
+    /// harness cannot express one.
     #[tokio::test]
     async fn simulation_does_not_populate_the_component_cache() {
         let (mut runtime, _dir, _name) = test_runtime().await.expect("test runtime");
@@ -1382,6 +1389,23 @@ mod tests {
             runtime.component_cache.get(&contract_id).await.is_none(),
             "a component compiled during simulation must not be cached — the id it \
              is keyed by is freed by the rollback and can be handed to a real publish"
+        );
+
+        // The publish path caches at its OWN site inside `validate_publishable`, so
+        // it has to be asserted separately — a guard on the call path says nothing
+        // about it. This publish fails (filestorage imports `file-registry`, which a
+        // user contract may not), but only AFTER the component is compiled and would
+        // have been cached, which is exactly the window under test.
+        let publish_id = runtime
+            .storage
+            .insert_contract("publish-probe", FILESTORAGE)
+            .await
+            .expect("insert contract");
+        let _ = runtime.validate_publishable(publish_id).await;
+        assert!(
+            runtime.component_cache.get(&publish_id).await.is_none(),
+            "a publish compiled during simulation must not be cached — this is the \
+             site the id-reuse hazard actually runs through"
         );
 
         // The guard must be scoped to simulation, not a blanket disable: caching is

--- a/core/indexer/src/runtime/mod.rs
+++ b/core/indexer/src/runtime/mod.rs
@@ -1214,6 +1214,47 @@ mod tests {
         );
     }
 
+    /// The same guard through the door an ordinary Bitcoin transaction actually
+    /// comes in by. The two tests above pin `validate_publishable` in isolation,
+    /// which leaves the classification free to be re-wrapped anywhere between
+    /// `publish` and it — and `publish` does not simply forward: it validates
+    /// provenance and the name, inserts the contract row, and on failure rolls
+    /// that row back and evicts the cache. Any of those could reclassify.
+    ///
+    /// `execute_op` records a `Deterministic` publish failure and continues, but
+    /// returns `Err` for `NonDeterministic`, which propagates out of
+    /// `execute_block` and exits the node. Since the payload is deterministic
+    /// content every node reaches that point together, so the wrong class here is
+    /// a whole-network halt costing one Bitcoin fee to trigger.
+    #[tokio::test]
+    async fn malformed_publish_is_recorded_not_fatal() {
+        let (mut runtime, _dir, _name) = test_runtime().await.expect("test runtime");
+        runtime
+            .set_context(
+                1,
+                Some(super::TransactionContext::builder().build()),
+                None,
+                None,
+            )
+            .await;
+        let signer = super::Signer::Core(Box::new(super::Signer::Nobody));
+        let payment = runtime.core_payment();
+        let provenance = super::native_provenance().expect("provenance");
+
+        // Well-formed op, garbage payload: valid kebab name and valid provenance,
+        // so nothing rejects it before the bytes are decoded. `filter_map` never
+        // inspects Publish bytes, so this is exactly what reaches execution.
+        let err = runtime
+            .publish(&signer, payment, "halt-probe", &[0xFFu8; 64], &provenance)
+            .await
+            .expect_err("garbage bytes cannot publish");
+        assert!(
+            matches!(err, super::ExecutionError::Deterministic(_)),
+            "a malformed publish must be a RECORDED op failure; NonDeterministic \
+             propagates out of execute_block and every node exits at this height: {err:?}"
+        );
+    }
+
     /// A user contract that *links* fine but violates a Kontor WIT rule (here,
     /// no `init`) must still be rejected at publish — and DETERMINISTICALLY. This
     /// exercises the WIT-rule branch of `validate_publishable`, which the link

--- a/core/indexer/src/runtime/mod.rs
+++ b/core/indexer/src/runtime/mod.rs
@@ -246,6 +246,21 @@ pub struct Runtime {
     /// lite executor); production paths (reactor, runtime pool) set it from
     /// `config.network`.
     pub network: bitcoin::Network,
+    /// Set while `simulate` runs a fabricated block it is going to throw away.
+    ///
+    /// The savepoint undoes everything in the DATABASE, but the component cache
+    /// lives outside it and is keyed by `contracts.id` — a rowid the rollback
+    /// frees for reuse (`INTEGER PRIMARY KEY`, no `AUTOINCREMENT`). A `Publish`
+    /// inside a simulation would otherwise leave its compiled WASM cached under
+    /// an id a later real publish can be assigned, and `load_component` would
+    /// serve the simulated contract's code — on this node only, so it diverges
+    /// from the network.
+    ///
+    /// A flag rather than a compensating invalidate: the cache has one write
+    /// site, so not writing is one check that cannot be forgotten, where cleanup
+    /// is a fourth thing to remember in a function whose first two (`height`,
+    /// then this) were both missed.
+    pub simulating: bool,
 }
 
 impl Runtime {
@@ -325,6 +340,7 @@ impl Runtime {
             op_return_data: None,
             node_label: String::new(),
             network: bitcoin::Network::Regtest,
+            simulating: false,
         })
     }
 
@@ -912,9 +928,15 @@ impl Runtime {
     async fn component_bytes_and_compiled(&self, contract_id: u64) -> Result<(Vec<u8>, Component)> {
         let bytes = self.storage.component_bytes(contract_id).await?;
         let component = Component::from_binary(&self.engine, &bytes)?;
-        self.component_cache
-            .put(contract_id, component.clone(), bytes.len())
-            .await;
+        // The one write site, so the one place the simulation guard has to hold.
+        // See `Runtime::simulating`: caching a speculative contract's code under an
+        // id the rollback frees would let a later real publish be served the wrong
+        // WASM on this node alone.
+        if !self.simulating {
+            self.component_cache
+                .put(contract_id, component.clone(), bytes.len())
+                .await;
+        }
         Ok((bytes, component))
     }
 
@@ -947,6 +969,7 @@ impl HasData for Runtime {
 
 #[cfg(test)]
 mod tests {
+    use crate::database::native_contracts::FILESTORAGE;
     use crate::database::queries::exists_contract_state;
     use crate::runtime::token;
     use crate::runtime::wit::resources::ViewContext;
@@ -1316,6 +1339,61 @@ mod tests {
         assert!(
             runtime.component_cache.get(&reused_id).await.is_none(),
             "failed publish must evict the cached component for its rolled-back id"
+        );
+    }
+
+    /// A simulation must leave NOTHING in the component cache. The savepoint undoes
+    /// the database, but the cache lives outside it and is keyed by `contracts.id` —
+    /// a rowid the rollback frees for reuse. A component compiled while simulating
+    /// would then be served to whatever contract is later assigned that id, on this
+    /// node alone, which is a silent divergence from the rest of the network.
+    ///
+    /// SCOPE: this pins the guard at the cache's single write site, which both
+    /// routes into it funnel through — `load_component` for calls, and
+    /// `validate_publishable` for publishes. It does not drive a publish through the
+    /// reactor's `simulate`: the lite executor's transactions carry no ops, so the
+    /// cluster harness cannot express one.
+    #[tokio::test]
+    async fn simulation_does_not_populate_the_component_cache() {
+        let (mut runtime, _dir, _name) = test_runtime().await.expect("test runtime");
+        runtime
+            .set_context(
+                0,
+                Some(super::TransactionContext::builder().build()),
+                None,
+                None,
+            )
+            .await;
+
+        // A fresh id — the natives are prewarmed into the cache, so reusing one of
+        // theirs would make the first assertion pass without the guard.
+        let contract_id = runtime
+            .storage
+            .insert_contract("cache-probe", FILESTORAGE)
+            .await
+            .expect("insert contract");
+
+        runtime.simulating = true;
+        runtime
+            .load_component(contract_id)
+            .await
+            .expect("component still compiles while simulating");
+        assert!(
+            runtime.component_cache.get(&contract_id).await.is_none(),
+            "a component compiled during simulation must not be cached — the id it \
+             is keyed by is freed by the rollback and can be handed to a real publish"
+        );
+
+        // The guard must be scoped to simulation, not a blanket disable: caching is
+        // what keeps every later call off the compiler.
+        runtime.simulating = false;
+        runtime
+            .load_component(contract_id)
+            .await
+            .expect("component compiles normally");
+        assert!(
+            runtime.component_cache.get(&contract_id).await.is_some(),
+            "outside simulation the cache must still be populated"
         );
     }
 

--- a/core/indexer/src/runtime/mod.rs
+++ b/core/indexer/src/runtime/mod.rs
@@ -256,10 +256,11 @@ pub struct Runtime {
     /// serve the simulated contract's code — on this node only, so it diverges
     /// from the network.
     ///
-    /// A flag rather than a compensating invalidate: the cache has one write
-    /// site, so not writing is one check that cannot be forgotten, where cleanup
-    /// is a fourth thing to remember in a function whose first two (`height`,
-    /// then this) were both missed.
+    /// A flag rather than a compensating invalidate: the cache has TWO write
+    /// sites (`component_bytes_and_compiled` and `validate_publishable`), each
+    /// carrying its own `!simulating` guard, so not writing is one check per
+    /// site rather than a cleanup to remember in a function whose first two
+    /// hazards (`height`, then this) were both missed.
     pub simulating: bool,
 }
 
@@ -933,7 +934,8 @@ impl Runtime {
     async fn component_bytes_and_compiled(&self, contract_id: u64) -> Result<(Vec<u8>, Component)> {
         let bytes = self.storage.component_bytes(contract_id).await?;
         let component = Component::from_binary(&self.engine, &bytes)?;
-        // The one write site, so the one place the simulation guard has to hold.
+        // One of the cache's TWO write sites — `validate_publishable` guards the
+        // other, and its guard is the one the publish path depends on.
         // See `Runtime::simulating`: caching a speculative contract's code under an
         // id the rollback frees would let a later real publish be served the wrong
         // WASM on this node alone.

--- a/core/indexer/src/runtime/storage.rs
+++ b/core/indexer/src/runtime/storage.rs
@@ -664,6 +664,39 @@ mod tests {
     use crate::test_utils::{new_mock_block_hash, new_test_db};
     use indexer_types::BlockRow;
 
+    // The savepoint must cover plain `conn.execute` writes issued through a
+    // CLONE of the connection, not just those made through `Storage`.
+    //
+    // The reactor relies on this: `db_conn()` hands out a clone, and
+    // `handle_block` writes the decided-batch record through it inside the
+    // block's savepoint so a failed execution cannot leave a consensus record
+    // behind. That is a property of libsql's `BEGIN TRANSACTION` on a shared
+    // connection, invisible at the call site — pinned here so it fails loudly
+    // if the connection sharing ever changes.
+    #[tokio::test]
+    async fn savepoint_covers_writes_through_a_cloned_connection() -> Result<()> {
+        use crate::database::queries::{insert_batch, select_batch};
+
+        let (_reader, writer, _temp) = new_test_db().await?;
+        let conn = writer.connection();
+        let storage = Storage::builder().conn(conn.clone()).build();
+
+        storage.savepoint().await?;
+        insert_batch(&conn.clone(), 7, 100, "deadbeef", b"cert", true).await?;
+        assert!(
+            select_batch(&conn, 7).await?.is_some(),
+            "the write must be visible inside its own transaction"
+        );
+        storage.rollback().await?;
+
+        assert!(
+            select_batch(&conn, 7).await?.is_none(),
+            "rolling back the block transaction must discard the decision record too — \
+             otherwise a node keeps a consensus record for a height it never executed"
+        );
+        Ok(())
+    }
+
     // `block_entropy` returns a present block's hash only when the height is in the
     // recent window `[current - K, current]`: not future, not expired, and a row
     // exists. (K = BLOCK_ENTROPY_WINDOW = 144.)

--- a/core/indexer/src/runtime/storage.rs
+++ b/core/indexer/src/runtime/storage.rs
@@ -367,36 +367,15 @@ impl Storage {
         Ok(get_contract_bytes_by_id(&self.conn, contract_id).await?)
     }
 
+    /// Plain accessor for callers that do not need the failure CLASS — the
+    /// classification lives in [`decode_component_bytes`], which this delegates to
+    /// so the decompression-bomb cap has exactly one definition.
     pub async fn component_bytes(&self, contract_id: u64) -> Result<Vec<u8>> {
-        let compressed_bytes = self
-            .contract_bytes(contract_id)
-            .await?
-            .ok_or(anyhow!("Contract not found when trying to load component"))?;
-        let module_bytes = tokio::task::spawn_blocking(move || {
-            // Cap decompressed size: a tiny on-chain brotli blob can otherwise
-            // inflate without bound in memory on every node that loads the
-            // contract (decompression bomb). 64 MiB is far above any legitimate
-            // WASM component.
-            const MAX_DECOMPRESSED: u64 = 64 * 1024 * 1024;
-            let decompressor = brotli::Decompressor::new(&compressed_bytes[..], 4096);
-            let mut module_bytes = Vec::new();
-            decompressor
-                .take(MAX_DECOMPRESSED + 1)
-                .read_to_end(&mut module_bytes)?;
-            if module_bytes.len() as u64 > MAX_DECOMPRESSED {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "decompressed contract component exceeds maximum size",
-                ));
-            }
-            Ok::<_, std::io::Error>(module_bytes)
-        })
-        .await??;
-
-        ComponentEncoder::default()
-            .module(&module_bytes)?
-            .validate(true)
-            .encode()
+        self.decode_component_bytes(contract_id)
+            .await
+            .map_err(|e| match e {
+                ComponentDecodeError::Content(e) | ComponentDecodeError::Infrastructure(e) => e,
+            })
     }
 
     /// Decode stored contract bytes, keeping content failures distinguishable from
@@ -417,6 +396,10 @@ impl Storage {
         // Split the join from the work: a JoinError is this node's task machinery
         // failing, everything inside is a property of the bytes.
         let decompressed = tokio::task::spawn_blocking(move || {
+            // Cap decompressed size: a tiny on-chain brotli blob can otherwise
+            // inflate without bound in memory on every node that loads the
+            // contract (decompression bomb). 64 MiB is far above any legitimate
+            // WASM component.
             const MAX_DECOMPRESSED: u64 = 64 * 1024 * 1024;
             let decompressor = brotli::Decompressor::new(&compressed_bytes[..], 4096);
             let mut module_bytes = Vec::new();

--- a/core/indexer/src/runtime/storage.rs
+++ b/core/indexer/src/runtime/storage.rs
@@ -34,6 +34,18 @@ use crate::{
 /// Bounds the lookup and forces prompt resolution. ~1 day on Bitcoin (144 blocks).
 pub const BLOCK_ENTROPY_WINDOW: u64 = 144;
 
+/// Why decoding stored contract bytes failed.
+///
+/// The split is load-bearing, not cosmetic: `Content` is a pure function of the
+/// bytes, so every node reaches it identically and a publish carrying such bytes must
+/// be REJECTED deterministically. `Infrastructure` is this node failing to do the
+/// work, so it must propagate — recording it as a rejection would make one node
+/// refuse a publish its peers accept, which is the silent mirror of a chain halt.
+pub enum ComponentDecodeError {
+    Content(anyhow::Error),
+    Infrastructure(anyhow::Error),
+}
+
 /// Decode the WIT embedded in already-encoded component bytes, unmodified
 /// (`init`/core-context preserved) — for on-chain publish validation, where the
 /// validator must see the real surface. `component_wit` strips `init`/core-context
@@ -385,6 +397,48 @@ impl Storage {
             .module(&module_bytes)?
             .validate(true)
             .encode()
+    }
+
+    /// Decode stored contract bytes, keeping content failures distinguishable from
+    /// this node's own failures. See [`ComponentDecodeError`].
+    pub async fn decode_component_bytes(
+        &self,
+        contract_id: u64,
+    ) -> std::result::Result<Vec<u8>, ComponentDecodeError> {
+        let compressed_bytes = self
+            .contract_bytes(contract_id)
+            .await
+            .map_err(ComponentDecodeError::Infrastructure)?
+            .ok_or_else(|| {
+                ComponentDecodeError::Infrastructure(anyhow!(
+                    "Contract not found when trying to load component"
+                ))
+            })?;
+        // Split the join from the work: a JoinError is this node's task machinery
+        // failing, everything inside is a property of the bytes.
+        let decompressed = tokio::task::spawn_blocking(move || {
+            const MAX_DECOMPRESSED: u64 = 64 * 1024 * 1024;
+            let decompressor = brotli::Decompressor::new(&compressed_bytes[..], 4096);
+            let mut module_bytes = Vec::new();
+            decompressor
+                .take(MAX_DECOMPRESSED + 1)
+                .read_to_end(&mut module_bytes)?;
+            if module_bytes.len() as u64 > MAX_DECOMPRESSED {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "decompressed contract component exceeds maximum size",
+                ));
+            }
+            Ok::<_, std::io::Error>(module_bytes)
+        })
+        .await
+        .map_err(|e| ComponentDecodeError::Infrastructure(e.into()))?
+        .map_err(|e| ComponentDecodeError::Content(e.into()))?;
+
+        ComponentEncoder::default()
+            .module(&decompressed)
+            .and_then(|m| m.validate(true).encode())
+            .map_err(ComponentDecodeError::Content)
     }
 
     pub async fn component_wit(&self, contract_id: u64) -> Result<String> {

--- a/core/indexer/src/test_utils.rs
+++ b/core/indexer/src/test_utils.rs
@@ -318,6 +318,26 @@ pub fn new_mock_transaction(txid_num: u32) -> Transaction {
     }
 }
 
+/// A fresh directory and database name for a node, owned by the caller so the
+/// database can outlive the process that used it — which is what a restart needs.
+pub fn new_test_db_dir() -> Result<(TempDir, String)> {
+    let temp_dir = TempDir::new()?;
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)?
+        .as_nanos()
+        .to_string();
+    Ok((temp_dir, format!("test_db_{timestamp}.db")))
+}
+
+/// Reopen an EXISTING test database, as a restart would. `new_test_db` always
+/// creates a fresh directory, so it cannot express a node coming back up on the
+/// state it left behind — which is the whole shape of issue #515.
+pub async fn open_test_db(data_dir: &std::path::Path, db_name: &str) -> Result<(Reader, Writer)> {
+    let writer = Writer::new(data_dir, db_name).await?;
+    let reader = Reader::new(data_dir, db_name).await?;
+    Ok((reader, writer))
+}
+
 pub async fn new_test_db() -> Result<(Reader, Writer, (TempDir, String))> {
     let temp_dir = TempDir::new()?;
     let timestamp = SystemTime::now()

--- a/core/indexer/src/test_utils.rs
+++ b/core/indexer/src/test_utils.rs
@@ -339,15 +339,8 @@ pub async fn open_test_db(data_dir: &std::path::Path, db_name: &str) -> Result<(
 }
 
 pub async fn new_test_db() -> Result<(Reader, Writer, (TempDir, String))> {
-    let temp_dir = TempDir::new()?;
-    let timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)?
-        .as_nanos()
-        .to_string();
-    let db_name = format!("test_db_{}.db", timestamp);
-    let data_dir = temp_dir.path();
-    let writer = Writer::new(data_dir, &db_name).await?;
-    let reader = Reader::new(data_dir, &db_name).await?; // Assuming Reader::new exists
+    let (temp_dir, db_name) = new_test_db_dir()?;
+    let (reader, writer) = open_test_db(temp_dir.path(), &db_name).await?;
     Ok((reader, writer, (temp_dir, db_name)))
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches consensus finality, rollback/replay, and durable exclusion state — incorrect behavior can cause permanent node divergence or unsafe truncations below the prune window.
> 
> **Overview**
> Closes the #515 divergence where a restart or tip advance outside the consensus path dropped pending finality deadlines, so this node kept transactions peers had already rolled back.
> 
> **Finality is now durable and always checked.** Startup rehydrates `unfinalized_batches` from executed rows (not the immortal certified list), extending the floor to any still-unsettled batch. A new `advance()` funnel drains deferred decisions then settles deadlines whenever the tip rises — including via `BlockInsert` — so lagging nodes can no longer walk past verdicts.
> 
> **Exclusions are recorded per decision, not as a global ban.** A new `excluded_batch_txids` table stores missing txids keyed by consensus height; reads re-verify against the chain before applying. Replay merges survivors with the reload set, drops descendants positionally, and preserves the full decided txid list plus raw bodies so sync peers can still resolve excluded txs.
> 
> Also hardens related paths: block decisions and execution commit atomically; declined/undrained decisions leave a `batches` row; rollbacks clear confirmations by deleted blocks and refuse depths past the prune window; sync no longer gates raw-tx serving on the finality window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01086b70f699141974c4fd58f73aac18c7ffd6f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->