### PR TITLE
fix(consensus): never execute a decided block out of order, and make its record atomic

### DIFF
--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -2,7 +2,7 @@ use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
 use std::time::Instant;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use bitcoin::hashes::Hash;
 use bitcoin::{BlockHash, Txid};
 use indexer_types::Event;
@@ -11,7 +11,7 @@ use malachitebft_core_types::{Round, Validity};
 use malachitebft_engine::host::Next;
 use metrics::{counter, gauge};
 use prost::Message;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::consensus::codec::encode_commit_certificate;
 use crate::consensus::finality_types::{DecidedBatch, StateEvent, UnfinalizedBatch, deadline_for};
@@ -22,10 +22,10 @@ use crate::database::queries::{
 };
 use crate::metrics::{CONSENSUS_HEIGHT, ITEMS_INDEXED};
 
-use super::Reactor;
 use super::consensus_state;
 use super::executor::Executor;
 use super::mempool_fee_index::MempoolFeeIndex;
+use super::{MAX_DEFERRED_DECISIONS, Reactor};
 
 /// Multiplier applied to `MempoolFeeIndex::fastest_fee()` to derive the
 /// per-batch acceptance threshold, as an integer ratio: 9/10 means we accept
@@ -644,6 +644,19 @@ impl<E: Executor> Reactor<E> {
         let value = match data {
             ProposalData::Block { height: bh, hash } => {
                 if let Some(block) = self.consensus.pending_blocks.get(bh) {
+                    // Deliberately NOT gated on `bh == last_height + 1`.
+                    //
+                    // Tempting, since a node behind on execution votes here for a
+                    // block it cannot yet apply. But a `Value::Block` asserts only
+                    // "this is the canonical Bitcoin block at this height", which
+                    // this node can confirm from its own buffer; when to run it is
+                    // a local ordering matter, settled by `handle_finalized` and
+                    // the deferred queue. Withholding the vote would trade a stuck
+                    // node for a stalled chain: at 3-of-4 quorum with one
+                    // validator already down, one nil vote is the difference
+                    // between the network advancing and halting — which is the
+                    // failure this whole change exists to prevent, reintroduced
+                    // from the other side.
                     if block.hash != *hash {
                         warn!(
                             block_height = bh,
@@ -654,10 +667,34 @@ impl<E: Executor> Reactor<E> {
                         return Ok(None);
                     }
                 } else {
-                    warn!(
-                        block_height = bh,
-                        "Rejecting block proposal: block not yet received"
-                    );
+                    // "Not yet received" and "already processed" are opposite
+                    // conditions with opposite remedies — one resolves itself
+                    // when the poller catches up, the other never does — and
+                    // they were indistinguishable in the logs. Naming them costs
+                    // one lookup on a path that is already rejecting.
+                    match select_block_at_height(&conn, *bh).await {
+                        Ok(Some(row)) if row.hash == *hash => warn!(
+                            block_height = bh,
+                            %hash,
+                            last_height,
+                            "Rejecting block proposal: height already processed"
+                        ),
+                        Ok(Some(row)) => warn!(
+                            block_height = bh,
+                            proposed = %hash,
+                            executed = %row.hash,
+                            "Rejecting block proposal: height processed with a different hash (reorg)"
+                        ),
+                        Ok(None) => warn!(
+                            block_height = bh,
+                            last_height, "Rejecting block proposal: block not yet received"
+                        ),
+                        Err(e) => warn!(
+                            error = %e,
+                            block_height = bh,
+                            "Rejecting block proposal: block lookup failed"
+                        ),
+                    }
                     return Ok(None);
                 }
                 Value::new_block(*bh, *hash)
@@ -1025,6 +1062,67 @@ impl<E: Executor> Reactor<E> {
                 } => {
                     let bh = *bh;
                     let decided_hash = *decided_hash;
+
+                    // Gate on the tip BEFORE touching `pending_blocks`. A block
+                    // can only execute at exactly `last_height + 1`; handing
+                    // `handle_block` anything else trips its height guard, which
+                    // is fatal to the reactor. Holding the block buffered is not
+                    // permission to run it — a node whose execution has fallen
+                    // behind caches the whole window from its tip to the
+                    // network's, so the buffer hit says nothing about ordering.
+                    if bh <= self.last_height {
+                        // Terminal, never parked: the height is already executed
+                        // (a re-decide after a rollback, or a sync replaying
+                        // both) or was reorged away. Parking a decision that
+                        // nothing can ever satisfy wedges the drain forever.
+                        // Reachable with the block still buffered, too — the
+                        // finality path deliberately keeps `pending_blocks`
+                        // across a rollback and re-execution.
+                        match select_block_at_height(&self.db_conn(), bh).await {
+                            Ok(row) => {
+                                warn!(
+                                    block_height = bh,
+                                    decided = %decided_hash,
+                                    executed = ?row.map(|r| r.hash),
+                                    last_height = self.last_height,
+                                    consensus_height = %decision.consensus_height,
+                                    "Dropping deferred block decision — at or below tip"
+                                );
+                                // Dropped is not unrecorded. `batches` is the only
+                                // copy of the decided sequence — Malachite asks us
+                                // for decided values rather than keeping them — and
+                                // the startup cleanup trims an unexecuted SUFFIX,
+                                // never a hole in the middle. A height that leaves
+                                // no row can never be served to a syncing peer.
+                                self.record_declined_block(&decision, bh, decided_hash)
+                                    .await;
+                                continue;
+                            }
+                            Err(e) => {
+                                warn!(error = %e, block_height = bh, "Block lookup failed during drain; parking decision");
+                                self.consensus.deferred_decisions.push_front(decision);
+                                break;
+                            }
+                        }
+                    }
+                    if bh > self.last_height + 1 {
+                        // The predecessors were decided by the network but never
+                        // reached this node's executor. Nothing here can close
+                        // that gap — the missed heights will not be re-decided —
+                        // so park and stay loud: this node needs a re-sync, and
+                        // the alternative (executing out of order) is fatal.
+                        error!(
+                            block_height = bh,
+                            last_height = self.last_height,
+                            gap = bh - self.last_height,
+                            consensus_height = %decision.consensus_height,
+                            "Deferred block decision is ahead of the tip — this node cannot \
+                             catch up on its own and needs a re-sync"
+                        );
+                        self.consensus.deferred_decisions.push_front(decision);
+                        break;
+                    }
+
                     let block = {
                         let cs = &mut self.consensus;
                         cs.pending_blocks.remove(&bh)
@@ -1060,33 +1158,11 @@ impl<E: Executor> Reactor<E> {
                         // The tip moved — anything held may now be ready.
                         restore_waiting(&mut self.consensus.deferred_decisions, &mut waiting);
                     } else {
-                        // No pending block at this height. Before parking the
-                        // queue on it, check whether the height was already
-                        // executed: a block row with the SAME hash means this
-                        // decision is a duplicate record (a re-decide after a
-                        // rollback, or a sync replaying both) — already
-                        // satisfied; a DIFFERENT hash means the decided block
-                        // was reorged away. Either way the decision is
-                        // terminal — parking it would wedge the drain forever
-                        // on a delivery that can never come.
-                        match select_block_at_height(&self.db_conn(), bh).await {
-                            Ok(Some(row)) => {
-                                warn!(
-                                    block_height = bh,
-                                    decided = %decided_hash,
-                                    executed = %row.hash,
-                                    consensus_height = %decision.consensus_height,
-                                    "Dropping deferred block decision — height already executed"
-                                );
-                                self.record_declined_block(&decision, bh, decided_hash)
-                                    .await;
-                                continue;
-                            }
-                            Ok(None) => {}
-                            Err(e) => {
-                                warn!(error = %e, block_height = bh, "Block lookup failed during drain; parking decision");
-                            }
-                        }
+                        // `bh == last_height + 1` and the poller has not
+                        // delivered it yet. The already-executed and reorged
+                        // cases were both settled by the tip gate above, so this
+                        // is the one genuinely transient case: park and wait for
+                        // `BlockInsert` to drive the drain again.
                         info!(
                             block_height = bh,
                             consensus_height = %decision.consensus_height,
@@ -1293,7 +1369,37 @@ impl<E: Executor> Reactor<E> {
                         .context("Failed to encode commit certificate")?
                         .encode_to_vec();
 
-                    if let Some(block) = self.consensus.pending_blocks.remove(height) {
+                    // Take the block only when it can execute immediately: the
+                    // exact next height, with no earlier block decision still
+                    // queued ahead of it. Everything else goes through the
+                    // deferred queue, the single ordered execution path.
+                    //
+                    // Without this, a buffered-but-not-next block was handed
+                    // straight to the executor, whose height guard is a `bail!`
+                    // — and the `batches` row had already been written. That is
+                    // how a signet validator spent 20 h restarting: each boot it
+                    // took one decision for a height 128 ahead of its tip, wrote
+                    // the record, died on the guard, and came back one consensus
+                    // height further from the state it actually held.
+                    //
+                    // The queue check is `is_block`, not `is_empty`: a deferred
+                    // BATCH must not hold a block back. Batches are only ever
+                    // gated on their own anchor (see `drain_deferred_decisions`),
+                    // and a batch waiting on this very block would deadlock
+                    // against it.
+                    let in_order = *height == self.last_height + 1
+                        && !self
+                            .consensus
+                            .deferred_decisions
+                            .iter()
+                            .any(|d| d.value.is_block());
+                    let ready = if in_order {
+                        self.consensus.pending_blocks.remove(height)
+                    } else {
+                        None
+                    };
+
+                    if let Some(block) = ready {
                         info!(
                             block_height = height,
                             block_hash = %hash,
@@ -1318,8 +1424,9 @@ impl<E: Executor> Reactor<E> {
                             info!(
                                 block_height = height,
                                 block_hash = %hash,
+                                last_height = self.last_height,
                                 consensus_height = %certificate.height,
-                                "Block decided but not yet received — deferring"
+                                "Block decided but not ready to execute — deferring"
                             );
                             self.consensus.deferred_decisions.push_back(
                                 consensus_state::DeferredDecision {
@@ -1361,6 +1468,23 @@ impl<E: Executor> Reactor<E> {
                 height = %certificate.height,
                 value = %certificate.value_id,
                 "Finalized a value not held among our undecided proposals for this height"
+            );
+        }
+
+        // An OOM backstop, not a policy knob. A node that genuinely cannot catch
+        // up accumulates one deferred decision per decided value, each carrying a
+        // certificate and possibly raw txs, forever. Failing here turns an
+        // eventual OOM-kill into an explicit, diagnosable exit that names the
+        // gap. Deliberately far above any real backlog: a tight bound would
+        // recreate the crash loop this whole change exists to remove, and on a
+        // bare-quorum network a crash loop takes the chain down with it.
+        if self.consensus.deferred_decisions.len() > MAX_DEFERRED_DECISIONS {
+            bail!(
+                "deferred decision queue exceeded {MAX_DEFERRED_DECISIONS} entries at block \
+                 height {} (consensus height {}) — this node is not executing what consensus \
+                 decides and cannot recover on its own; re-sync required",
+                self.last_height,
+                certificate.height
             );
         }
 

--- a/core/indexer/src/reactor/blocks.rs
+++ b/core/indexer/src/reactor/blocks.rs
@@ -108,6 +108,37 @@ impl<E: Executor> Reactor<E> {
     ///
     /// The reactor's canonical block-processing path discards this; the
     /// simulate handler consumes it.
+    /// The fallible body of `handle_block`'s transaction: the decision record
+    /// (when the block arrives decided) plus the block's own writes. Split out
+    /// so `handle_block` has a single place to roll back from.
+    async fn block_txn(
+        &mut self,
+        block: &Block,
+        decision: Option<&consensus_state::DeferredDecision>,
+    ) -> Result<(usize, u64)> {
+        if let Some(decision) = decision {
+            insert_batch(
+                &self.db_conn(),
+                decision.consensus_height.as_u64(),
+                block.height,
+                &block.hash.to_string(),
+                &decision.certificate,
+                true,
+            )
+            .await
+            .context("Failed to insert block batch decision")?;
+        }
+
+        let (unbatched_count, executed_ops, _failures) = self
+            .execute_block(block)
+            .await
+            .context("execute_block failed")?;
+        self.run_block_lifecycle(block)
+            .await
+            .context("run_block_lifecycle failed")?;
+        Ok((unbatched_count, executed_ops))
+    }
+
     pub(super) async fn execute_block(
         &mut self,
         block: &Block,
@@ -311,23 +342,26 @@ impl<E: Executor> Reactor<E> {
         block: Block,
         decision: &consensus_state::DeferredDecision,
     ) -> Result<()> {
-        insert_batch(
-            &self.db_conn(),
-            decision.consensus_height.as_u64(),
-            block.height,
-            &block.hash.to_string(),
-            &decision.certificate,
-            true,
-        )
-        .await
-        .context("Failed to insert block batch decision")?;
-        self.handle_block(block)
+        self.handle_block(block, Some(decision))
             .await
-            .context("handle_block failed after block batch decision")?;
-        Ok(())
+            .context("handle_block failed after block batch decision")
     }
 
-    pub(super) async fn handle_block(&mut self, block: Block) -> Result<()> {
+    /// Execute `block` and, when it arrives decided, record that decision in the
+    /// SAME transaction as the block's own writes.
+    ///
+    /// A consensus record and the execution it certifies must commit or fail
+    /// together. Writing the `batches` row first — as this did — let a node keep
+    /// a row claiming a height it never executed: the row survived, the
+    /// execution did not, and every restart then resumed consensus above state
+    /// the node did not hold. `delete_unexecuted_batch_suffix` cleans that up at
+    /// startup, but the window should not exist at all; `process_decided_batch`
+    /// has always taken the savepoint first, and the block path was the outlier.
+    pub(super) async fn handle_block(
+        &mut self,
+        block: Block,
+        decision: Option<&consensus_state::DeferredDecision>,
+    ) -> Result<()> {
         let started_at = Instant::now();
         let height = block.height;
         let hash = block.hash;
@@ -356,28 +390,40 @@ impl<E: Executor> Reactor<E> {
             );
         }
 
-        self.last_height = height;
-        self.last_hash = Some(hash);
-
         self.runtime
             .storage
             .savepoint()
             .await
             .context("Failed to begin block transaction")?;
 
-        let (unbatched_count, executed_ops, _failures) = self
-            .execute_block(&block)
-            .await
-            .context("execute_block failed")?;
-        self.run_block_lifecycle(&block)
-            .await
-            .context("run_block_lifecycle failed")?;
+        // Everything up to the commit is one transaction, rolled back explicitly
+        // on any error rather than left open for process teardown to discard.
+        // `last_height`/`last_hash` advance only after the commit, so a failed
+        // block leaves no trace in memory either.
+        let txn = self.block_txn(&block, decision).await;
+        let (unbatched_count, executed_ops) = match txn {
+            Ok(counts) => counts,
+            Err(e) => {
+                if let Err(rollback_err) = self.runtime.storage.rollback().await {
+                    warn!(error = %rollback_err, height, "Failed to roll back block transaction");
+                }
+                return Err(e);
+            }
+        };
 
         self.runtime
             .storage
             .commit()
             .await
             .context("Failed to commit block transaction")?;
+
+        self.last_height = height;
+        self.last_hash = Some(hash);
+        // Blocks at or below the tip can no longer be proposed or decided.
+        // Dropping them keeps `make_value` proposing only heights still ahead,
+        // and keeps `validate_batch`'s "a block is pending" gate honest.
+        self.consensus.pending_blocks.retain(|&h, _| h > height);
+
         // Reflect what's actually persisted, not what we're mid-processing.
         // Op counter increments only after commit so the simulation path
         // (rolls back instead of committing) doesn't inflate it.

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -75,6 +75,18 @@ use executor::Executor;
 /// Keep this constant and that config default in lockstep.
 const MAX_PENDING_BLOCKS: usize = 128;
 
+/// Ceiling on `consensus_state::deferred_decisions` — decided values parked
+/// because their data has not arrived or their turn has not come.
+///
+/// Unlike [`MAX_PENDING_BLOCKS`] this is not backpressure: there is nothing to
+/// slow down, since the queue is fed by consensus itself. It is an OOM backstop
+/// for the one state that cannot resolve itself — a node whose execution has
+/// fallen behind heights the network already decided, which parks one entry per
+/// decided value from then on. Set far above any legitimate backlog: a healthy
+/// node idles near zero and drains within a block, and a tight bound would turn
+/// a transient stall into the crash loop this bound exists to avoid.
+const MAX_DEFERRED_DECISIONS: usize = 4096;
+
 pub type Simulation = (
     indexer_types::Transaction,
     oneshot::Sender<Result<Vec<OpWithResult>>>,

--- a/core/indexer/src/reactor/reactor_cluster_tests.rs
+++ b/core/indexer/src/reactor/reactor_cluster_tests.rs
@@ -63,6 +63,13 @@ struct ReactorCluster {
     /// while a single node can also be stopped on its own.
     node_cancels: Vec<CancellationToken>,
     block_txs: Vec<mpsc::Sender<BlockEvent>>,
+    /// Fatal errors that killed a node's reactor task.
+    ///
+    /// `spawn_node` used to log these and move on, which made "the reactor
+    /// died" unassertable: a test whose node crashed showed up as a timeout on
+    /// whatever it was waiting for, indistinguishable from consensus simply
+    /// being slow. Tests that expect every node to survive assert this is empty.
+    reactor_errors: Arc<Mutex<Vec<(usize, String)>>>,
     mempool_tx: broadcast::Sender<MempoolEvent>,
     decided_rx: mpsc::Receiver<DecidedBatch>,
     finality_rx: mpsc::Receiver<FinalityEvent>,
@@ -165,6 +172,7 @@ impl ReactorCluster {
         let (event_tx, event_rx) = mpsc::channel(1024);
 
         let mut join_set = JoinSet::new();
+        let reactor_errors: Arc<Mutex<Vec<(usize, String)>>> = Arc::new(Mutex::new(Vec::new()));
         let mut started_nodes = vec![false; total];
         let mut simulate_txs = Vec::new();
 
@@ -218,6 +226,7 @@ impl ReactorCluster {
                 node_dirs[i].0.path().to_path_buf(),
                 node_dirs[i].1.clone(),
                 true,
+                reactor_errors.clone(),
                 &mut join_set,
             );
             started_nodes[i] = true;
@@ -233,6 +242,7 @@ impl ReactorCluster {
             node_dirs,
             node_cancels,
             block_txs,
+            reactor_errors,
             mempool_tx,
             decided_rx,
             finality_rx,
@@ -330,6 +340,7 @@ impl ReactorCluster {
             self.node_dirs[i].0.path().to_path_buf(),
             self.node_dirs[i].1.clone(),
             false,
+            self.reactor_errors.clone(),
             &mut self.join_set,
         );
 
@@ -409,6 +420,7 @@ impl ReactorCluster {
         // seeding runs only on the first boot. That distinction is the whole point
         // of the restart path — a node that re-seeds has not really restarted.
         first_boot: bool,
+        reactor_errors: Arc<Mutex<Vec<(usize, String)>>>,
         join_set: &mut JoinSet<()>,
     ) {
         let genesis = genesis.clone();
@@ -530,7 +542,9 @@ impl ReactorCluster {
             let _ = rtx.send(i).await;
 
             if let Err(e) = reactor.run().await {
-                tracing::error!(node = i, e = format!("{e:#}"), "Reactor error");
+                let msg = format!("{e:#}");
+                tracing::error!(node = i, e = %msg, "Reactor error");
+                reactor_errors.lock().unwrap().push((i, msg));
             }
         });
     }
@@ -579,6 +593,7 @@ impl ReactorCluster {
             self.node_dirs[i].0.path().to_path_buf(),
             self.node_dirs[i].1.clone(),
             true,
+            self.reactor_errors.clone(),
             &mut self.join_set,
         );
 
@@ -724,6 +739,40 @@ impl ReactorCluster {
             txids,
             state_events,
             events,
+        }
+    }
+
+    /// Assert no node's reactor died during the test.
+    ///
+    /// Worth calling explicitly wherever survival is the property under test: a
+    /// dead reactor otherwise surfaces only as a timeout somewhere downstream,
+    /// which reads as "consensus was slow" and hides the actual failure.
+    fn assert_no_reactor_errors(&self) {
+        let errors = self.reactor_errors.lock().unwrap();
+        assert!(errors.is_empty(), "reactor(s) died: {errors:?}");
+    }
+
+    /// Wait until `height` is DECIDED by consensus, without requiring every node
+    /// to have executed it.
+    ///
+    /// `wait_for_block` demands `BlockProcessed` from all `node_count` nodes,
+    /// which is the right check when everyone is healthy but cannot express
+    /// "the chain advanced even though one node could not follow" — the exact
+    /// property at stake when a node is deliberately left behind.
+    async fn wait_for_block_decided(&mut self, height: u64, timeout: Duration) {
+        let deadline = tokio::time::sleep(timeout);
+        tokio::pin!(deadline);
+        loop {
+            tokio::select! {
+                _ = &mut deadline => {
+                    panic!("wait_for_block_decided(height={height}) timed out");
+                }
+                Some(d) = self.decided_rx.recv() => {
+                    if d.value.is_block() && d.value.block_height() == height {
+                        return;
+                    }
+                }
+            }
         }
     }
 
@@ -1788,6 +1837,80 @@ async fn prod_reactor_pending_blocks_bounded_under_stalled_consensus() -> Result
         "pending_blocks is unbounded: accepted {accepted}/{flood} exceeds {ceiling} — high-water gate not applied"
     );
 
+    cluster.shutdown().await;
+    Ok(())
+}
+
+/// A node whose execution has fallen behind heights the network already decided
+/// must PARK the out-of-order decision, not die on it.
+///
+/// This is the signet halt of 2026-08. One validator's executor was 128 blocks
+/// behind while its buffer held the whole window, so a decision for the network's
+/// tip found that block cached and went straight to the executor — whose height
+/// guard is a `bail!`, taken *after* the `batches` row was already committed.
+/// The reactor exited, the pod restarted, and because that validator held the
+/// third of three usable votes in a 3/4 quorum, each restart bought exactly one
+/// decided height before dying again: 121 restarts, 20 h, chain stopped.
+///
+/// The property is asymmetric on purpose. The lagging node stays stuck — the
+/// heights it missed will not be re-decided, and value-sync will not backfill a
+/// node whose *consensus* height is current — but it stays UP, keeps voting, and
+/// the chain keeps moving. A stuck node is an operator problem; a crash-looping
+/// one takes the network down with it.
+#[tokio::test]
+async fn prod_reactor_out_of_order_block_decision_parks_instead_of_dying() -> Result<()> {
+    crate::logging::setup();
+
+    let mut cluster = ReactorCluster::start(4).await?;
+    cluster.wait_for_ready().await;
+
+    // Blocks 1 and 2 reach only nodes 0-2. Node 3 has no block at all, so it
+    // rejects both proposals and votes nil; 3 of 4 still clears the 2/3
+    // threshold, so consensus decides and executes them without it. Node 3's
+    // consensus height advances with every decision — which is precisely why it
+    // will never be re-sent these heights.
+    let lagging = 3;
+    for height in 1..=2u64 {
+        let (blk_events, _) = cluster.mock_bitcoin().mine_empty_block();
+        for event in blk_events {
+            for (i, tx) in cluster.block_txs.iter().enumerate() {
+                if i != lagging {
+                    let _ = tx.try_send(event.clone());
+                }
+            }
+        }
+        cluster
+            .wait_for_block_decided(height, Duration::from_secs(60))
+            .await;
+    }
+
+    // Block 3 goes to everyone. Node 3 now holds a block for height 3 with a tip
+    // of 0 — buffered, but 2 heights out of reach. It accepts the proposal (the
+    // block IS the canonical one at that height, which is all a `Value::Block`
+    // asserts) and votes for it, so the decision lands on a node that cannot
+    // execute it. Before the ordering gate, this is the line that killed the
+    // reactor: "Unexpected block height 3, expected 1".
+    let (blk_events, _) = cluster.mock_bitcoin().mine_empty_block();
+    for event in blk_events {
+        cluster.send_block_event(event);
+    }
+    cluster
+        .wait_for_block_decided(3, Duration::from_secs(60))
+        .await;
+
+    // The chain keeps advancing afterwards — the lagging node still votes, so
+    // quorum survives. Two more heights prove it is not a one-off.
+    for height in 4..=5u64 {
+        let (blk_events, _) = cluster.mock_bitcoin().mine_empty_block();
+        for event in blk_events {
+            cluster.send_block_event(event);
+        }
+        cluster
+            .wait_for_block_decided(height, Duration::from_secs(60))
+            .await;
+    }
+
+    cluster.assert_no_reactor_errors();
     cluster.shutdown().await;
     Ok(())
 }

--- a/core/indexer/src/runtime/storage.rs
+++ b/core/indexer/src/runtime/storage.rs
@@ -664,6 +664,39 @@ mod tests {
     use crate::test_utils::{new_mock_block_hash, new_test_db};
     use indexer_types::BlockRow;
 
+    // The savepoint must cover plain `conn.execute` writes issued through a
+    // CLONE of the connection, not just those made through `Storage`.
+    //
+    // The reactor relies on this: `db_conn()` hands out a clone, and
+    // `handle_block` writes the decided-batch record through it inside the
+    // block's savepoint so a failed execution cannot leave a consensus record
+    // behind. That is a property of libsql's `BEGIN TRANSACTION` on a shared
+    // connection, invisible at the call site — pinned here so it fails loudly
+    // if the connection sharing ever changes.
+    #[tokio::test]
+    async fn savepoint_covers_writes_through_a_cloned_connection() -> Result<()> {
+        use crate::database::queries::{insert_batch, select_batch};
+
+        let (_reader, writer, _temp) = new_test_db().await?;
+        let conn = writer.connection();
+        let storage = Storage::builder().conn(conn.clone()).build();
+
+        storage.savepoint().await?;
+        insert_batch(&conn.clone(), 7, 100, "deadbeef", b"cert", true).await?;
+        assert!(
+            select_batch(&conn, 7).await?.is_some(),
+            "the write must be visible inside its own transaction"
+        );
+        storage.rollback().await?;
+
+        assert!(
+            select_batch(&conn, 7).await?.is_none(),
+            "rolling back the block transaction must discard the decision record too — \
+             otherwise a node keeps a consensus record for a height it never executed"
+        );
+        Ok(())
+    }
+
     // `block_entropy` returns a present block's hash only when the height is in the
     // recent window `[current - K, current]`: not future, not expired, and a row
     // exists. (K = BLOCK_ENTROPY_WINDOW = 144.)


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #518** (`fix/finality-rehydration-and-advance`). It rewrites `drain_deferred_decisions` and both drain call sites, which this change also touches — building on `main` would guarantee conflicts. Retarget to `main` once #518 lands.

## Why

This is the reactor defect behind the signet halt of 2026-08-04/05. #519 fixes why it went unnoticed for 20 h; this fixes the crash itself.

A validator's executor was at block `316205` while the network executed `316333`. Its poller was at the tip, so `pending_blocks` held `316206..316333` — exactly `MAX_PENDING_BLOCKS = 128`. The `Value::Block` arm of `handle_finalized` then did:

```rust
if let Some(block) = self.consensus.pending_blocks.remove(height) {
```

No ordering check. A lagging node buffers the whole window from its tip to the network's, so **the buffer hit says nothing about whether the block can run**. The block went straight to `handle_block`, whose height guard is a `bail!` — taken *after* `handle_block_with_decision` had already committed the `batches` row:

```
ERROR Reactor error: handle_block_with_decision failed after consensus block:
      handle_block failed after block batch decision:
      Unexpected block height 316333, expected 316206, exiting
```

Each boot: take a decision for a far-ahead height, commit the consensus record, die on the guard, come back one consensus height further from the state actually held. 121 restarts over 20 h. Because that node held the third of three usable votes in a 3/4 quorum, the chain only advanced during the seconds it was alive.

Its consensus height stayed current throughout, so value-sync never backfilled it: **nothing about being behind on *execution* looks like being behind on *consensus***. Note the `Value::Batch` arm one screen above has always gated on `anchor_height > last_height`. The block arm was the asymmetry.

## What

**Atomicity** — `handle_block` now takes the decision and writes it *inside* the block's savepoint, so the consensus record and the execution it certifies commit or fail together. `process_decided_batch` has always done this; the block path was the outlier. `delete_unexecuted_batch_suffix` (#424) cleans the mismatch up at startup, but the window should not exist. Errors inside the window roll the savepoint back explicitly rather than relying on the process dying, and `last_height`/`last_hash` advance only after the commit, so a failed block leaves no trace in memory either.

Chose folding it in over simply reordering `insert_batch` after `handle_block`: the reorder leaves the inverse hazard — a crash between `commit()` and the insert executes a block with no consensus record, and `delete_unexecuted_batch_suffix` would then resume *below* an already-executed height, leaving the node unable to serve that decided value to a syncing peer.

**Ordering gate in `handle_finalized`** — the block goes to the executor only when it is the exact next height with no earlier block decision queued. Everything else goes through the deferred queue, the single ordered execution path.

The queue check is `is_block`, **not** `is_empty`. A deferred *batch* must not hold a block back: batches are gated only on their own anchor (see the `waiting` aside-queue #518 adds), and a batch waiting on this very block would deadlock against it. `is_empty` would introduce a new wedge while fixing this one.

**Tip gate in the drain** — checked *before* touching `pending_blocks`. At or below the tip the decision is terminal and dropped; parking one that nothing can ever satisfy wedges the drain forever. That case is reachable *with the block still buffered*, since the finality path deliberately keeps `pending_blocks` across a rollback and re-execution — the pre-existing check only covered the buffer-miss case. Ahead of the tip it parks with an `error!` naming the gap, which is the operator signal that this node needs a re-sync.

## The trade, stated plainly

**The lagging node stays stuck.** Heights `316206..316332` were decided long ago and will not be re-decided, and value-sync will not backfill a node whose consensus height is current. So it parks indefinitely.

That is the right trade: it stays **up**, keeps voting, and the chain keeps moving. A stuck node is an operator problem; a crash-looping one takes the network down with it. `MAX_DEFERRED_DECISIONS` (4096) bounds the queue that state grows — an OOM backstop, not a policy knob, set far above any real backlog because a tight bound would recreate the very crash loop this removes. Combined with #519's exit code and the `index_deferred_decisions` gauge, this state is now loud instead of silent.

## Deliberately not changed

`validate_and_accept_proposal` still votes for a buffered block that is not yet executable. Gating it on `bh == last_height + 1` is tempting and I implemented it before backing it out: a `Value::Block` asserts only *"this is the canonical Bitcoin block at this height"*, which the node can confirm from its own buffer — when to run it is local ordering, settled by the deferred queue. Withholding the vote trades a stuck node for a **stalled chain**: at 3-of-4 quorum with one validator already down, one nil vote is the difference between advancing and halting. That is this same incident reintroduced from the other side.

The rejection path does now distinguish *"not yet received"* from *"already processed"* — opposite conditions with opposite remedies (one resolves itself when the poller catches up, the other never does), previously indistinguishable in the logs.

## Tests

`prod_reactor_out_of_order_block_decision_parks_instead_of_dying` leaves one node two heights behind, then decides a block it has buffered. On the old code it fails with the exact production error:

```
reactor(s) died: [(3, "handle_block_with_decision failed after consensus block:
  handle_block failed after block batch decision: Unexpected block height 3, expected 1")]
```

The harness now records reactor errors instead of logging them — a dead reactor otherwise surfaces only as a downstream timeout, which reads as slow consensus and hides the failure. Added `wait_for_block_decided`, since `wait_for_block` requires all nodes to execute and so cannot express "the chain advanced even though one node could not follow", the property under test.

Plus a storage test pinning the assumption the atomicity fix rests on: libsql's `BEGIN TRANSACTION` covers plain writes issued through a *cloned* connection handle (`db_conn()` hands out a clone).

`cargo test -p indexer --lib` (396 passed), `cargo clippy -p indexer --all-targets` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes consensus-adjacent block finalization, deferred draining, and transactional persistence—core paths where ordering bugs previously halted signet; mitigated by extensive comments, bounds, and a cluster regression test.
> 
> **Overview**
> Fixes a reactor crash loop where a lagging validator could **execute a decided block far ahead of its tip** because `pending_blocks` held the block but execution order was unchecked—committing a `batches` row then dying on `handle_block`'s height guard.
> 
> **Ordered execution** — On finalize, a block runs only when it is exactly `last_height + 1` and no earlier **block** decision remains in `deferred_decisions` (batches do not block blocks). Otherwise the decision is deferred. The deferred drain applies a **tip gate** first: at/below tip → drop and record declined; ahead of tip → park with `error!` (re-sync signal); only `last_height + 1` proceeds to execution.
> 
> **Atomic block path** — `handle_block` writes the decided `batches` row inside the same savepoint as `execute_block` / lifecycle, rolls back on failure, and advances `last_height` only after commit—matching `process_decided_batch`.
> 
> **Safety and ops** — `MAX_DEFERRED_DECISIONS` (4096) bails before unbounded deferred-queue growth. Proposal validation still votes for buffered canonical blocks (not gated on next height); rejections distinguish not-yet-received vs already-processed. Cluster test reproduces park-not-die; storage test pins savepoint coverage for cloned `db_conn()` writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4701a9fa449af6554ff9177fe605e3870b2770bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->