### PR TITLE
perf(consensus): take the hot-path work off the reactor event loop

### DIFF
--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -770,18 +770,20 @@ impl<E: Executor> Reactor<E> {
         }
 
         // Candidate filter: state predicates only. Everything that needs
-        // bitcoind happens in the I/O phase, off this loop.
+        // bitcoind happens in the I/O phase, off this loop. Iterate by key —
+        // the pool is keyed by txid, so `compute_txid()` per entry (a
+        // double-SHA256 over the serialized tx) would recompute what we already
+        // hold.
         let mut txs = Vec::new();
         let mut invalid_txids = Vec::new();
-        for (raw_tx, parsed) in self.consensus.pending_transactions.values() {
-            let txid = raw_tx.compute_txid();
-            if !unbatched_set.contains(&txid) {
+        for (txid, (raw_tx, parsed)) in &self.consensus.pending_transactions {
+            if !unbatched_set.contains(txid) {
                 continue;
             }
             if is_batchable(&parsed.inputs) {
                 txs.push(raw_tx.clone());
             } else {
-                invalid_txids.push(txid);
+                invalid_txids.push(*txid);
             }
         }
         for txid in &invalid_txids {

--- a/core/indexer/src/reactor/batches.rs
+++ b/core/indexer/src/reactor/batches.rs
@@ -310,20 +310,22 @@ fn build_replay_queue(
         }
     });
 
+    // Dropped positions per merged index, so the emit below filters by index and
+    // never re-hashes a tx the walk already hashed here.
     let mut all_excluded: HashSet<Txid> = HashSet::new();
-    let mut dropped_per_height: HashMap<u64, HashSet<Txid>> = HashMap::new();
+    let mut dropped_positions: HashMap<usize, HashSet<usize>> = HashMap::new();
     for &i in &execution_order {
         let (decision, txs) = &merged[i];
         if !matches!(decision.value, Value::Batch { .. }) {
             continue;
         }
         let mut dropped = HashSet::new();
-        for tx in txs {
+        for (pos, tx) in txs.iter().enumerate() {
             let txid = tx.compute_txid();
             if dropped_at(decision, &txid) {
                 all_excluded.insert(txid);
                 unavailable.insert(txid);
-                dropped.insert(txid);
+                dropped.insert(pos);
             } else if tx
                 .input
                 .iter()
@@ -341,7 +343,7 @@ fn build_replay_queue(
                 // divergence.
                 all_excluded.insert(txid);
                 unavailable.insert(txid);
-                dropped.insert(txid);
+                dropped.insert(pos);
             } else {
                 // A re-decided copy of a previously excluded tx: from here on its
                 // outputs exist again, so later children survive.
@@ -349,14 +351,21 @@ fn build_replay_queue(
             }
         }
         if !dropped.is_empty() {
-            dropped_per_height.insert(decision.consensus_height.as_u64(), dropped);
+            dropped_positions.insert(i, dropped);
         }
     }
 
-    // Emit the queue in its original (replay-first) order, applying the per-height
-    // drops computed above.
+    // Emit the queue in its original (replay-first) order — deliberately NOT the
+    // execution order above. Replay-first is the drain's LIVENESS order (a survivor
+    // BLOCK decision ahead of the replay set would stall the tip); the drain
+    // executes each batch only when the tip reaches its anchor, and among batches
+    // sharing an anchor it cannot reverse a cross-batch dependency: the dependent
+    // batch can only be a survivor while its dependency is one (both wait for the
+    // same tip in decided order), never replayed-ahead of a survivor dependency,
+    // because the tip passing an anchor drains every deferred batch at it. So the
+    // deterministic per-position drop set is safe under the node-local queue order.
     let mut queue = VecDeque::with_capacity(merged.len());
-    for (mut decision, txs) in merged {
+    for (idx, (mut decision, txs)) in merged.into_iter().enumerate() {
         if let Value::Batch {
             anchor_height,
             anchor_hash,
@@ -364,11 +373,12 @@ fn build_replay_queue(
         } = &decision.value
         {
             let (anchor_height, anchor_hash) = (*anchor_height, *anchor_hash);
-            let dropped = dropped_per_height.get(&decision.consensus_height.as_u64());
+            let dropped = dropped_positions.get(&idx);
             let kept: Vec<bitcoin::Transaction> = txs
                 .iter()
-                .filter(|tx| !dropped.is_some_and(|d| d.contains(&tx.compute_txid())))
-                .cloned()
+                .enumerate()
+                .filter(|(pos, _)| !dropped.is_some_and(|d| d.contains(pos)))
+                .map(|(_, tx)| tx.clone())
                 .collect();
             // Narrowing what we execute must not narrow what we record as decided —
             // see `DeferredDecision::certified_txs`. The BODIES are retained, not just
@@ -479,6 +489,35 @@ impl<E: Executor> Reactor<E> {
         Ok(())
     }
 
+    /// Record a decided batch WITHOUT executing it: the `batches` row plus its
+    /// certified content, so a syncing peer can still fetch what consensus
+    /// decided. The single "recorded, not run" path — both the anchor-mismatch
+    /// skip and the unparseable-tx skip funnel through here so they cannot drift.
+    async fn record_batch_for_sync(
+        &mut self,
+        conn: &libsql::Connection,
+        consensus_height: Height,
+        anchor_height: u64,
+        anchor_hash: BlockHash,
+        certificate: &[u8],
+        batch_txs: &[bitcoin::Transaction],
+        certified: Option<&[bitcoin::Transaction]>,
+    ) -> Result<BatchOutcome> {
+        insert_batch(
+            conn,
+            consensus_height.as_u64(),
+            anchor_height,
+            &anchor_hash.to_string(),
+            certificate,
+            false,
+        )
+        .await
+        .context("Failed to record batch for sync")?;
+        self.record_batch_txs(conn, consensus_height, batch_txs, certified)
+            .await?;
+        Ok(BatchOutcome::RecordedOnly)
+    }
+
     pub(super) async fn process_decided_batch(
         &mut self,
         anchor_height: u64,
@@ -567,22 +606,17 @@ impl<E: Executor> Reactor<E> {
                 consensus_height = %consensus_height,
                 "Skipping decided batch — anchor does not match local tip; recording only"
             );
-            insert_batch(
-                &conn,
-                consensus_height.as_u64(),
-                anchor_height,
-                &anchor_hash.to_string(),
-                certificate,
-                false,
-            )
-            .await
-            .context("Failed to record anchor-mismatched batch for sync")?;
-            // Persist the certified content too (idempotent): a skipped batch
-            // must still be servable to syncing peers with its real txs, and
-            // the batch_txids/unconfirmed rows are what the sync path reads.
-            self.record_batch_txs(&conn, consensus_height, batch_txs, certified)
-                .await?;
-            return Ok(BatchOutcome::RecordedOnly);
+            return self
+                .record_batch_for_sync(
+                    &conn,
+                    consensus_height,
+                    anchor_height,
+                    anchor_hash,
+                    certificate,
+                    batch_txs,
+                    certified,
+                )
+                .await;
         }
 
         // Execute in decided order. `validate_batch` enforces dependency
@@ -615,19 +649,17 @@ impl<E: Executor> Reactor<E> {
                     "Decided batch contains an unparseable transaction — recording for sync \
                      and skipping execution (deterministic; every node does the same)"
                 );
-                insert_batch(
-                    &conn,
-                    consensus_height.as_u64(),
-                    anchor_height,
-                    &anchor_hash.to_string(),
-                    certificate,
-                    false,
-                )
-                .await
-                .context("Failed to record unparseable batch for sync")?;
-                self.record_batch_txs(&conn, consensus_height, batch_txs, certified)
-                    .await?;
-                return Ok(BatchOutcome::RecordedOnly);
+                return self
+                    .record_batch_for_sync(
+                        &conn,
+                        consensus_height,
+                        anchor_height,
+                        anchor_hash,
+                        certificate,
+                        batch_txs,
+                        certified,
+                    )
+                    .await;
             }
             parsed
         };

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -748,9 +748,7 @@ impl ConsensusState {
     /// executed block, per decided batch, and per rollback — a wasted SQL round
     /// trip each time otherwise.
     pub async fn get_checkpoint(&self, conn: &libsql::Connection) -> Option<[u8; 32]> {
-        if self.observation.is_none() {
-            return None;
-        }
+        self.observation.as_ref()?;
         match get_checkpoint_latest(conn).await {
             Ok(Some(row)) => {
                 if let Ok(decoded) = hex::decode(&row.hash)

--- a/core/indexer/src/reactor/consensus_state.rs
+++ b/core/indexer/src/reactor/consensus_state.rs
@@ -741,7 +741,16 @@ impl ConsensusState {
         }
     }
 
+    /// The latest checkpoint hash — used ONLY to populate observation
+    /// `StateEvent`s, so it short-circuits when nothing is observing. Every
+    /// production node runs without observation channels (they are test-only
+    /// wiring), and this is called on the consensus write connection per
+    /// executed block, per decided batch, and per rollback — a wasted SQL round
+    /// trip each time otherwise.
     pub async fn get_checkpoint(&self, conn: &libsql::Connection) -> Option<[u8; 32]> {
+        if self.observation.is_none() {
+            return None;
+        }
         match get_checkpoint_latest(conn).await {
             Ok(Some(row)) => {
                 if let Ok(decoded) = hex::decode(&row.hash)

--- a/core/indexer/src/reactor/executor.rs
+++ b/core/indexer/src/reactor/executor.rs
@@ -76,6 +76,13 @@ pub trait Executor {
     /// data for batch execution — batches carry only txids.
     async fn resolve_transaction(&self, txid: &Txid) -> Option<bitcoin::Transaction>;
 
+    /// Batched [`resolve_transaction`]: resolve many txids in ONE round trip
+    /// where the backend supports it (bitcoind's JSON-RPC batch + tx cache),
+    /// returning `None` per still-unresolved txid, in input order. The reactor's
+    /// replay/sync path resolves whole decided batches at once, so a per-txid
+    /// RPC there is one round trip per historical transaction.
+    async fn resolve_transactions(&self, txids: &[Txid]) -> Vec<Option<bitcoin::Transaction>>;
+
     /// Execute a single transaction's operations at the given height.
     /// Called by the reactor after DB row insertion. Sets context and runs ops.
     /// Returns Err only for non-deterministic infrastructure failures.
@@ -121,6 +128,9 @@ impl Executor for NoopExecutor {
     }
     async fn resolve_transaction(&self, _txid: &Txid) -> Option<bitcoin::Transaction> {
         None
+    }
+    async fn resolve_transactions(&self, txids: &[Txid]) -> Vec<Option<bitcoin::Transaction>> {
+        txids.iter().map(|_| None).collect()
     }
     async fn execute_transaction(
         &self,
@@ -256,6 +266,26 @@ impl Executor for RuntimeExecutor {
             Err(e) => {
                 warn!(%txid, %e, "Failed to resolve transaction via RPC");
                 None
+            }
+        }
+    }
+    async fn resolve_transactions(&self, txids: &[Txid]) -> Vec<Option<bitcoin::Transaction>> {
+        // One JSON-RPC batch (cache-checked) instead of a round trip per txid.
+        match self.bitcoin_client.get_raw_transactions(txids).await {
+            Ok(results) => results
+                .into_iter()
+                .zip(txids)
+                .map(|(r, txid)| match r {
+                    Ok(tx) => Some(tx),
+                    Err(e) => {
+                        warn!(%txid, %e, "Failed to resolve transaction via RPC");
+                        None
+                    }
+                })
+                .collect(),
+            Err(e) => {
+                warn!(%e, "Batched transaction resolution failed");
+                txids.iter().map(|_| None).collect()
             }
         }
     }

--- a/core/indexer/src/reactor/lite_executor.rs
+++ b/core/indexer/src/reactor/lite_executor.rs
@@ -242,6 +242,10 @@ impl Executor for LiteExecutor {
     async fn resolve_transaction(&self, txid: &Txid) -> Option<bitcoin::Transaction> {
         self.mock_bitcoin.lock().unwrap().get_raw_transaction(txid)
     }
+    async fn resolve_transactions(&self, txids: &[Txid]) -> Vec<Option<bitcoin::Transaction>> {
+        let mock = self.mock_bitcoin.lock().unwrap();
+        txids.iter().map(|t| mock.get_raw_transaction(t)).collect()
+    }
 
     async fn execute_transaction(
         &self,

--- a/core/indexer/src/reactor/mempool_fee_index/mod.rs
+++ b/core/indexer/src/reactor/mempool_fee_index/mod.rs
@@ -130,23 +130,34 @@ impl MempoolFeeIndex {
     /// snapshot. Always clears `dirty` — the next periodic tick will
     /// skip until a new mutation arrives.
     pub fn recompute(&mut self) -> Fees {
-        let blocks = block_projection::project_blocks(&self.entries, 4);
-        let min = self.mempool_min_fee_sat_per_vb;
-        let fastest = optimize_median_fee(blocks.first(), blocks.get(1), None, min);
-        let half_hour = optimize_median_fee(blocks.get(1), blocks.get(2), Some(fastest), min);
-        let hour = optimize_median_fee(blocks.get(2), blocks.get(3), Some(half_hour), min);
-        self.fees = Fees {
-            fastest,
-            half_hour,
-            hour,
-        };
+        let fees = project_fees(&self.entries, self.mempool_min_fee_sat_per_vb);
         self.dirty = false;
+        self.store_recomputed(fees);
+        fees
+    }
+
+    /// The inputs a `recompute` needs, cloned so the projection can run on a
+    /// blocking thread off the reactor's event loop. The clone is an O(entries)
+    /// memcpy; the projection it enables — a topological sort with a per-tx
+    /// ancestor-set union — is the expensive part (tens to hundreds of ms at
+    /// mainnet scale) and is what must not run inline on the consensus thread.
+    /// The caller clears `dirty` (via `take_dirty`) when it decides to start the
+    /// off-loop compute, so a mutation arriving DURING it re-sets the flag and
+    /// the next tick re-runs.
+    pub fn snapshot(&self) -> (HashMap<Txid, MempoolEntry>, u64) {
+        (self.entries.clone(), self.mempool_min_fee_sat_per_vb)
+    }
+
+    /// Cache and publish fees computed off-loop from `snapshot`, exactly as
+    /// `recompute` would — but leaving `dirty` alone (the caller already
+    /// cleared it when it started the off-loop job).
+    pub fn store_recomputed(&mut self, fees: Fees) {
+        self.fees = fees;
         if let Some(tx) = &self.fee_tx {
             // Errors only when all receivers are dropped — fine, the
             // reactor keeps running.
             let _ = tx.send(self.fees);
         }
-        self.fees
     }
 
     /// Run the block projection bypassing the cached `fees`. Exposed for
@@ -182,6 +193,21 @@ impl ProjectedBlock {
         }
         // Shouldn't happen unless entries is empty.
         self.entries.last().map(|(r, _)| *r).unwrap_or(0)
+    }
+}
+
+/// Project the three fee tiers from a mempool snapshot. Pure — no `self`, no
+/// I/O — so it can run on a blocking thread. This is the expensive body of
+/// `recompute`, lifted out for [`MempoolFeeIndex::snapshot_for_recompute`].
+pub fn project_fees(entries: &HashMap<Txid, MempoolEntry>, min: u64) -> Fees {
+    let blocks = block_projection::project_blocks(entries, 4);
+    let fastest = optimize_median_fee(blocks.first(), blocks.get(1), None, min);
+    let half_hour = optimize_median_fee(blocks.get(1), blocks.get(2), Some(fastest), min);
+    let hour = optimize_median_fee(blocks.get(2), blocks.get(3), Some(half_hour), min);
+    Fees {
+        fastest,
+        half_hour,
+        hour,
     }
 }
 

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -242,24 +242,42 @@ impl<E: Executor> Reactor<E> {
 
     async fn resolve_batch_txs(&mut self, txs: &[BatchTx]) -> Result<Vec<bitcoin::Transaction>> {
         let conn = self.db_conn();
-        let mut resolved = Vec::with_capacity(txs.len());
+        // First pass: everything the pool and DB can answer, in order. Slots that
+        // still need bitcoind are left `None` and their txids collected, so the
+        // RPC misses go out as ONE batch instead of a round trip per txid — the
+        // replay/sync path resolves whole decided histories here.
+        let mut resolved: Vec<Option<bitcoin::Transaction>> = Vec::with_capacity(txs.len());
+        let mut rpc_slots: Vec<usize> = Vec::new();
+        let mut rpc_txids: Vec<Txid> = Vec::new();
         for entry in txs {
             match entry {
-                BatchTx::Raw(tx) => resolved.push(tx.clone()),
+                BatchTx::Raw(tx) => resolved.push(Some(tx.clone())),
                 BatchTx::Id(txid) => {
                     if let Some((raw, _)) = self.consensus.pending_transactions.get(txid) {
-                        resolved.push(raw.clone());
+                        resolved.push(Some(raw.clone()));
                     } else if let Some(tx) = Self::resolve_tx_from_db(&conn, txid).await {
-                        resolved.push(tx);
-                    } else if let Some(tx) = self.executor.resolve_transaction(txid).await {
-                        resolved.push(tx);
+                        resolved.push(Some(tx));
                     } else {
-                        anyhow::bail!("Could not resolve decided batch transaction {txid}");
+                        rpc_slots.push(resolved.len());
+                        rpc_txids.push(*txid);
+                        resolved.push(None);
                     }
                 }
             }
         }
-        Ok(resolved)
+        if !rpc_txids.is_empty() {
+            let fetched = self.executor.resolve_transactions(&rpc_txids).await;
+            for ((slot, txid), tx) in rpc_slots.iter().zip(&rpc_txids).zip(fetched) {
+                match tx {
+                    Some(tx) => resolved[*slot] = Some(tx),
+                    None => anyhow::bail!("Could not resolve decided batch transaction {txid}"),
+                }
+            }
+        }
+        Ok(resolved
+            .into_iter()
+            .map(|t| t.expect("all slots filled"))
+            .collect())
     }
 
     async fn process_block_event(&mut self, event: BlockEvent) -> Result<()> {

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -298,9 +298,12 @@ impl<E: Executor> Reactor<E> {
                     pending_count = self.consensus.pending_blocks.len() + 1,
                     "Adding block to pending_blocks"
                 );
-                self.consensus
-                    .pending_blocks
-                    .insert(block.height, block.clone());
+                // Move, not clone: `block` is owned here and unused afterward.
+                // The catch-up stream can hold up to MAX_PENDING_BLOCKS full
+                // blocks, so a per-block deep copy of every transaction, witness,
+                // and op_return is pure waste.
+                let height = block.height;
+                self.consensus.pending_blocks.insert(height, block);
                 self.advance()
                     .await
                     .context("advance failed after block insert")?;

--- a/core/indexer/src/reactor/mod.rs
+++ b/core/indexer/src/reactor/mod.rs
@@ -140,6 +140,11 @@ pub struct Reactor<E: Executor> {
     /// Verdicts that outlived their proposal, banked for the next one — see
     /// `batches::ValidatedCandidates`.
     validated_candidates: Option<batches::ValidatedCandidates>,
+    /// An in-flight off-loop mempool fee projection (`spawn_blocking`). The
+    /// periodic tick starts one from a snapshot rather than projecting inline;
+    /// its result is applied when this completes. `None` when idle — one at a
+    /// time, so a slow projection never queues behind itself.
+    fee_recompute: Option<tokio::task::JoinHandle<Fees>>,
 }
 
 impl<E: Executor> Reactor<E> {
@@ -183,6 +188,7 @@ impl<E: Executor> Reactor<E> {
             consensus_listen_addr,
             io_jobs: VecDeque::new(),
             validated_candidates: None,
+            fee_recompute: None,
         }
     }
 
@@ -430,6 +436,16 @@ impl<E: Executor> Reactor<E> {
                 }
             };
 
+            // The off-loop fee projection's result, or never. Same shape as
+            // `io_verdicts`: polled through `&mut` so it survives losing the
+            // select, dropped with the loop at shutdown.
+            let fee_recompute = async {
+                match self.fee_recompute.as_mut() {
+                    Some(handle) => handle.await,
+                    None => pending().await,
+                }
+            };
+
             let debounce_sleep = async {
                 match debounce_deadline {
                     Some(deadline) => tokio::time::sleep_until(deadline).await,
@@ -584,9 +600,31 @@ impl<E: Executor> Reactor<E> {
                         .context("apply_io_verdicts failed")?;
                 }
                 _ = fee_publish_ticker.tick() => {
-                    if self.consensus.mempool_fee_index.take_dirty() {
-                        // recompute() publishes to fee_tx internally.
-                        self.consensus.mempool_fee_index.recompute();
+                    // Project OFF the loop: at mainnet mempool sizes the
+                    // projection is tens to hundreds of ms, and running it inline
+                    // here stalls every Malachite reply, block, and finality check
+                    // for that long every 2s. One job at a time — a mutation
+                    // arriving mid-projection re-sets `dirty` and the next tick
+                    // re-runs. The Sync arm and startup still recompute inline:
+                    // they are infrequent and must establish the fresh threshold
+                    // synchronously before the node reports available.
+                    if self.fee_recompute.is_none()
+                        && self.consensus.mempool_fee_index.take_dirty()
+                    {
+                        let (entries, min) = self.consensus.mempool_fee_index.snapshot();
+                        self.fee_recompute = Some(tokio::task::spawn_blocking(move || {
+                            mempool_fee_index::project_fees(&entries, min)
+                        }));
+                    }
+                }
+                result = fee_recompute => {
+                    self.fee_recompute = None;
+                    match result {
+                        Ok(fees) => self.consensus.mempool_fee_index.store_recomputed(fees),
+                        // The blocking task panicked or was cancelled. It carries
+                        // no state — the cached fees simply stay put and the next
+                        // tick re-projects — so log and move on rather than exit.
+                        Err(e) => warn!(error = %e, "Fee projection task failed; keeping the last fees"),
                     }
                 }
             }


### PR DESCRIPTION
The performance bucket from the whole-subsystem capstone audit. Nothing here
changes consensus semantics — it moves or removes work on paths the reactor's
single event-loop thread runs while it must also answer Malachite, drain blocks,
and settle finality. Invisible on signet, real at mainnet mempool sizes.

## The headline

**The mempool fee projection now runs off the loop.** `recompute()` ran
mempool.space's block-projection algorithm — a topological sort with a per-tx
ancestor-set union over the whole mempool — inline on the reactor's `select!`
every 2 seconds. At 100k–300k entries that is tens to hundreds of ms of CPU
stalling every consensus reply, block, and finality check, each tick. It now
snapshots the entries and runs the projection in `spawn_blocking`, delivering the
result back through the existing owned fee watch as a new select arm (same shape
as the io-jobs). One projection at a time; a mutation arriving mid-run re-arms
the next tick. The Sync arm and the startup recompute stay inline — they are
infrequent and must establish the fresh threshold synchronously before the node
reports available. `compute_fee_threshold` reads only the cached snapshot, so
consensus sees exactly what it saw before.

## Smaller wins

- **The inserted block is moved, not cloned** — `BlockInsert` owns its block and
  never touched it again, yet deep-copied every transaction/witness/op_return of
  it (up to `MAX_PENDING_BLOCKS` full blocks in a catch-up stream).
- **The checkpoint read is skipped when nothing is observing** — it ran per
  block, per decided batch, and per rollback purely to populate a `StateEvent`
  that is dropped without observation channels, which every production node is.
- **`make_value_snapshot` uses the pool key instead of re-hashing** — the pool is
  keyed by txid, so `compute_txid()` per candidate was a double-SHA256 recomputing
  what it already held, on every proposal attempt.
- **Decided-batch resolution batches its RPCs** — `resolve_batch_txs` issued one
  `getrawtransaction` per unresolved txid; it now resolves pool+DB in order, then
  the RPC misses in one cache-backed JSON-RPC batch (`get_raw_transactions`). The
  hot case is a node syncing a long decided history.

## Deliberately deferred

Two audit findings in this bucket are left to their own focused changes:
- **Per-tx `testmempoolaccept` → package** (`validate_txs`): batching these is not
  a pure perf change — package acceptance rules differ from individual, so it
  changes what a validator accepts/rejects and supersedes the in-order relay. It
  is consensus-adjacent and deserves its own review.
- **`Arc<Transaction>` for `BatchTx::Raw`**: this would turn the propose/decide
  path's ~4–5 full-batch deep copies into refcount bumps, but it is a type change
  rippling through the core `Value` and every serialization site — a structural
  change, not a tweak.

## Tests

428 lib, 10 supervisor-unit, daemon_exit, workspace clippy `-D warnings`, fmt,
release regtest cluster (3). The off-loop projection is exercised by the cluster
suite (proposal/fee path); the batched resolution by the replay/sync tests.

## Second-pass review (/code-review)

An independent review of the merged correctness PR (#523) surfaced follow-ups
folded in here:
- **Refuted, but documented**: a concern that the replay availability walk's
  `(anchor, consensus_height)` order could disagree with the drain's node-local
  queue order for same-anchor batches. It can't cause divergence — the drain
  executes every deferred batch when the tip reaches its anchor, so a dependent
  batch can never be replayed ahead of a survivor dependency. The invariant is
  now written down where the next reader will look.
- **Perf**: the replay walk no longer re-hashes each kept tx at emit time (it
  filters by position now) — one double-SHA256 per retained tx per rollback, gone.
- **Elegance**: the two record-only paths (anchor-mismatch, unparseable-tx) share
  one `record_batch_for_sync` helper so they cannot drift.
- **Acknowledged**: the "finalized value not held" fail-stop can crash-loop a
  validator whose decided value is genuinely unfetchable — intentional (loud stop
  over silent hole), already documented at the site.