### PR TITLE
fix(daemon): exit non-zero on fatal subsystem errors, withdraw readiness on shutdown

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -3951,6 +3951,7 @@ dependencies = [
  "indexer-types",
  "indexmap 2.14.0",
  "kontor-crypto",
+ "libc",
  "libsql",
  "macros",
  "metrics",

--- a/core/indexer/Cargo.toml
+++ b/core/indexer/Cargo.toml
@@ -72,6 +72,9 @@ blst = { workspace = true }
 bls-crypto = { path = "../bls-crypto" }
 metrics = "=0.24.6"
 metrics-exporter-prometheus = "=0.18.3"
+# Only for sending SIGTERM to a child node in the regtest harness — tokio's
+# `Child` can only SIGKILL, which cannot exercise the graceful-shutdown path.
+libc = "=0.2.186"
 
 # Malachite BFT consensus
 malachitebft-app-channel = { workspace = true }

--- a/core/indexer/src/api/handlers/info.rs
+++ b/core/indexer/src/api/handlers/info.rs
@@ -87,6 +87,11 @@ pub struct NodeStatus {
     pub network: String,
     pub consensus_mode: ConsensusMode,
     pub reactor_ready: bool,
+    /// Whether the node is tearing down. `reactor_ready` alone cannot say —
+    /// it never un-sets — and this is the ungated endpoint an operator reaches
+    /// for first, so it must not read healthy on a dying node.
+    #[serde(default)]
+    pub shutting_down: bool,
     /// Resolved consensus listen multiaddr, or `null` until bound / for
     /// non-consensus nodes.
     pub consensus_listen_addr: Option<String>,
@@ -100,6 +105,7 @@ pub async fn get_status(State(env): State<Env>) -> Json<NodeStatus> {
         network: env.config.network.to_string(),
         consensus_mode: env.config.consensus_mode,
         reactor_ready: env.reactor_ready.load(Ordering::Relaxed),
+        shutting_down: env.cancel_token.is_cancelled(),
         consensus_listen_addr: env.consensus_listen_addr.borrow().clone(),
     })
 }
