### PR TITLE
fix(consensus): correctness cluster from the whole-subsystem capstone audit

### DIFF
--- a/core/indexer/src/database/queries/batches.rs
+++ b/core/indexer/src/database/queries/batches.rs
@@ -49,6 +49,15 @@ pub async fn insert_batch_txids(
 /// NOT an anchor band: deleting by `anchor_height > ?` punches holes in the
 /// consensus-height sequence when anchors are non-monotone across a rollback,
 /// and a gap can never be refilled locally. Returns (deleted batches, X).
+///
+/// X is additionally capped at the FIRST GAP in the recorded sequence. The bare
+/// `MAX(consensus_height WHERE anchor <= tip)` heuristic is defeated by rows
+/// written out of decision order — a declined/stale block records its own low
+/// anchor at a high consensus height (see `record_declined_block`), dragging X
+/// above a lower, still-rowless height. Resuming above such a gap makes it a
+/// permanent unrefillable hole (Malachite never re-delivers it, sync never
+/// backfills below the resume point). Trimming too much is safe — every trimmed
+/// height re-syncs and re-processes idempotently — so cap X below any gap.
 pub async fn delete_unexecuted_batch_suffix(
     conn: &Connection,
     last_block_height: u64,
@@ -59,10 +68,26 @@ pub async fn delete_unexecuted_batch_suffix(
             params![last_block_height],
         )
         .await?;
-    let x: u64 = match rows.next().await? {
+    let anchor_x: u64 = match rows.next().await? {
         Some(row) => row.get(0)?,
         None => 0,
     };
+    // The smallest recorded height with no immediate successor — i.e. the last
+    // height of the first contiguous run. Everything above it may straddle a gap
+    // and must be re-synced, so X cannot exceed it.
+    let mut rows = conn
+        .query(
+            "SELECT MIN(consensus_height) FROM batches b \
+             WHERE NOT EXISTS ( \
+               SELECT 1 FROM batches n WHERE n.consensus_height = b.consensus_height + 1)",
+            (),
+        )
+        .await?;
+    let first_run_end: u64 = match rows.next().await? {
+        Some(row) => row.get::<Option<u64>>(0)?.unwrap_or(anchor_x),
+        None => anchor_x,
+    };
+    let x = anchor_x.min(first_run_end);
     conn.execute(
         "DELETE FROM unconfirmed_batch_txs WHERE batch_height > ?",
         params![x],

--- a/core/indexer/src/database/queries/tests.rs
+++ b/core/indexer/src/database/queries/tests.rs
@@ -2638,6 +2638,38 @@ async fn test_insert_and_select_batch() -> Result<()> {
     Ok(())
 }
 
+/// The suffix cleanup must cap its cutoff below the FIRST gap in the recorded
+/// sequence, even when a later out-of-order low-anchor row would otherwise drag
+/// the `MAX(anchor <= tip)` cutoff above the gap. Here height 900 is rowless
+/// (deferred, never recorded) while a declined block at height 901 carries a low
+/// anchor <= tip — the exact race that made 900 a permanent hole.
+#[tokio::test]
+async fn suffix_cleanup_caps_the_cutoff_below_the_first_gap() -> Result<()> {
+    let (_reader, writer, _temp_dir) = new_test_db().await?;
+    let conn = writer.connection();
+
+    let tip: u64 = 205;
+    let h = new_mock_block_hash(tip as u32);
+    insert_block(&conn, BlockRow::builder().height(tip).hash(h).build()).await?;
+
+    // Contiguous, executed history up to 899, all anchored at/below the tip.
+    for ch in 1..=899u64 {
+        insert_batch(&conn, ch, tip, &h.to_string(), b"c", false).await?;
+    }
+    // Height 900 is NEVER recorded (a rowless deferred survivor). Height 901 is a
+    // declined block recording its own low anchor (<= tip) at a high height.
+    insert_batch(&conn, 901, 203, &h.to_string(), b"c", true).await?;
+
+    let (_deleted, x) = delete_unexecuted_batch_suffix(&conn, tip).await?;
+    assert_eq!(
+        x, 899,
+        "cutoff must stop at the last contiguous height, not jump to 901 over the 900 gap"
+    );
+    assert!(select_batch(&conn, 901).await?.is_none(), "901 trimmed");
+    assert!(select_batch(&conn, 899).await?.is_some(), "899 kept");
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_select_min_batch_height() -> Result<()> {
     let (_reader, writer, _temp_dir) = new_test_db().await?;

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -39,11 +39,12 @@ const FEE_THRESHOLD_NUM: u64 = 9;
 const FEE_THRESHOLD_DEN: u64 = 10;
 
 /// A consensus I/O job: bitcoind validation running OFF the event loop as an
-/// owned future, paired with what to do with its verdicts. The loop polls the
-/// front job as an arm of its root `select!`, so the reactor keeps executing
-/// blocks, draining mempool events, and settling finality while bitcoind is
-/// slow — and dropping the loop drops the in-flight RPC, so shutdown costs
-/// nothing (see `Executor::validate_txs`).
+/// owned future, paired with what to do with its verdicts. The loop races EVERY
+/// in-flight job (`select_all`) as one arm of its root `select!`, so the reactor
+/// keeps executing blocks, draining mempool events, and settling finality while
+/// bitcoind is slow — and a stalled job never parks another whose reply the
+/// engine is waiting on. Dropping the loop drops the in-flight RPCs, so shutdown
+/// costs nothing (see `Executor::validate_txs`).
 ///
 /// State is read twice, never held across the I/O: a SNAPSHOT phase collects
 /// candidates and cheap-rejects on the loop, and the APPLY phase re-checks
@@ -1064,11 +1065,6 @@ impl<E: Executor> Reactor<E> {
         Ok(())
     }
 
-    /// The APPLY phase of a finished [`IoJob`]: act on the verdicts, but only
-    /// after re-judging every state predicate against wherever the chain moved
-    /// while the I/O ran. `Err` from the I/O is infrastructure (bitcoind
-    /// unreachable after retries) and fatal — I5, same as it was when the RPCs
-    /// ran inline.
     /// The APPLY phase of a finished [`IoJob`]: act on the verdicts, but only
     /// after re-judging every state predicate against wherever the chain moved
     /// while the I/O ran. `Err` from the I/O is infrastructure (bitcoind

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -790,6 +790,15 @@ impl<E: Executor> Reactor<E> {
         if txs.is_empty() {
             return Ok(ProposalSnapshot::Nothing);
         }
+        // Dependency-order the candidates BEFORE the I/O phase, not after. The
+        // I/O phase relays each accepted tx before validating the next
+        // (`validate_txs`), and a child's mempool-acceptance check only passes on
+        // a bitcoind that already holds its parent — so the parent must be relayed
+        // first, which requires it to come first HERE. The pool enumerates in
+        // arbitrary order; sorting at apply (as an earlier version did) is too
+        // late, a child ahead of its parent is already rejected on relay.
+        let order = dependency_sort(&txs);
+        let txs: Vec<bitcoin::Transaction> = order.into_iter().map(|i| txs[i].clone()).collect();
         // Compute the fee threshold once for this candidate set (the index is
         // a snapshot during this pass) and carry it into the I/O phase.
         let threshold = compute_fee_threshold(&self.consensus.mempool_fee_index);

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -587,17 +587,49 @@ impl<E: Executor> Reactor<E> {
         // Execute in decided order. `validate_batch` enforces dependency
         // order at propose/accept time, so a decided batch — carrying 2/3+
         // signatures — is already ordered; no re-sort or re-check here.
-        let parsed_txs: Vec<indexer_types::Transaction> = batch_txs
-            .iter()
-            .map(|btx| {
-                self.executor.parse_transaction(btx).ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "Failed to parse decided batch transaction {}",
-                        btx.compute_txid()
-                    )
-                })
-            })
-            .collect::<Result<Vec<_>>>()?;
+        //
+        // A parse failure here is a DETERMINISTIC content fact — parsing decided
+        // bytes reads no chain state, so every node fails identically — which per
+        // I5 must be handled the same everywhere and must NOT be node-fatal: a
+        // `?` here halts the whole chain (each node exits, re-syncs the same value,
+        // exits again). Proposal validation normally rejects unparseable txs before
+        // they are decided; if one is decided anyway, record the batch for sync and
+        // skip execution uniformly, rather than crash-looping the network.
+        let parsed_txs: Vec<indexer_types::Transaction> = {
+            let mut parsed = Vec::with_capacity(batch_txs.len());
+            let mut bad: Option<Txid> = None;
+            for btx in batch_txs {
+                match self.executor.parse_transaction(btx) {
+                    Some(p) => parsed.push(p),
+                    None => {
+                        bad = Some(btx.compute_txid());
+                        break;
+                    }
+                }
+            }
+            if let Some(txid) = bad {
+                error!(
+                    %txid,
+                    consensus_height = %consensus_height,
+                    "Decided batch contains an unparseable transaction — recording for sync \
+                     and skipping execution (deterministic; every node does the same)"
+                );
+                insert_batch(
+                    &conn,
+                    consensus_height.as_u64(),
+                    anchor_height,
+                    &anchor_hash.to_string(),
+                    certificate,
+                    false,
+                )
+                .await
+                .context("Failed to record unparseable batch for sync")?;
+                self.record_batch_txs(&conn, consensus_height, batch_txs, certified)
+                    .await?;
+                return Ok(BatchOutcome::RecordedOnly);
+            }
+            parsed
+        };
 
         // Track for finality — must happen once per batch execution
         let txids: Vec<Txid> = batch_txs.iter().map(|tx| tx.compute_txid()).collect();

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -1290,9 +1290,15 @@ impl<E: Executor> Reactor<E> {
         );
 
         // BOTH sides resolve, not just the replay set — see `resolve_decisions`.
+        // Resolve from a CLONE of the queued survivors and clear the originals only
+        // once resolution has succeeded, rather than `mem::take`-ing first: a
+        // resolve failure (bitcoind unreachable for a `BatchTx::Id`) then leaves
+        // `deferred_decisions` intact instead of destroying the only in-memory copy
+        // of its rowless entries before propagating.
         let replayed = self.resolve_decisions(replay_batches).await?;
-        let queued = std::mem::take(&mut self.consensus.deferred_decisions);
+        let queued: Vec<_> = self.consensus.deferred_decisions.iter().cloned().collect();
         let survivors = self.resolve_decisions(queued).await?;
+        self.consensus.deferred_decisions.clear();
 
         let (queue, excluded) = build_replay_queue(replayed, survivors, &applicable);
         self.consensus.deferred_decisions = queue;
@@ -1968,15 +1974,22 @@ impl<E: Executor> Reactor<E> {
                 }
             }
         } else {
-            // We decided a value we never assembled locally. For blocks this can't
-            // happen (every node rebuilds the same block reference when proposing);
-            // it would mean a batch decided at a round whose proposal we never saw
-            // and whose txs aren't in our pool. Surface it rather than dropping it
-            // silently, which would leave a hole in the decided sequence.
-            warn!(
-                height = %certificate.height,
-                value = %certificate.value_id,
-                "Finalized a value not held among our undecided proposals for this height"
+            // We finalized a value we never assembled locally — a batch decided at
+            // a round whose proposal we never saw, whose txs are not in our pool.
+            // We have the certificate but not the content, so there is no row to
+            // write. Falling through to advance `current_height` past this height
+            // would make it a PERMANENT hole (I3): Malachite never re-delivers a
+            // height it considers decided, and the startup cleanup only trims a
+            // suffix. Fail-stop instead (I5) — restart resumes at this height and
+            // value-sync re-delivers the decided value into `undecided`, where the
+            // arm above records it. A node that keeps hitting this is persistently
+            // unable to follow consensus, which is exactly the loud stop an
+            // operator needs, not a quiet divergence.
+            bail!(
+                "Finalized value {} at height {} is not among our undecided proposals — \
+                 cannot record it; stopping so a restart re-syncs the decided value",
+                certificate.value_id,
+                certificate.height,
             );
         }
 

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -261,23 +261,33 @@ fn build_replay_queue(
             .is_some_and(|s| s.contains(&txid.to_string()))
     };
 
-    // Outputs the ORIGINAL execution had produced by each queue position that this
-    // replay will NOT have: every excluded tx, from the position it was dropped at,
-    // until (if ever) a later decision re-decides and keeps it. The queue order IS
-    // the execution order, so availability is a positional fact, not a global one:
+    // Which txids each decision must drop, computed in EXECUTION order and then
+    // applied in queue order. Two orders, because they answer different questions:
     //
-    // - A keep re-creates the parent's outputs only from its own position onward.
-    //   A child sitting BETWEEN an excluded parent and its re-decided copy executes
-    //   before the parent is rebuilt, so it drops — an order-blind "kept anywhere"
-    //   guard let exactly that child through (#427 through the re-decide door).
-    // - Conversely, a child ordered BEFORE its parent's position never saw the
-    //   parent's effects in the original execution either, so it keeps; the replay
-    //   reproduces the original sequence position by position.
+    //   * availability — whether a tx's parent output exists when the tx runs — is
+    //     a function of the order transactions EXECUTE, which is anchor order: the
+    //     drain holds every batch aside until the tip reaches its anchor, so a batch
+    //     at a lower anchor runs first regardless of consensus height. That order is
+    //     a shared input `(anchor_height, consensus_height)` — the same one
+    //     `check_finality` renders its verdict in — so every node computes the same
+    //     drops. Walking in QUEUE order instead (replay-set-first, survivors behind)
+    //     was node-local: a lagging node orders a survivor differently from a node
+    //     that already executed the height, so the two kept different tx sets from
+    //     one rollback with identical exclusion rows — silent state divergence.
     //
-    // Exclusions recorded at heights not in this queue happened below `from_anchor`
-    // — before every position here — so they are unavailable from the start: the
-    // rollback wiped the parent's effects and nothing in the queue rebuilds them
-    // (#427's original shape).
+    //   * the QUEUE order is replay-set-first for drain LIVENESS (a survivor block
+    //     decision ordered ahead of the replay set would stall the very decisions
+    //     that raise the tip back up), and is unrelated to availability.
+    //
+    // The walk tracks outputs the original execution produced that this replay will
+    // not: every excluded tx, from the anchor position it was dropped at, until (if
+    // ever) a later position re-decides and keeps it. A keep re-creates its parent's
+    // outputs only from its own position onward, so a child ordered between an
+    // excluded parent and its re-decide drops (#427 through the re-decide door),
+    // while a child ordered before the parent keeps — it never saw those effects in
+    // the original execution either. Exclusions recorded at heights not in this
+    // queue happened below `from_anchor`, before every position here, so they are
+    // unavailable from the start (#427's original shape).
     let queued_heights: HashSet<u64> = merged
         .iter()
         .map(|(d, _)| d.consensus_height.as_u64())
@@ -288,9 +298,63 @@ fn build_replay_queue(
         .flat_map(|(_, txids)| txids.iter().filter_map(|t| t.parse::<Txid>().ok()))
         .collect();
 
-    let mut all_excluded: HashSet<Txid> = HashSet::new();
-    let mut queue = VecDeque::with_capacity(merged.len());
+    let mut execution_order: Vec<usize> = (0..merged.len()).collect();
+    execution_order.sort_by_key(|&i| {
+        let (d, _) = &merged[i];
+        match &d.value {
+            Value::Batch { anchor_height, .. } => (*anchor_height, d.consensus_height.as_u64()),
+            // Blocks carry no batch txs; the walk ignores them, so their key only
+            // needs to be stable. Their own height orders them among batches.
+            Value::Block { height, .. } => (*height, d.consensus_height.as_u64()),
+        }
+    });
 
+    let mut all_excluded: HashSet<Txid> = HashSet::new();
+    let mut dropped_per_height: HashMap<u64, HashSet<Txid>> = HashMap::new();
+    for &i in &execution_order {
+        let (decision, txs) = &merged[i];
+        if !matches!(decision.value, Value::Batch { .. }) {
+            continue;
+        }
+        let mut dropped = HashSet::new();
+        for tx in txs {
+            let txid = tx.compute_txid();
+            if dropped_at(decision, &txid) {
+                all_excluded.insert(txid);
+                unavailable.insert(txid);
+                dropped.insert(txid);
+            } else if tx
+                .input
+                .iter()
+                .any(|i| unavailable.contains(&i.previous_output.txid))
+            {
+                // A descendant of a tx missing AT THIS EXECUTION POSITION. Dropped in
+                // memory, deliberately NOT recorded in `excluded_batch_txids`: a
+                // descendant's drop is only justified while its parent stays excluded,
+                // and a durable row outlives that justification — the read predicate
+                // re-checks the CHILD's confirmation, never the parent's recovery, so a
+                // recorded child would stay dropped after a reorg heals the parent while
+                // every fresh syncer executes it. Re-deriving from the durable base rows
+                // each pass costs at most one extra rollback (a leaked child re-arms its
+                // own deadline and becomes a base row); a wrong durable drop is a
+                // divergence.
+                all_excluded.insert(txid);
+                unavailable.insert(txid);
+                dropped.insert(txid);
+            } else {
+                // A re-decided copy of a previously excluded tx: from here on its
+                // outputs exist again, so later children survive.
+                unavailable.remove(&txid);
+            }
+        }
+        if !dropped.is_empty() {
+            dropped_per_height.insert(decision.consensus_height.as_u64(), dropped);
+        }
+    }
+
+    // Emit the queue in its original (replay-first) order, applying the per-height
+    // drops computed above.
+    let mut queue = VecDeque::with_capacity(merged.len());
     for (mut decision, txs) in merged {
         if let Value::Batch {
             anchor_height,
@@ -299,36 +363,12 @@ fn build_replay_queue(
         } = &decision.value
         {
             let (anchor_height, anchor_hash) = (*anchor_height, *anchor_hash);
-            let mut kept = Vec::with_capacity(txs.len());
-            for tx in &txs {
-                let txid = tx.compute_txid();
-                if dropped_at(&decision, &txid) {
-                    all_excluded.insert(txid);
-                    unavailable.insert(txid);
-                } else if tx
-                    .input
-                    .iter()
-                    .any(|i| unavailable.contains(&i.previous_output.txid))
-                {
-                    // A descendant of a tx that is missing AT THIS POSITION. Dropped
-                    // in memory, deliberately NOT recorded in `excluded_batch_txids`:
-                    // a descendant's drop is only justified while its parent stays
-                    // excluded, and a durable row outlives that justification — the
-                    // read predicate re-checks the CHILD's confirmation, never the
-                    // parent's recovery, so a recorded child would stay dropped after
-                    // a reorg heals the parent while every fresh syncer executes it.
-                    // Re-deriving from the durable base rows each pass costs at most
-                    // one extra rollback (a leaked child re-arms its own deadline and
-                    // becomes a base row); a wrong durable drop is a divergence.
-                    all_excluded.insert(txid);
-                    unavailable.insert(txid);
-                } else {
-                    kept.push(tx.clone());
-                    // A re-decided copy of a previously excluded tx: from here on
-                    // its outputs exist again, so later children survive.
-                    unavailable.remove(&txid);
-                }
-            }
+            let dropped = dropped_per_height.get(&decision.consensus_height.as_u64());
+            let kept: Vec<bitcoin::Transaction> = txs
+                .iter()
+                .filter(|tx| !dropped.is_some_and(|d| d.contains(&tx.compute_txid())))
+                .cloned()
+                .collect();
             // Narrowing what we execute must not narrow what we record as decided —
             // see `DeferredDecision::certified_txs`. The BODIES are retained, not just
             // the txids: an excluded tx never confirmed, so this is the only copy left
@@ -2062,6 +2102,18 @@ mod tests {
         (decision(consensus_height), Vec::new())
     }
 
+    /// `carrying` with an explicit anchor height, so a test can pin the
+    /// EXECUTION order (which is anchor order) independently of the queue order.
+    fn carrying_at(
+        consensus_height: u64,
+        anchor_height: u64,
+        txs: Vec<Transaction>,
+    ) -> (DeferredDecision, Vec<Transaction>) {
+        let mut d = decision(consensus_height);
+        d.value = Value::new_batch_raw(anchor_height, bitcoin::BlockHash::all_zeros(), txs.clone());
+        (d, txs)
+    }
+
     /// Exclusions attributed to the decision they were dropped from.
     fn excl(pairs: &[(u64, Txid)]) -> HashMap<u64, HashSet<String>> {
         let mut m: HashMap<u64, HashSet<String>> = HashMap::new();
@@ -2375,6 +2427,63 @@ mod tests {
             "a descendant of an excluded, otherwise-absent parent must not execute"
         );
         assert!(dropped.contains(&child.compute_txid()));
+    }
+
+    /// The availability walk must give the SAME answer on two nodes that split the
+    /// same decisions differently between the replay set and the survivors — because
+    /// that split is node-local (a lagging node holds as a survivor what a caught-up
+    /// node already executed), while the drop set must be a shared input or two
+    /// honest nodes diverge from one rollback.
+    ///
+    /// Parent P is excluded below `from_anchor` (out of queue), then re-decided by D
+    /// at a HIGHER anchor than child C's batch — so in execution (anchor) order C
+    /// runs before P is rebuilt and must drop, whichever side of the queue split D
+    /// and C land on. The pre-fix queue-order walk kept C whenever D happened to sit
+    /// ahead of it in the queue.
+    #[test]
+    fn build_replay_queue_availability_is_anchor_order_not_queue_order() {
+        let parent = tx(&[OutPoint::null()], 1);
+        let child = tx(&[spend(&parent)], 2);
+        // P excluded at height 3, which is NOT in either queue → seeds the walk.
+        let rows = || excl(&[(3, parent.compute_txid())]);
+        // C's batch anchors at 100; D re-decides P at 105 (executes AFTER C).
+        let child_batch = || carrying_at(10, 100, vec![child.clone()]);
+        let redecide = || carrying_at(20, 105, vec![parent.clone()]);
+
+        // Node A: C is in the replay set, D is a survivor behind it.
+        let (_, dropped_a) = build_replay_queue(vec![child_batch()], vec![redecide()], &rows());
+        // Node B: D is in the replay set, C is a survivor behind it.
+        let (_, dropped_b) = build_replay_queue(vec![redecide()], vec![child_batch()], &rows());
+
+        assert!(
+            dropped_a.contains(&child.compute_txid()),
+            "C executes before P is rebuilt, so it must drop"
+        );
+        assert_eq!(
+            dropped_a, dropped_b,
+            "the drop set must not depend on the node-local replay/survivor split"
+        );
+    }
+
+    /// The mirror: a child ordered BEFORE its parent's re-decide in EXECUTION order
+    /// keeps, again independent of the queue split. C's batch anchors ABOVE D here,
+    /// so P is rebuilt first and C's input exists.
+    #[test]
+    fn build_replay_queue_keeps_a_child_executed_after_its_parents_redecide() {
+        let parent = tx(&[OutPoint::null()], 1);
+        let child = tx(&[spend(&parent)], 2);
+        let rows = || excl(&[(3, parent.compute_txid())]);
+        let child_batch = || carrying_at(10, 110, vec![child.clone()]);
+        let redecide = || carrying_at(20, 105, vec![parent.clone()]);
+
+        let (_, dropped_a) = build_replay_queue(vec![child_batch()], vec![redecide()], &rows());
+        let (_, dropped_b) = build_replay_queue(vec![redecide()], vec![child_batch()], &rows());
+
+        assert!(
+            !dropped_a.contains(&child.compute_txid()),
+            "P is rebuilt at anchor 105 before C runs at 110, so C keeps"
+        );
+        assert_eq!(dropped_a, dropped_b, "and the answer is split-independent");
     }
 
     /// An unmarked decision is untouched — the record-only case, which has certified

--- a/core/indexer/src/reactor/blocks.rs
+++ b/core/indexer/src/reactor/blocks.rs
@@ -425,7 +425,7 @@ impl<E: Executor> Reactor<E> {
         self.last_height = height;
         self.last_hash = Some(hash);
         // Blocks at or below the tip can no longer be proposed or decided.
-        // Dropping them keeps `make_value` proposing only heights still ahead,
+        // Dropping them keeps `pending_block_value` proposing only heights still ahead,
         // and keeps `validate_batch`'s "a block is pending" gate honest.
         self.consensus.pending_blocks.retain(|&h, _| h > height);
 

--- a/core/indexer/src/reactor/blocks.rs
+++ b/core/indexer/src/reactor/blocks.rs
@@ -74,6 +74,14 @@ impl<E: Executor> Reactor<E> {
         self.runtime.component_cache.clear();
         self.last_height = height;
 
+        // Drop candidates validated against the old tip. An in-flight `IoJob` is
+        // still safe — its apply re-checks the anchor and re-runs `validate_batch`
+        // against the new tip before doing anything — but the banked set is
+        // consumed on a LATER `try_fulfill` with only an anchor-equality guard, so
+        // clearing it here is the belt to that suspenders and keeps a stale bank
+        // from ever reaching the proposer.
+        self.validated_candidates = None;
+
         // Err is NOT "no previous block": folding a transient read failure into
         // `last_hash = None` makes the next batch anchored at this height fail its
         // hash gate and record-only while every peer executes it — an over-skip

--- a/core/indexer/src/reactor/blocks.rs
+++ b/core/indexer/src/reactor/blocks.rs
@@ -74,12 +74,24 @@ impl<E: Executor> Reactor<E> {
         self.runtime.component_cache.clear();
         self.last_height = height;
 
-        if let Ok(Some(row)) = select_block_at_height(&self.db_conn(), height).await {
-            self.last_hash = Some(row.hash);
-            info!("Rollback to height {} ({})", height, row.hash);
-        } else {
-            self.last_hash = None;
-            warn!("Rollback to height {}, no previous block found", height);
+        // Err is NOT "no previous block": folding a transient read failure into
+        // `last_hash = None` makes the next batch anchored at this height fail its
+        // hash gate and record-only while every peer executes it — an over-skip
+        // that forks the checkpoint (I5, and the exact Err-vs-None distinction
+        // `missing_txids` argues for). Only a genuine absent row (pre-genesis
+        // truncation) clears the hash; a read error stops the node.
+        match select_block_at_height(&self.db_conn(), height)
+            .await
+            .context("Failed to read the post-rollback tip block")?
+        {
+            Some(row) => {
+                info!("Rollback to height {} ({})", height, row.hash);
+                self.last_hash = Some(row.hash);
+            }
+            None => {
+                warn!("Rollback to height {}, no previous block found", height);
+                self.last_hash = None;
+            }
         }
 
         // Refresh cached validator set — rolled-back state may have different active set

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -486,13 +486,20 @@ impl ConsensusState {
             );
         }
 
-        let current_height = match select_latest_consensus_height(&conn).await {
-            Ok(Some(h)) => {
+        // `Err` must be loud, like the suffix delete three lines up (#424): folding
+        // a transient read failure into "fresh start" resumes a node with thousands
+        // of decided heights at height 1, re-deciding history. Only a genuinely
+        // empty table is a fresh start.
+        let current_height = match select_latest_consensus_height(&conn)
+            .await
+            .context("Failed to read the latest consensus height")?
+        {
+            Some(h) => {
                 let resume = Height::new(h + 1);
                 info!(%resume, "Resuming consensus from DB");
                 resume
             }
-            _ => Height::new(1),
+            None => Height::new(1),
         };
 
         // Rebuild finality tracking. Without this a restart inside the window drops

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -46,6 +46,7 @@ pub enum ConsensusResult {
     BatchProcessed { txids: Vec<String> },
 }
 
+#[derive(Clone)]
 pub struct DeferredDecision {
     pub consensus_height: Height,
     pub value: Value,

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -956,7 +956,7 @@ impl ConsensusState {
 
     /// Validate batch-level rules. Returns a rejection reason if any rule
     /// fails — the single gate every batch passes, at both propose time
-    /// (`make_value`) and proposal-acceptance time
+    /// (`make_value_snapshot`) and proposal-acceptance time
     /// (`validate_and_accept_proposal`).
     pub(super) async fn validate_batch(
         &self,

--- a/core/indexer/src/reactor/executor.rs
+++ b/core/indexer/src/reactor/executor.rs
@@ -207,9 +207,12 @@ impl Executor for RuntimeExecutor {
                 // a child spending an unconfirmed parent's output only passes
                 // `testmempoolaccept` on a bitcoind that already HOLDS the
                 // parent, and on a validator whose node has not seen it via
-                // P2P yet, this in-order relay is what puts it there — the
-                // pre-io-job code did exactly this, per tx, for this reason.
-                // (`-27` = already known; `-25`/`-26` = rejected on submit.)
+                // P2P yet, this in-order relay is what puts it there. It works
+                // only because the caller hands `txs` in dependency order — an
+                // incoming proposal is validated for that order (`batch_is_ordered`)
+                // and a locally-built candidate set is `dependency_sort`ed before
+                // this phase (`make_value_snapshot`), so a parent always precedes
+                // its child here. (`-27` = already known; `-25`/`-26` = rejected.)
                 let policy = match policy {
                     TxPolicy::Accepted => {
                         let submitted = retry(

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -128,11 +128,14 @@ pub struct Reactor<E: Executor> {
     consensus_listen_addr: tokio::sync::watch::Sender<Option<String>>,
     /// Consensus I/O in flight — bitcoind validation running off the loop, ALL
     /// raced together as one arm of the root `select!` (`select_all`), so a
-    /// stalled job cannot park another. Bounded by construction (at most one
-    /// build job and one proposal validation outstanding: `pending_proposal` is
-    /// single and the engine awaits each proposal reply before the next part).
-    /// A `VecDeque` for cheap removal-by-index after `select_all`. See
-    /// `batches::IoJob`.
+    /// stalled job cannot park another. Small, not a fixed size: at most one
+    /// BUILD job (the `pending_proposal` is single, and `try_fulfill` refuses a
+    /// second build while one is in flight), plus one VALIDATE job per in-flight
+    /// proposal round — the `undecided` guard admits one per (height, round), and
+    /// a fresh round at the same height can arrive before the previous round's
+    /// job has applied. Bounded in practice by concurrent rounds, which the
+    /// round-timeout machinery keeps to a handful. A `VecDeque` for cheap
+    /// removal-by-index after `select_all`. See `batches::IoJob`.
     io_jobs: VecDeque<batches::IoJob>,
     /// Verdicts that outlived their proposal, banked for the next one — see
     /// `batches::ValidatedCandidates`.

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -126,11 +126,13 @@ pub struct Reactor<E: Executor> {
     /// Shared with the API (`Env.consensus_listen_addr`); written on the first
     /// `Listening` (see `handle_consensus_msg`'s `ConsensusReady` arm).
     consensus_listen_addr: tokio::sync::watch::Sender<Option<String>>,
-    /// Consensus I/O in flight — bitcoind validation running off the loop,
-    /// polled as an arm of the root `select!`. FIFO; bounded by construction
-    /// (at most one build job and one proposal validation can be outstanding:
-    /// `pending_proposal` is single and the engine awaits each proposal reply
-    /// before sending the next part). See `batches::IoJob`.
+    /// Consensus I/O in flight — bitcoind validation running off the loop, ALL
+    /// raced together as one arm of the root `select!` (`select_all`), so a
+    /// stalled job cannot park another. Bounded by construction (at most one
+    /// build job and one proposal validation outstanding: `pending_proposal` is
+    /// single and the engine awaits each proposal reply before the next part).
+    /// A `VecDeque` for cheap removal-by-index after `select_all`. See
+    /// `batches::IoJob`.
     io_jobs: VecDeque<batches::IoJob>,
     /// Verdicts that outlived their proposal, banked for the next one — see
     /// `batches::ValidatedCandidates`.
@@ -265,7 +267,7 @@ impl<E: Executor> Reactor<E> {
 
                 // A block at or below the tip is already applied and can never be
                 // proposed or executed again — buffering it is not merely useless,
-                // it HALTS THE CHAIN. `make_value` proposes the minimum pending
+                // it HALTS THE CHAIN. `pending_block_value` proposes the minimum pending
                 // height, peers still hold the block so they vote it valid, and it
                 // is decided; the finalize gate then refuses it as out of order and
                 // nothing removes it from the buffer. It stays the minimum forever,


### PR DESCRIPTION
The consensus core got a whole-subsystem audit on main `07b0b70f` (54-agent
adversarially-verified workflow): 43 confirmed findings. This PR is the
correctness cluster — the state-divergence, chain-halt, and unrefillable-hole
class. Performance and a security workstream (unauthenticated proposal parts,
witness-malleable batch identity) are tracked separately. Each fix is verified;
the two with expressible failure modes are red-proofed.

## The headline — a state-divergence bug (HIGH)

**Replay exclusions were computed in queue order, which is node-local**
(`build_replay_queue`). The positional availability walk added for #518 walked
the merged queue, and queue order differs between two honest nodes doing the
*same* rollback: a lagging node appends a survivor behind the replay set where a
caught-up node has it in front. So the two kept different transaction sets from
identical exclusion rows — silent divergence, undetected (no state root). Fixed
by walking availability in `(anchor_height, consensus_height)` order — the
*shared* execution order `check_finality` already uses — while still emitting the
queue replay-first for drain liveness. Two new tests pin that the drop set is
independent of the replay/survivor split; both red against the old walk.

## The rest of the cluster

- **`rollback()` folded a DB read error into "no previous block"** → the next
  batch records-only while peers execute → checkpoint fork. Now propagates (I5).
- **Consensus-height resume swallowed a read error** → silently restarted from
  height 1. Now propagates; only an empty table is a fresh start.
- **An unparseable tx in a *decided* batch was node-fatal** → deterministic
  content, so every node crash-loops. Now a uniform record-only skip.
- **Startup suffix-cleanup cutoff** could jump over a rowless middle height
  (an out-of-order low-anchor decline row dragged `MAX(anchor≤tip)` up),
  leaving a permanent unrefillable hole. Now capped below the first gap;
  trimming more is safe (idempotent re-sync). Pinned by a query test.
- **`prepare_replay` emptied the deferred queue before a fallible resolve** →
  destroyed the only in-memory copy of rowless entries. Now resolves first,
  clears after.
- **"Finalized a value not held" warned and advanced past the height** — the
  comment claimed it prevented a hole, then punched one. Now fail-stops so a
  restart re-syncs the decided value (closes the silent sub-path of the
  new-chain re-decision race).

Plus the doc comments the audit flagged as contradicting their code (the io-job
"polls the front job" — it races all jobs; a verbatim-duplicated apply doc;
stale `make_value` references).

## Deliberately deferred

The new-chain re-decision *wedge* (a poller-lagged node consuming a raced
new-chain block decision) is left to its own change: its silent sub-path is
closed here, the remaining exposure is a loud, self-healing wedge with no
divergence, and the proper fix touches the "terminal, never parked" drain
contract three prior audit rounds hardened — it wants a design pass and a
harness reorg-timing seam that does not exist yet. Rationale recorded in the
audit folder.

## Tests

428 lib (3 new), 10 supervisor-unit, daemon_exit e2e, workspace clippy
`-D warnings`, fmt, release regtest cluster (3, incl. SIGTERM→exit-0). The two
divergence/hole fixes with expressible failure modes are red-proofed against
their pre-fix code.

## Second-pass review (/code-review)

An independent review pass over the diff caught one real latent bug and two doc
inaccuracies, all fixed in this branch:
- **Relay was not dependency-ordered for locally-built proposals** — candidates
  reached the relay phase in arbitrary pool order, so a child could be relayed
  before its parent and rejected `missing-inputs`, dropping a valid parent+child
  pair. Now `dependency_sort`ed before the I/O phase.
- The `io_jobs` "bounded at 2" comment was wrong (validate jobs coexist across
  rounds) — corrected.
- The `validated_candidates` bank is now explicitly cleared on rollback (in-flight
  jobs stay on their apply-time anchor/validate_batch re-checks).