@@ -110,6 +116,8 @@ pub async fn get_status(State(env): State<Env>) -> Json<NodeStatus> {
 pub struct Healthz {
     pub ready: bool,
     pub reactor_ready: bool,
+    /// Set once the node is tearing down — see [`get_healthz_ready`].
+    pub shutting_down: bool,
     /// Highest indexed block, `null` until the first block lands.
     pub height: Option<u64>,
 }
@@ -123,12 +131,20 @@ pub async fn get_healthz_live() -> &'static str {
 
 /// `GET /healthz/ready` — readiness for traffic: the exact predicate the
 /// `require_available` middleware gates on (reactor started AND chain state
-/// exists), so a pod reads ready precisely when its chain endpoints stop
-/// answering 503 (#214).
+/// exists AND not shutting down), so a pod reads ready precisely when its chain
+/// endpoints stop answering 503 (#214).
+///
+/// `reactor_ready` is a latch: it is armed once at startup and never disarmed,
+/// so on its own it keeps reporting a node healthy long after its reactor has
+/// died. The cancellation token supplies what it cannot — the reactor's fatal
+/// path cancels it, and the event loop only ever exits on cancellation, so a
+/// cancelled token means the reactor is stopping or already stopped. Without
+/// this term a desynced node answers 200 and keeps taking traffic.
 pub async fn get_healthz_ready(State(env): State<Env>) -> (StatusCode, Json<Healthz>) {
     let reactor_ready = env.reactor_ready.load(Ordering::Relaxed);
+    let shutting_down = env.cancel_token.is_cancelled();
     let height = env.info_rx.borrow().height;
-    let ready = reactor_ready && height.is_some();
+    let ready = reactor_ready && !shutting_down && height.is_some();
     let code = if ready {
         StatusCode::OK
     } else {
@@ -139,6 +155,7 @@ pub async fn get_healthz_ready(State(env): State<Env>) -> (StatusCode, Json<Heal
         Json(Healthz {
             ready,
             reactor_ready,
+            shutting_down,
             height,
         }),
     )

--- a/core/indexer/src/api/handlers/info_tests.rs
+++ b/core/indexer/src/api/handlers/info_tests.rs
@@ -281,7 +281,10 @@ async fn require_available_mirrors_readiness_on_shutdown() -> Result<()> {
     ));
 
     // Available while healthy.
-    server.get("/api/blocks").await.assert_status(StatusCode::OK);
+    server
+        .get("/api/blocks")
+        .await
+        .assert_status(StatusCode::OK);
 
     cancel.cancel();
     server

--- a/core/indexer/src/api/handlers/info_tests.rs
+++ b/core/indexer/src/api/handlers/info_tests.rs
@@ -199,6 +199,7 @@ async fn healthz_ready_tracks_availability() -> Result<()> {
     env.info_rx = info_rx;
     let reactor_ready = env.reactor_ready.clone();
     reactor_ready.store(false, Ordering::Relaxed);
+    let cancel = env.cancel_token.clone();
     let app = Router::new()
         .route("/healthz/live", get(get_healthz_live))
         .route("/healthz/ready", get(get_healthz_ready))
@@ -225,6 +226,68 @@ async fn healthz_ready_tracks_availability() -> Result<()> {
     })?;
     let res = server.get("/healthz/ready").await;
     res.assert_status(StatusCode::OK);
+
+    // A subsystem dies and cancels the token: readiness must withdraw. The
+    // reactor latch stays set (it never un-sets) and the info snapshot keeps its
+    // last height, so without the shutdown term this node would keep reporting
+    // 200 while indexing nothing — which is exactly how a 20 h signet halt went
+    // unnoticed behind a green probe.
+    cancel.cancel();
+    let res = server.get("/healthz/ready").await;
+    res.assert_status(StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(
+        res.json::<serde_json::Value>()["shutting_down"],
+        serde_json::json!(true),
+        "the body must say why, not just fail"
+    );
+    assert_eq!(
+        res.json::<serde_json::Value>()["reactor_ready"],
+        serde_json::json!(true),
+        "the latch is still set — the shutdown term is what withdrew readiness"
+    );
+
+    // Liveness still answers: the process is up, it is just not serving traffic.
+    // Only a hung process should fail this probe.
+    server
+        .get("/healthz/live")
+        .await
+        .assert_status(StatusCode::OK);
+
+    Ok(())
+}
+
+/// `require_available` must withdraw availability on the same signal as
+/// `/healthz/ready`. The probe's only job is to predict this gate; if the two
+/// drift, orchestration routes traffic to a node that 503s everything.
+#[tokio::test]
+async fn require_available_mirrors_readiness_on_shutdown() -> Result<()> {
+    use std::sync::atomic::Ordering;
+
+    let (mut env, _conn, _dir) = new_test_env().await?;
+    let (info_tx, info_rx) = watch::channel(InfoCore::default());
+    env.info_rx = info_rx;
+    env.reactor_ready.store(true, Ordering::Relaxed);
+    let cancel = env.cancel_token.clone();
+    info_tx.send(InfoCore {
+        height: Some(1),
+        ..Default::default()
+    })?;
+
+    let server = TestServer::new(crate::api::router::new(
+        env,
+        metrics_exporter_prometheus::PrometheusBuilder::new()
+            .build_recorder()
+            .handle(),
+    ));
+
+    // Available while healthy.
+    server.get("/api/blocks").await.assert_status(StatusCode::OK);
+
+    cancel.cancel();
+    server
+        .get("/api/blocks")
+        .await
+        .assert_status(StatusCode::SERVICE_UNAVAILABLE);
 
     Ok(())
 }

--- a/core/indexer/src/api/mod.rs
+++ b/core/indexer/src/api/mod.rs
@@ -22,7 +22,11 @@ use tracing::{error, info};
 /// router and the handler both read this constant.
 pub const API_REQUEST_TIMEOUT_MS: u64 = 30_000;
 
-pub async fn run(env: Env, prom_handle: PrometheusHandle) -> Result<JoinHandle<()>> {
+pub async fn run(
+    env: Env,
+    prom_handle: PrometheusHandle,
+    fatal: crate::fatal::FatalSlot,
+) -> Result<JoinHandle<()>> {
     let addr = SocketAddr::from(([0, 0, 0, 0], env.config.api_port));
     let handle = Handle::new();
 
@@ -48,16 +52,23 @@ pub async fn run(env: Env, prom_handle: PrometheusHandle) -> Result<JoinHandle<(
         }
     });
 
+    let cancel_token = env.cancel_token.clone();
     let router = router::new(env, prom_handle);
 
     Ok(tokio::spawn(async move {
-        if axum_server::bind(addr)
+        // This resolves on a bind failure (port already taken) as well as on a
+        // serve error, and until now both only logged — leaving the node running
+        // headless, with no API and no probe endpoint answering, while `main`
+        // waited on tasks that would never finish. The probes are the only way an
+        // orchestrator sees inside this process, so losing them is fatal.
+        if let Err(e) = axum_server::bind(addr)
             .handle(handle)
             .serve(router.into_make_service_with_connect_info::<SocketAddr>())
             .await
-            .is_err()
         {
-            error!("HTTP server panicked on join");
+            error!("HTTP server failed on {addr}: {e}");
+            fatal.record_msg("http server", format!("failed on {addr}: {e}"));
+            cancel_token.cancel();
         }
         info!("HTTP server exited");
     }))

--- a/core/indexer/src/api/router.rs
+++ b/core/indexer/src/api/router.rs
@@ -77,21 +77,28 @@ impl<B> OnFailure<B> for NoOpOnFailure {
 }
 
 /// Tower middleware that 503s every `/api/*` request until the indexer
-/// is both (a) reactor-ready — `ready_rx` signaled, mempool sync done,
-/// `fees_rx` carrying a real estimate — and (b) holding chain state
-/// (`InfoCore.height.is_some()`). A warm-DB restart can pass (b) on
-/// startup (height seeded from disk by `compute_info_core`) before
-/// passing (a), so both must be checked; checking both *here* keeps
+/// is (a) reactor-ready — `ready_rx` signaled, mempool sync done,
+/// `fees_rx` carrying a real estimate — (b) holding chain state
+/// (`InfoCore.height.is_some()`), and (c) not shutting down. A warm-DB
+/// restart can pass (b) on startup (height seeded from disk by
+/// `compute_info_core`) before passing (a), so both must be checked;
+/// (a) is a latch that never un-sets, so only (c) can withdraw
+/// availability once a subsystem dies. Checking all three *here* keeps
 /// the decision single-point — handlers downstream of the gate can
 /// trust the snapshot and don't re-decide.
+///
+/// Must stay identical to `get_healthz_ready`: the probe's whole purpose
+/// is to predict this gate, and a node whose readiness probe disagrees
+/// with its own 503s is worse than one with no probe at all.
 async fn require_available(
     State(env): State<Env>,
     req: AxumRequest,
     next: Next,
 ) -> std::result::Result<axum::response::Response, super::error::Error> {
     let reactor_ready = env.reactor_ready.load(std::sync::atomic::Ordering::Relaxed);
+    let shutting_down = env.cancel_token.is_cancelled();
     let has_chain_state = env.info_rx.borrow().height.is_some();
-    if !reactor_ready || !has_chain_state {
+    if !reactor_ready || shutting_down || !has_chain_state {
         return Err(HttpError::ServiceUnavailable("Indexer is not available".to_string()).into());
     }
     Ok(next.run(req).await)

--- a/core/indexer/src/bitcoin_follower/mod.rs
+++ b/core/indexer/src/bitcoin_follower/mod.rs
@@ -8,7 +8,9 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 use tracing::error;
 
-use crate::{bitcoin_client::client::BitcoinRpc, block::TransactionFilterMap};
+use crate::{
+    bitcoin_client::client::BitcoinRpc, block::TransactionFilterMap, fatal::FatalSlot,
+};
 
 use self::{
     event::{BlockEvent, MempoolEvent},
@@ -28,6 +30,7 @@ pub async fn run<C: BitcoinRpc>(
     starting_block_height: u64,
     known_hashes: Vec<(u64, BlockHash)>,
     zmq_address: String,
+    fatal: FatalSlot,
 ) -> (
     mpsc::Receiver<BlockEvent>,
     mpsc::Receiver<MempoolEvent>,
@@ -68,23 +71,36 @@ pub async fn run<C: BitcoinRpc>(
             ListenerConfig::new(zmq_address),
         ));
 
+        // Whichever task exits first takes the whole node down with it — neither
+        // is optional. `Ok(Ok(()))` is only legitimate as a response to
+        // cancellation; reached any other way it means a task quietly stopped
+        // feeding the reactor, which used to be silent (the old catch-all arm
+        // logged nothing at all) and is just as fatal as an error.
+        macro_rules! subsystem_exit {
+            ($name:literal, $result:expr) => {{
+                match $result {
+                    Ok(Err(e)) => {
+                        error!("{} error: {:#}", $name, e);
+                        fatal.record($name, &e);
+                    }
+                    Err(e) => {
+                        error!("{} task panicked: {}", $name, e);
+                        fatal.record_msg($name, format!("task panicked: {e}"));
+                    }
+                    Ok(Ok(())) => {
+                        if !cancel_token.is_cancelled() {
+                            error!("{} exited without being cancelled", $name);
+                            fatal.record_msg($name, "exited without being cancelled");
+                        }
+                    }
+                }
+                cancel_token.cancel();
+            }};
+        }
+
         select! {
-            r = poller_handle => {
-                match r {
-                    Ok(Err(e)) => error!("Poller error: {:#}", e),
-                    Err(e) => error!("Poller task panicked: {}", e),
-                    _ => {}
-                }
-                cancel_token.cancel();
-            }
-            r = listener_handle => {
-                match r {
-                    Ok(Err(e)) => error!("Listener error: {:#}", e),
-                    Err(e) => error!("Listener task panicked: {}", e),
-                    _ => {}
-                }
-                cancel_token.cancel();
-            }
+            r = poller_handle => subsystem_exit!("bitcoin poller", r),
+            r = listener_handle => subsystem_exit!("bitcoin listener", r),
         }
     });
 

--- a/core/indexer/src/bitcoin_follower/mod.rs
+++ b/core/indexer/src/bitcoin_follower/mod.rs
@@ -8,9 +8,7 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 use tracing::error;
 
-use crate::{
-    bitcoin_client::client::BitcoinRpc, block::TransactionFilterMap, fatal::FatalSlot,
-};
+use crate::{bitcoin_client::client::BitcoinRpc, block::TransactionFilterMap, fatal::FatalSlot};
 
 use self::{
     event::{BlockEvent, MempoolEvent},

--- a/core/indexer/src/fatal.rs
+++ b/core/indexer/src/fatal.rs
@@ -63,10 +63,7 @@ mod tests {
         let fatal = FatalSlot::new();
         fatal.record_msg("reactor", "the cause");
         fatal.record_msg("bitcoin poller", "a consequence");
-        fatal.record(
-            "http server",
-            &anyhow::anyhow!("another consequence"),
-        );
+        fatal.record("http server", &anyhow::anyhow!("another consequence"));
         assert_eq!(fatal.take().as_deref(), Some("reactor: the cause"));
     }
 

--- a/core/indexer/src/fatal.rs
+++ b/core/indexer/src/fatal.rs
@@ -1,0 +1,97 @@
+//! Why the process is shutting down.
+//!
+//! `CancellationToken` is the shutdown bus, but it is a bare "stop" signal: a
+//! SIGTERM and a dead reactor look identical at the token, and every subsystem
+//! hands `main` a `JoinHandle<()>` that cannot carry a failure either. So a
+//! fatal error was logged, the token was cancelled, and `main` returned
+//! `Ok(())` — exit status 0. Kubernetes read that as `Completed`, restarted the
+//! pod, and never entered `CrashLoopBackOff`; on signet a validator crash-looped
+//! 121 times over 20 h while `kubectl get pods` showed `1/1 Running` throughout.
+//!
+//! This slot carries the missing bit. Every fatal path records here next to its
+//! `cancel()`; the signal path records nothing. `main` reads it once after all
+//! tasks join and exits non-zero if it is set.
+
+use std::sync::{Arc, Mutex};
+
+/// The first fatal subsystem error of the process, if any.
+///
+/// Cloneable and cheap — every subsystem holds the same slot.
+#[derive(Clone, Default)]
+pub struct FatalSlot(Arc<Mutex<Option<String>>>);
+
+impl FatalSlot {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a fatal error, keeping the FIRST one.
+    ///
+    /// Cancellation propagates, so one real failure typically produces a burst
+    /// of consequential ones — channels closing, tasks unwinding. The first
+    /// writer is the cause; the rest are its wake. Reporting the cause is what
+    /// makes the exit message actionable.
+    pub fn record(&self, source: &str, err: &anyhow::Error) {
+        self.record_msg(source, format!("{err:#}"));
+    }
+
+    /// Record a fatal condition that is not an `anyhow::Error` — a panic, or a
+    /// task that ended when it should not have.
+    pub fn record_msg(&self, source: &str, msg: impl Into<String>) {
+        // A poisoned lock means another thread panicked while holding it; the
+        // stored value is a `String` and cannot be left inconsistent, so
+        // recovering is strictly better than panicking inside a panic hook.
+        let mut slot = self.0.lock().unwrap_or_else(|e| e.into_inner());
+        if slot.is_none() {
+            *slot = Some(format!("{source}: {}", msg.into()));
+        }
+    }
+
+    /// Take the recorded cause, if any. Called once, by `main`, after every
+    /// task has joined.
+    pub fn take(&self) -> Option<String> {
+        self.0.lock().unwrap_or_else(|e| e.into_inner()).take()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_writer_wins() {
+        let fatal = FatalSlot::new();
+        fatal.record_msg("reactor", "the cause");
+        fatal.record_msg("bitcoin poller", "a consequence");
+        fatal.record(
+            "http server",
+            &anyhow::anyhow!("another consequence"),
+        );
+        assert_eq!(fatal.take().as_deref(), Some("reactor: the cause"));
+    }
+
+    #[test]
+    fn empty_slot_takes_none() {
+        // The signal path records nothing — this is the exit-0 case.
+        assert_eq!(FatalSlot::new().take(), None);
+    }
+
+    #[test]
+    fn take_empties_the_slot() {
+        let fatal = FatalSlot::new();
+        fatal.record_msg("reactor", "boom");
+        assert!(fatal.take().is_some());
+        assert_eq!(fatal.take(), None);
+    }
+
+    #[test]
+    fn record_flattens_the_error_chain() {
+        let err = anyhow::anyhow!("root cause").context("outer context");
+        let fatal = FatalSlot::new();
+        fatal.record("reactor", &err);
+        let msg = fatal.take().unwrap();
+        assert!(msg.starts_with("reactor: "), "{msg}");
+        assert!(msg.contains("outer context"), "{msg}");
+        assert!(msg.contains("root cause"), "{msg}");
+    }
+}

--- a/core/indexer/src/lib.rs
+++ b/core/indexer/src/lib.rs
@@ -8,6 +8,7 @@ pub mod config;
 pub mod consensus;
 pub mod database;
 pub mod event;
+pub mod fatal;
 pub mod info;
 pub mod keygen;
 pub mod legacy_test_utils;

--- a/core/indexer/src/main.rs
+++ b/core/indexer/src/main.rs
@@ -393,6 +393,9 @@ mod tests {
         let err = exit_result(&fatal).expect_err("a recorded fatal must fail the process");
         let msg = format!("{err:#}");
         assert!(msg.contains("reactor"), "{msg}");
-        assert!(msg.contains("316333"), "the cause must reach the operator: {msg}");
+        assert!(
+            msg.contains("316333"),
+            "the cause must reach the operator: {msg}"
+        );
     }
 }

--- a/core/indexer/src/main.rs
+++ b/core/indexer/src/main.rs
@@ -8,6 +8,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use indexer::database::queries::select_recent_blocks;
 use indexer::event::EventSubscriber;
+use indexer::fatal::FatalSlot;
 use indexer::info::{compute_info_core, run_info_publisher};
 use indexer::keygen::{self, KeygenArgs};
 use indexer::{api, block, built_info, reactor, reg_tester, runtime};
@@ -188,7 +189,10 @@ async fn run_daemon(config: Config) -> Result<()> {
     }
     let bitcoin = bitcoin_client::Client::new_from_config(&config)?;
     let cancel_token = CancellationToken::new();
+    // Why we are stopping. Cancellation alone cannot say — see `fatal`.
+    let fatal = FatalSlot::new();
     let panic_token = cancel_token.clone();
+    let panic_fatal = fatal.clone();
     panic::set_hook(Box::new(move |info| {
         let message = info
             .payload()
@@ -201,6 +205,7 @@ async fn run_daemon(config: Config) -> Result<()> {
             .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
             .unwrap_or_else(|| "unknown location".to_string());
         error!(target: "panic", "Panic at {}: {}", location, message);
+        panic_fatal.record_msg("panic", format!("at {location}: {message}"));
         panic_token.cancel();
     }));
     let mut handles = vec![];
@@ -252,6 +257,7 @@ async fn run_daemon(config: Config) -> Result<()> {
                 info_rx,
             },
             prom_handle.clone(),
+            fatal.clone(),
         )
         .await?,
     );
@@ -272,6 +278,7 @@ async fn run_daemon(config: Config) -> Result<()> {
         config.starting_block_height,
         known_hashes,
         config.zmq_address.clone(),
+        fatal.clone(),
     )
     .await;
     handles.push(follower_handle);
@@ -318,6 +325,7 @@ async fn run_daemon(config: Config) -> Result<()> {
             enabled: config.prune,
             retain_blocks: config.prune_retain_blocks,
         },
+        fatal.clone(),
     ));
     ready_rx.await?;
     reactor_ready.store(true, std::sync::atomic::Ordering::Relaxed);
@@ -325,8 +333,25 @@ async fn run_daemon(config: Config) -> Result<()> {
     for handle in handles {
         let _ = handle.await;
     }
-    info!("Exited");
-    Ok(())
+    exit_result(&fatal)
+}
+
+/// Turn "why did we stop" into a process exit status.
+///
+/// A signal-driven shutdown records nothing and exits 0; a subsystem that died
+/// exits non-zero, so an orchestrator sees a failure instead of `Completed` and
+/// backs off instead of restarting into the same fault forever.
+fn exit_result(fatal: &FatalSlot) -> Result<()> {
+    match fatal.take() {
+        Some(cause) => {
+            error!("Exited: {cause}");
+            anyhow::bail!("fatal: {cause}")
+        }
+        None => {
+            info!("Exited");
+            Ok(())
+        }
+    }
 }
 
 fn load_genesis_validators(config: &Config) -> Result<Vec<runtime::GenesisValidator>> {
@@ -345,4 +370,29 @@ fn load_genesis_validators(config: &Config) -> Result<Vec<runtime::GenesisValida
             })
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A signal-driven shutdown records nothing, so the daemon exits 0 and the
+    /// orchestrator treats the stop as intentional.
+    #[test]
+    fn clean_shutdown_exits_zero() {
+        assert!(exit_result(&FatalSlot::new()).is_ok());
+    }
+
+    /// A recorded fatal error must surface as an `Err`, which `#[tokio::main]`
+    /// turns into a non-zero exit status. Without this the reactor could die and
+    /// the process would still report `Completed`.
+    #[test]
+    fn fatal_error_exits_non_zero() {
+        let fatal = FatalSlot::new();
+        fatal.record_msg("reactor", "Unexpected block height 316333, expected 316206");
+        let err = exit_result(&fatal).expect_err("a recorded fatal must fail the process");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("reactor"), "{msg}");
+        assert!(msg.contains("316333"), "the cause must reach the operator: {msg}");
+    }
 }

--- a/core/indexer/src/metrics.rs
+++ b/core/indexer/src/metrics.rs
@@ -10,3 +10,18 @@
 pub const BLOCK_HEIGHT: &str = "index_current_block_height";
 pub const CONSENSUS_HEIGHT: &str = "index_current_consensus_height";
 pub const ITEMS_INDEXED: &str = "items_indexed_total";
+
+/// Bitcoin blocks buffered but not yet executed. Bounded by
+/// `MAX_PENDING_BLOCKS`; sitting at that ceiling means the reactor has stopped
+/// consuming the poller.
+pub const PENDING_BLOCKS: &str = "index_pending_blocks";
+
+/// Decided values waiting on data before they can execute. Healthy nodes idle
+/// near zero and drain within a block. A queue that only grows is a node whose
+/// consensus height is advancing while its execution is not — it is on the
+/// chain but no longer of it, and no amount of waiting recovers it.
+///
+/// Together with `BLOCK_HEIGHT` and `CONSENSUS_HEIGHT` this is the alert that
+/// would have caught the 2026-08 signet halt in minutes: consensus climbing
+/// while the block height stays flat.
+pub const DEFERRED_DECISIONS: &str = "index_deferred_decisions";

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -36,8 +36,8 @@ use metrics::gauge;
 use tracing::{debug, error, info, warn};
 
 use crate::consensus::finality_types::{FINALITY_WINDOW, StateEvent};
-use crate::metrics::{DEFERRED_DECISIONS, PENDING_BLOCKS};
 use crate::consensus::{BatchTx, Ctx};
+use crate::metrics::{DEFERRED_DECISIONS, PENDING_BLOCKS};
 use crate::{
     bitcoin_follower::event::{BlockEvent, MempoolEvent},
     consensus::{Genesis, Validator, ValidatorSet, signing::PublicKey},

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -32,9 +32,11 @@ use malachitebft_app_channel::NetworkMsg;
 use malachitebft_app_channel::app::types::LocallyProposedValue;
 use malachitebft_app_channel::app::types::core::VotingPower;
 use malachitebft_core_types::{LinearTimeouts, Round};
+use metrics::gauge;
 use tracing::{debug, error, info, warn};
 
 use crate::consensus::finality_types::{FINALITY_WINDOW, StateEvent};
+use crate::metrics::{DEFERRED_DECISIONS, PENDING_BLOCKS};
 use crate::consensus::{BatchTx, Ctx};
 use crate::{
     bitcoin_follower::event::{BlockEvent, MempoolEvent},
@@ -334,6 +336,14 @@ impl<E: Executor> Reactor<E> {
                     Err(_) => break,
                 }
             }
+
+            // Publish the backlog gauges from the one point every state change
+            // passes through, rather than from each mutation site. Both queues
+            // matter most exactly when nothing is happening — a wedged node
+            // executes no blocks and decides no batches, so a gauge hung off
+            // either of those paths would go stale precisely when it is needed.
+            gauge!(PENDING_BLOCKS).set(self.consensus.pending_blocks.len() as f64);
+            gauge!(DEFERRED_DECISIONS).set(self.consensus.deferred_decisions.len() as f64);
 
             let hard_deadline_instant = self.consensus.pending_proposal.as_ref().map(|p| {
                 let deadline = p.hard_deadline();
@@ -757,6 +767,7 @@ pub fn run(
     consensus_listen_addr: tokio::sync::watch::Sender<Option<String>>,
     network: bitcoin::Network,
     prune: PruneConfig,
+    fatal: crate::fatal::FatalSlot,
 ) -> JoinHandle<()> {
     tokio::spawn({
         async move {
@@ -904,6 +915,10 @@ pub fn run(
 
             if let Err(e) = result {
                 error!("Reactor error: {e:#}, exiting");
+                // Record BEFORE cancelling: cancellation is what tears the other
+                // subsystems down, and whatever they report afterwards is a
+                // consequence of this error, not a separate failure.
+                fatal.record("reactor", &e);
                 cancel_token.cancel();
             }
 

--- a/core/indexer/src/reg_tester.rs
+++ b/core/indexer/src/reg_tester.rs
@@ -1482,6 +1482,35 @@ impl RegTesterCluster {
             .client
     }
 
+    /// Stop a node the way an orchestrator does — SIGTERM — and hand back its
+    /// exit status.
+    ///
+    /// [`Self::kill_node`] sends SIGKILL to simulate a crash; this is the
+    /// graceful path, and its exit status is the only thing a deployment has to
+    /// tell "asked to stop" from "died on its own". A node that exits 0 either
+    /// way is a node whose failures are invisible to Kubernetes, which reads
+    /// status 0 as `Completed`, restarts the pod, and never raises
+    /// `CrashLoopBackOff`.
+    pub async fn stop_node_gracefully(&mut self, index: usize) -> Result<std::process::ExitStatus> {
+        let nc = &mut self.node_configs[index];
+        let node = nc
+            .running
+            .as_mut()
+            .ok_or(anyhow!("Node {index} not running"))?;
+        let pid = node.child.id().ok_or(anyhow!("Node {index} already reaped"))?;
+        // SAFETY: `kill(2)` with a pid this process owns and has not yet reaped
+        // (the `id()` above is `None` after reaping) and a valid signal number.
+        if unsafe { libc::kill(pid as i32, libc::SIGTERM) } != 0 {
+            bail!(
+                "SIGTERM to node {index} (pid {pid}) failed: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+        let status = node.child.wait().await?;
+        nc.running = None;
+        Ok(status)
+    }
+
     /// Kill a node's process.
     pub async fn kill_node(&mut self, index: usize) -> Result<()> {
         let nc = &mut self.node_configs[index];

--- a/core/indexer/src/reg_tester.rs
+++ b/core/indexer/src/reg_tester.rs
@@ -1497,7 +1497,10 @@ impl RegTesterCluster {
             .running
             .as_mut()
             .ok_or(anyhow!("Node {index} not running"))?;
-        let pid = node.child.id().ok_or(anyhow!("Node {index} already reaped"))?;
+        let pid = node
+            .child
+            .id()
+            .ok_or(anyhow!("Node {index} already reaped"))?;
         // SAFETY: `kill(2)` with a pid this process owns and has not yet reaped
         // (the `id()` above is `None` after reaping) and a valid signal number.
         if unsafe { libc::kill(pid as i32, libc::SIGTERM) } != 0 {

--- a/core/indexer/tests/contracts/regtester_cluster.rs
+++ b/core/indexer/tests/contracts/regtester_cluster.rs
@@ -212,6 +212,19 @@ async fn cluster_consensus_lifecycle() -> Result<()> {
         .await?;
     cluster.assert_checkpoints_match().await?;
 
+    // A healthy node asked to stop must exit 0 — the other half of "fatal errors
+    // exit non-zero". Reporting failure on every shutdown would be as useless as
+    // reporting success on every one: an orchestrator that sees a restart loop
+    // on ordinary rollouts learns to ignore the signal. This is the regression a
+    // careless fatal-slot wiring introduces, and the cluster is already up here,
+    // so it costs one signal.
+    let status = cluster.stop_node_gracefully(3).await?;
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "SIGTERM on a healthy node must exit 0, got {status:?}"
+    );
+
     cluster.teardown().await?;
     Ok(())
 }


### PR DESCRIPTION
## Why

Signet consensus halted for ~20 h on 2026-08-04/05 and nobody was paged. The proximate cause was a validator crash-looping in the reactor, but the reason it went unnoticed for 20 h is here: **a fatal reactor error exits the process with status 0.**

```
ERROR Reactor error: ... exiting
INFO  Initiating shutdown
INFO  Exited
```
→ container exit code `0`, Kubernetes `Reason: Completed`, pod restarted normally, never `CrashLoopBackOff`. `kubectl get pods` showed `1/1 Running` across 121 restarts. Because that validator held the third of three usable votes in a 3/4 quorum, each restart bought exactly one decided height before dying again.

The error was logged and the cancellation token cancelled, but nothing propagated: every subsystem hands `main` a `JoinHandle<()>` that cannot carry a failure, and the join loop discarded results anyway (`let _ = handle.await`), so `run_daemon` returned `Ok(())`. There is no `process::exit` or `ExitCode` anywhere in the binary. A fatal error and a clean SIGTERM are identical at the process level.

This PR fixes that, and the readiness blind spot that let the same node keep serving 200s. **It does not fix the reactor defect that caused the crash loop** — that is a separate change, on top of #518, which rewrites the same code paths.

## What

**`FatalSlot` (`src/fatal.rs`).** `CancellationToken` is the shutdown bus but carries no reason. Every fatal path now records into a shared slot next to its `cancel()`; the signal path records nothing. `main` reads it once after all tasks join and returns `Err`, which `#[tokio::main]` maps to a non-zero exit. First writer wins — one real failure produces a burst of consequential ones as channels close behind the cancel, and the first is the cause.

Chose a shared slot over `JoinHandle<Result<()>>`: only `main.rs` calls `reactor::run`, `bitcoin_follower::run` and `api::run`, so it is three signatures, against a conversion that would touch every spawner (`stopper`, `run_info_publisher`, `event_subscriber`, the follower's two nested spawns) and the join loop's semantics.

**Two adjacent silent failures found while wiring it up:**

- The Bitcoin follower's supervisor had a catch-all `_ => {}` arm that cancelled the whole node on a *clean* poller or listener exit **without logging anything at all**. A task that stops feeding the reactor is as fatal as one that errors; it is only legitimate as a response to cancellation, which the new arm checks.
- An API bind failure (port already taken) only logged `"HTTP server panicked on join"` — a misleading message for a bind error — and **never cancelled**, leaving the node running headless with no API and no probe endpoint while `main` waited forever on tasks that had already given up.

**Readiness.** `reactor_ready` is a latch: armed once at startup, never disarmed. So `/healthz/ready` and `require_available` kept reporting healthy after the reactor died — on signet the desynced node answered `200` with `height: 316205` while the network was at `316333`. Both predicates now also require a live cancellation token; the reactor's fatal path cancels it and the event loop only exits on cancellation, so a cancelled token means the reactor is stopping or stopped. `/healthz/live` still answers 200 — the process is up, it just is not serving; only a hung process should fail liveness. `Healthz` and `NodeStatus` expose `shutting_down` so an operator reading probe output sees *why*.

**Gauges.** `index_pending_blocks` and `index_deferred_decisions`, published from the reactor's event loop rather than from either queue's mutation sites — both matter most when nothing is happening, and a gauge hung off the block or batch path goes stale precisely when it is needed. With the existing height gauges, *"consensus height climbing while block height stays flat"* becomes a dashboard rule that catches this class of halt in minutes rather than hours.

## Not in scope

Readiness that detects divergence from the network's decided height. The node knows both numbers but in different units; the useful signal is `pending_blocks.last_key() - last_height` and `deferred_decisions.len()`, which needs a `watch<ReactorHealth>` from the reactor to `Env` plus a staleness clock and a real threshold decision (should a legitimately-syncing node fail readiness?). The two gauges cover most of the value at no risk.

## Tests

- Readiness withdraws on cancellation while liveness holds, and the body says `shutting_down: true` with the latch still set — proving it is the new term that withdrew readiness.
- `require_available` mirrors it, so the probe and the gate it predicts cannot drift.
- **SIGTERM on a healthy cluster node still exits 0.** This is the regression a careless wiring introduces, and it matters: reporting failure on every shutdown would make the signal as useless as reporting success on every one. Added `stop_node_gracefully` to the regtest cluster (`kill_node` sends SIGKILL and cannot exercise this path) and asserted it at the end of an existing test, where the cluster is already up.
- `FatalSlot` first-writer-wins, error-chain flattening, and the exit-status mapping.

`cargo test -p indexer --lib` (383 passed), `cargo clippy -p indexer --all-targets` clean, `cargo check --workspace --all-targets` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes process exit codes, Kubernetes probe semantics, and the API availability gate—operational paths that directly affect paging, restarts, and traffic routing after failures.
> 
> **Overview**
> Fatal subsystem failures no longer exit the process with status **0**. A shared **`FatalSlot`** records the first fatal cause (reactor, HTTP server, Bitcoin follower, panic); **`main`** maps that to a non-zero exit after tasks join, while clean SIGTERM still exits **0**.
> 
> **Readiness and traffic gating** now treat a cancelled shutdown token like “not available”: **`/healthz/ready`**, **`require_available`**, and **`GET /api/status`** expose **`shutting_down`** and fail readiness when the reactor is tearing down—even if **`reactor_ready`** and last **`height`** still look healthy.
> 
> Adjacent wiring fixes: HTTP **bind/serve errors** are fatal and cancel shutdown; the Bitcoin follower supervisor **logs and records** poller/listener exits (including previously silent clean exits); reactor publishes **`index_pending_blocks`** and **`index_deferred_decisions`** gauges from the event loop. Regtest gains **`stop_node_gracefully`** (SIGTERM) and asserts healthy nodes still exit **0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06883f20958e4324e765e905563a06fb98c5ffa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->